### PR TITLE
Fill in detail for V2 registry api specification

### DIFF
--- a/api/v2/descriptors.go
+++ b/api/v2/descriptors.go
@@ -977,6 +977,14 @@ var errorDescriptors = []ErrorDescriptor{
 		started, this error code may be returned.`,
 		HTTPStatusCodes: []int{http.StatusNotFound},
 	},
+	{
+		Code:    ErrorCodeBlobUploadInvalid,
+		Value:   "BLOB_UPLOAD_INVALID",
+		Message: "blob upload invalid",
+		Description: `The blob upload encountered an error and can no
+		longer proceed.`,
+		HTTPStatusCodes: []int{http.StatusNotFound},
+	},
 }
 
 var errorCodeToDescriptors map[ErrorCode]ErrorDescriptor

--- a/api/v2/descriptors.go
+++ b/api/v2/descriptors.go
@@ -40,10 +40,18 @@ var (
 		Description: `Digest of desired blob.`,
 	}
 
+	hostHeader = ParameterDescriptor{
+		Name:        "Host",
+		Type:        "string",
+		Description: "Standard HTTP Host Header. Should be set to the registry host.",
+		Format:      "<registry host>",
+		Examples:    []string{"registry-1.docker.io"},
+	}
+
 	authHeader = ParameterDescriptor{
 		Name:        "Authorization",
 		Type:        "string",
-		Description: "rfc7235 compliant authorization header.",
+		Description: "An RFC7235 compliant authorization header.",
 		Format:      "<scheme> <token>",
 		Examples:    []string{"Bearer dGhpcyBpcyBhIGZha2UgYmVhcmVyIHRva2VuIQ=="},
 	}
@@ -64,6 +72,48 @@ var (
 		Type:        "integer",
 		Format:      "0",
 	}
+
+	unauthorizedResponse = ResponseDescriptor{
+		Description: "The client does not have access to the repository.",
+		StatusCode:  http.StatusUnauthorized,
+		Headers: []ParameterDescriptor{
+			authChallengeHeader,
+			{
+				Name:        "Content-Length",
+				Type:        "integer",
+				Description: "Length of the JSON error response body.",
+				Format:      "<length>",
+			},
+		},
+		ErrorCodes: []ErrorCode{
+			ErrorCodeUnauthorized,
+		},
+		Body: BodyDescriptor{
+			ContentType: "application/json; charset=utf-8",
+			Format:      unauthorizedErrorsBody,
+		},
+	}
+
+	unauthorizedResponsePush = ResponseDescriptor{
+		Description: "The client does not have access to push to the repository.",
+		StatusCode:  http.StatusUnauthorized,
+		Headers: []ParameterDescriptor{
+			authChallengeHeader,
+			{
+				Name:        "Content-Length",
+				Type:        "integer",
+				Description: "Length of the JSON error response body.",
+				Format:      "<length>",
+			},
+		},
+		ErrorCodes: []ErrorCode{
+			ErrorCodeUnauthorized,
+		},
+		Body: BodyDescriptor{
+			ContentType: "application/json; charset=utf-8",
+			Format:      unauthorizedErrorsBody,
+		},
+	}
 )
 
 const (
@@ -82,9 +132,21 @@ const (
 }`
 
 	errorsBody = `{
-	"errors:" [{
+	"errors:" [
+	    {
             "code": <error code>,
             "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}`
+
+	unauthorizedErrorsBody = `{
+	"errors:" [
+	    {
+            "code": "UNAUTHORIZED",
+            "message": "access to the requested resource is not authorized",
             "detail": ...
         },
         ...
@@ -279,6 +341,7 @@ var routeDescriptors = []RouteDescriptor{
 				Requests: []RequestDescriptor{
 					{
 						Headers: []ParameterDescriptor{
+							hostHeader,
 							authHeader,
 						},
 						Successes: []ResponseDescriptor{
@@ -293,6 +356,13 @@ var routeDescriptors = []RouteDescriptor{
 								StatusCode:  http.StatusUnauthorized,
 								Headers: []ParameterDescriptor{
 									authChallengeHeader,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+								ErrorCodes: []ErrorCode{
+									ErrorCodeUnauthorized,
 								},
 							},
 							{
@@ -316,6 +386,10 @@ var routeDescriptors = []RouteDescriptor{
 				Description: "Fetch the tags under the repository identified by `name`.",
 				Requests: []RequestDescriptor{
 					{
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
 						},
@@ -323,8 +397,16 @@ var routeDescriptors = []RouteDescriptor{
 							{
 								StatusCode:  http.StatusOK,
 								Description: "A list of tags for the named repository.",
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON response body.",
+										Format:      "<length>",
+									},
+								},
 								Body: BodyDescriptor{
-									ContentType: "application/json",
+									ContentType: "application/json; charset=utf-8",
 									Format: `{
     "name": <name>,
     "tags": [
@@ -339,10 +421,24 @@ var routeDescriptors = []RouteDescriptor{
 							{
 								StatusCode:  http.StatusNotFound,
 								Description: "The repository is not known to the registry.",
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+								ErrorCodes: []ErrorCode{
+									ErrorCodeNameUnknown,
+								},
 							},
 							{
 								StatusCode:  http.StatusUnauthorized,
-								Description: "The client doesn't have access to repository.",
+								Description: "The client does not have access to the repository.",
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+								ErrorCodes: []ErrorCode{
+									ErrorCodeUnauthorized,
+								},
 							},
 						},
 					},
@@ -361,16 +457,20 @@ var routeDescriptors = []RouteDescriptor{
 				Description: "Fetch the manifest identified by `name` and `tag`.",
 				Requests: []RequestDescriptor{
 					{
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
 							tagParameterDescriptor,
 						},
 						Successes: []ResponseDescriptor{
 							{
-								Description: "The manifest idenfied by `name` and `tag`.",
+								Description: "The manifest idenfied by `name` and `tag`. The contents can be used to identify and resolve resources required to run the specified image.",
 								StatusCode:  http.StatusOK,
 								Body: BodyDescriptor{
-									ContentType: "application/json",
+									ContentType: "application/json; charset=utf-8",
 									Format:      manifestBody,
 								},
 							},
@@ -384,8 +484,19 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeTagInvalid,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json",
+									ContentType: "application/json; charset=utf-8",
 									Format:      errorsBody,
+								},
+							},
+							{
+								StatusCode:  http.StatusUnauthorized,
+								Description: "The client does not have access to the repository.",
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+								ErrorCodes: []ErrorCode{
+									ErrorCodeUnauthorized,
 								},
 							},
 							{
@@ -396,7 +507,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeManifestUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json",
+									ContentType: "application/json; charset=utf-8",
 									Format:      errorsBody,
 								},
 							},
@@ -410,6 +521,7 @@ var routeDescriptors = []RouteDescriptor{
 				Requests: []RequestDescriptor{
 					{
 						Headers: []ParameterDescriptor{
+							hostHeader,
 							authHeader,
 						},
 						PathParameters: []ParameterDescriptor{
@@ -417,17 +529,33 @@ var routeDescriptors = []RouteDescriptor{
 							tagParameterDescriptor,
 						},
 						Body: BodyDescriptor{
-							ContentType: "application/json",
+							ContentType: "application/json; charset=utf-8",
 							Format:      manifestBody,
 						},
 						Successes: []ResponseDescriptor{
 							{
-								StatusCode: http.StatusAccepted,
+								Description: "The manifest has been accepted by the registry and is stored under the specified `name` and `tag`.",
+								StatusCode:  http.StatusAccepted,
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Location",
+										Type:        "url",
+										Description: "The canonical location url of the uploaded manifest.",
+										Format:      "<url>",
+									},
+									contentLengthZeroHeader,
+								},
 							},
 						},
 						Failures: []ResponseDescriptor{
 							{
-								StatusCode: http.StatusBadRequest,
+								Name:        "Invalid Manifest",
+								Description: "The recieved manifest was invalid in some way, as described by the error codes. The client should resolve the issue and retry the request.",
+								StatusCode:  http.StatusBadRequest,
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
 								ErrorCodes: []ErrorCode{
 									ErrorCodeNameInvalid,
 									ErrorCodeTagInvalid,
@@ -437,13 +565,25 @@ var routeDescriptors = []RouteDescriptor{
 								},
 							},
 							{
+								StatusCode:  http.StatusUnauthorized,
+								Description: "The client does not have permission to push to the repository.",
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+								ErrorCodes: []ErrorCode{
+									ErrorCodeUnauthorized,
+								},
+							},
+							{
+								Name:        "Missing Layer(s)",
 								Description: "One or more layers may be missing during a manifest upload. If so, the missing layers will be enumerated in the error response.",
 								StatusCode:  http.StatusBadRequest,
 								ErrorCodes: []ErrorCode{
 									ErrorCodeBlobUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json",
+									ContentType: "application/json; charset=utf-8",
 									Format: `{
     "errors:" [{
             "code": "BLOB_UNKNOWN",
@@ -461,6 +601,19 @@ var routeDescriptors = []RouteDescriptor{
 								StatusCode: http.StatusUnauthorized,
 								Headers: []ParameterDescriptor{
 									authChallengeHeader,
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON error response body.",
+										Format:      "<length>",
+									},
+								},
+								ErrorCodes: []ErrorCode{
+									ErrorCodeUnauthorized,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
 								},
 							},
 						},
@@ -473,6 +626,7 @@ var routeDescriptors = []RouteDescriptor{
 				Requests: []RequestDescriptor{
 					{
 						Headers: []ParameterDescriptor{
+							hostHeader,
 							authHeader,
 						},
 						PathParameters: []ParameterDescriptor{
@@ -486,23 +640,48 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						Failures: []ResponseDescriptor{
 							{
-								StatusCode: http.StatusBadRequest,
+								Name:        "Invalid Name or Tag",
+								Description: "The specified `name` or `tag` were invalid and the delete was unable to proceed.",
+								StatusCode:  http.StatusBadRequest,
 								ErrorCodes: []ErrorCode{
 									ErrorCodeNameInvalid,
 									ErrorCodeTagInvalid,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
 								},
 							},
 							{
 								StatusCode: http.StatusUnauthorized,
 								Headers: []ParameterDescriptor{
 									authChallengeHeader,
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON error response body.",
+										Format:      "<length>",
+									},
+								},
+								ErrorCodes: []ErrorCode{
+									ErrorCodeUnauthorized,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
 								},
 							},
 							{
-								StatusCode: http.StatusNotFound,
+								Name:        "Unknown Manifest",
+								Description: "The specified `name` or `tag` are unknown to the registry and the delete was unable to proceed. Clients can assume the manifest was already deleted if this response is returned.",
+								StatusCode:  http.StatusNotFound,
 								ErrorCodes: []ErrorCode{
 									ErrorCodeNameUnknown,
 									ErrorCodeManifestUnknown,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
 								},
 							},
 						},
@@ -521,9 +700,14 @@ var routeDescriptors = []RouteDescriptor{
 
 			{
 				Method:      "GET",
-				Description: "Retrieve the blob from the registry identified by `digest`.",
+				Description: "Retrieve the blob from the registry identified by `digest`. A `HEAD` request can also be issued to this endpoint to obtain resource information without receiving all data.",
 				Requests: []RequestDescriptor{
 					{
+						Name: "Fetch Blob",
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
 							digestPathParameter,
@@ -532,6 +716,14 @@ var routeDescriptors = []RouteDescriptor{
 							{
 								Description: "The blob identified by `digest` is available. The blob content will be present in the body of the request.",
 								StatusCode:  http.StatusOK,
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "The length of the requested blob content.",
+										Format:      "<length>",
+									},
+								},
 								Body: BodyDescriptor{
 									ContentType: "application/octet-stream",
 									Format:      "<blob binary data>",
@@ -552,17 +744,25 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						Failures: []ResponseDescriptor{
 							{
-								StatusCode: http.StatusBadRequest,
+								Description: "There was a problem with the request that needs to be addressed by the client, such as an invalid `name` or `tag`.",
+								StatusCode:  http.StatusBadRequest,
 								ErrorCodes: []ErrorCode{
 									ErrorCodeNameInvalid,
 									ErrorCodeDigestInvalid,
 								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
 							},
+							unauthorizedResponse,
 							{
-								StatusCode: http.StatusUnauthorized,
-							},
-							{
-								StatusCode: http.StatusNotFound,
+								Description: "The blob, identified by `name` and `digest`, is unknown to the registry.",
+								StatusCode:  http.StatusNotFound,
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
 								ErrorCodes: []ErrorCode{
 									ErrorCodeNameUnknown,
 									ErrorCodeBlobUnknown,
@@ -570,16 +770,76 @@ var routeDescriptors = []RouteDescriptor{
 							},
 						},
 					},
-				},
-			},
-			{
-				Method:      "HEAD",
-				Description: "Check if the blob is known to the registry.",
-				Requests: []RequestDescriptor{
 					{
+						Name:        "Fetch Blob Part",
+						Description: "This endpoint may also support RFC7233 compliant range requests. Support can be detected by issuing a HEAD request. If the header `Accept-Range: bytes` is returned, range requests can be used to fetch partial content.",
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+							{
+								Name:        "Range",
+								Type:        "string",
+								Description: "HTTP Range header specifying blob chunk.",
+								Format:      "bytes=<start>-<end>",
+							},
+						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
 							digestPathParameter,
+						},
+						Successes: []ResponseDescriptor{
+							{
+								Description: "The blob identified by `digest` is available. The specified chunk of blob content will be present in the body of the request.",
+								StatusCode:  http.StatusPartialContent,
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "The length of the requested blob chunk.",
+										Format:      "<length>",
+									},
+									{
+										Name:        "Content-Range",
+										Type:        "byte range",
+										Description: "Content range of blob chunk.",
+										Format:      "bytes <start>-<end>/<size>",
+									},
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/octet-stream",
+									Format:      "<blob binary data>",
+								},
+							},
+						},
+						Failures: []ResponseDescriptor{
+							{
+								Description: "There was a problem with the request that needs to be addressed by the client, such as an invalid `name` or `tag`.",
+								StatusCode:  http.StatusBadRequest,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeNameInvalid,
+									ErrorCodeDigestInvalid,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							unauthorizedResponse,
+							{
+								StatusCode: http.StatusNotFound,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeNameUnknown,
+									ErrorCodeBlobUnknown,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							{
+								Description: "The range specification cannot be satisfied for the requested content. This can happen when the range is not formatted correctly or if the range is outside of the valid size of the content.",
+								StatusCode:  http.StatusRequestedRangeNotSatisfiable,
+							},
 						},
 					},
 				},
@@ -604,6 +864,7 @@ var routeDescriptors = []RouteDescriptor{
 						Name:        "Initiate Monolithic Blob Upload",
 						Description: "Upload a blob identified by the `digest` parameter in single request. This upload will not be resumable unless a recoverable error is returned.",
 						Headers: []ParameterDescriptor{
+							hostHeader,
 							authHeader,
 							{
 								Name:   "Content-Length",
@@ -629,7 +890,8 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						Successes: []ResponseDescriptor{
 							{
-								StatusCode: http.StatusCreated,
+								Description: "The blob has been created in the registry and is available the provided location.",
+								StatusCode:  http.StatusCreated,
 								Headers: []ParameterDescriptor{
 									{
 										Name:   "Location",
@@ -649,23 +911,14 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeNameInvalid,
 								},
 							},
-							{
-								Name:       "Unauthorized",
-								StatusCode: http.StatusUnauthorized,
-								Headers: []ParameterDescriptor{
-									authChallengeHeader,
-								},
-								ErrorCodes: []ErrorCode{
-									ErrorCodeDigestInvalid,
-									ErrorCodeNameInvalid,
-								},
-							},
+							unauthorizedResponsePush,
 						},
 					},
 					{
 						Name:        "Initiate Resumable Blob Upload",
 						Description: "Initiate a resumable blob upload with an empty request body.",
 						Headers: []ParameterDescriptor{
+							hostHeader,
 							authHeader,
 							contentLengthZeroHeader,
 						},
@@ -674,7 +927,7 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						Successes: []ResponseDescriptor{
 							{
-								Description: "The upload has been created. The `Location` header must be used to complete the upload. The response should identical to a `GET` request on the contents of the returned `Location` header.",
+								Description: "The upload has been created. The `Location` header must be used to complete the upload. The response should be identical to a `GET` request on the contents of the returned `Location` header.",
 								StatusCode:  http.StatusAccepted,
 								Headers: []ParameterDescriptor{
 									contentLengthZeroHeader,
@@ -692,6 +945,17 @@ var routeDescriptors = []RouteDescriptor{
 								},
 							},
 						},
+						Failures: []ResponseDescriptor{
+							{
+								Name:       "Invalid Name or Digest",
+								StatusCode: http.StatusBadRequest,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeDigestInvalid,
+									ErrorCodeNameInvalid,
+								},
+							},
+							unauthorizedResponsePush,
+						},
 					},
 				},
 			},
@@ -702,7 +966,7 @@ var routeDescriptors = []RouteDescriptor{
 		Name:        RouteNameBlobUploadChunk,
 		Path:        "/v2/{name:" + common.RepositoryNameRegexp.String() + "}/blobs/uploads/{uuid}",
 		Entity:      "Blob Upload",
-		Description: "Interact with blob uploads. Clients should never assemble URLs for this endpoint and should only take it through the `Location` header on related API requests.",
+		Description: "Interact with blob uploads. Clients should never assemble URLs for this endpoint and should only take it through the `Location` header on related API requests. The `Location` header and its parameters should be preserved by clients, using the latest value returned via upload related API calls.",
 		Methods: []MethodDescriptor{
 			{
 				Method:      "GET",
@@ -710,13 +974,19 @@ var routeDescriptors = []RouteDescriptor{
 				Requests: []RequestDescriptor{
 					{
 						Description: "Retrieve the progress of the current upload, as reported by the `Range` header.",
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
 							uuidParameterDescriptor,
 						},
 						Successes: []ResponseDescriptor{
 							{
-								StatusCode: http.StatusNoContent,
+								Name:        "Upload Progress",
+								Description: "The upload is known and in progress. The last received offset is available in the `Range` header.",
+								StatusCode:  http.StatusNoContent,
 								Headers: []ParameterDescriptor{
 									{
 										Name:        "Range",
@@ -724,32 +994,34 @@ var routeDescriptors = []RouteDescriptor{
 										Format:      "0-<offset>",
 										Description: "Range indicating the current progress of the upload.",
 									},
+									contentLengthZeroHeader,
 								},
 							},
 						},
-					},
-				},
-			},
-			{
-				Method:      "HEAD",
-				Description: "Retrieve status of upload identified by `uuid`. This is identical to the GET request.",
-				Requests: []RequestDescriptor{
-					{
-						Description: "Retrieve the progress of the current upload, as reported by the `Range` header.",
-						PathParameters: []ParameterDescriptor{
-							nameParameterDescriptor,
-							uuidParameterDescriptor,
-						},
-						Successes: []ResponseDescriptor{
+						Failures: []ResponseDescriptor{
 							{
-								StatusCode: http.StatusNoContent,
-								Headers: []ParameterDescriptor{
-									{
-										Name:        "Range",
-										Type:        "header",
-										Format:      "0-<offset>",
-										Description: "Range indicating the current progress of the upload.",
-									},
+								Description: "There was an error processing the upload and it must be restarted.",
+								StatusCode:  http.StatusBadRequest,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeDigestInvalid,
+									ErrorCodeNameInvalid,
+									ErrorCodeBlobUploadInvalid,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							unauthorizedResponse,
+							{
+								Description: "The upload is unknown to the registry. The upload must be restarted.",
+								StatusCode:  http.StatusNotFound,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeBlobUploadUnknown,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
 								},
 							},
 						},
@@ -767,6 +1039,8 @@ var routeDescriptors = []RouteDescriptor{
 							uuidParameterDescriptor,
 						},
 						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
 							{
 								Name:        "Content-Range",
 								Type:        "header",
@@ -787,8 +1061,16 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						Successes: []ResponseDescriptor{
 							{
-								StatusCode: http.StatusNoContent,
+								Name:        "Chunk Accepted",
+								Description: "The chunk of data has been accepted and the current progress is available in the range header. The updated upload location is available in the `Location` header.",
+								StatusCode:  http.StatusNoContent,
 								Headers: []ParameterDescriptor{
+									{
+										Name:        "Location",
+										Type:        "url",
+										Format:      "/v2/<name>/blobs/uploads/<uuid>",
+										Description: "The location of the upload. Clients should assume this changes after each request. Clients should use the contents verbatim to complete the upload, adding parameters where required.",
+									},
 									{
 										Name:        "Range",
 										Type:        "header",
@@ -797,6 +1079,37 @@ var routeDescriptors = []RouteDescriptor{
 									},
 									contentLengthZeroHeader,
 								},
+							},
+						},
+						Failures: []ResponseDescriptor{
+							{
+								Description: "There was an error processing the upload and it must be restarted.",
+								StatusCode:  http.StatusBadRequest,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeDigestInvalid,
+									ErrorCodeNameInvalid,
+									ErrorCodeBlobUploadInvalid,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							unauthorizedResponsePush,
+							{
+								Description: "The upload is unknown to the registry. The upload must be restarted.",
+								StatusCode:  http.StatusNotFound,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeBlobUploadUnknown,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							{
+								Description: "The `Content-Range` specification cannot be accepted, either because it does not overlap with the current progress or it is invalid.",
+								StatusCode:  http.StatusRequestedRangeNotSatisfiable,
 							},
 						},
 					},
@@ -812,7 +1125,23 @@ var routeDescriptors = []RouteDescriptor{
 						// 	2. Complete an upload where the entire body is in the PUT.
 						// 	3. Complete an upload where the final, partial chunk is the body.
 
-						Description: "Upload the _final_ chunk of data.",
+						Description: "Complete the upload, providing the _final_ chunk of data, if necessary. This method may take a body with all the data. If the `Content-Range` header is specified, it may include the final chunk. A request without a body will just complete the upload with previously uploaded content.",
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+							{
+								Name:        "Content-Range",
+								Type:        "header",
+								Format:      "<start of range>-<end of range, inclusive>",
+								Description: "Range of bytes identifying the block of content represented by the body. Start must the end offset retrieved via status check plus one. Note that this is a non-standard use of the `Content-Range` header. May be omitted if no data is provided.",
+							},
+							{
+								Name:        "Content-Length",
+								Type:        "integer",
+								Format:      "<length of chunk>",
+								Description: "Length of the chunk being uploaded, corresponding to the length of the request body. May be zero if no data is provided.",
+							},
+						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
 							uuidParameterDescriptor,
@@ -827,10 +1156,21 @@ var routeDescriptors = []RouteDescriptor{
 								Description: `Digest of uploaded blob.`,
 							},
 						},
+						Body: BodyDescriptor{
+							ContentType: "application/octet-stream",
+							Format:      "<binary chunk>",
+						},
 						Successes: []ResponseDescriptor{
 							{
-								StatusCode: http.StatusNoContent,
+								Name:        "Upload Complete",
+								Description: "The upload has been completed and accepted by the registry. The canonical location will be available in the `Location` header.",
+								StatusCode:  http.StatusNoContent,
 								Headers: []ParameterDescriptor{
+									{
+										Name:   "Location",
+										Type:   "url",
+										Format: "<blob location>",
+									},
 									{
 										Name:        "Content-Range",
 										Type:        "header",
@@ -844,9 +1184,50 @@ var routeDescriptors = []RouteDescriptor{
 										Description: "Length of the chunk being uploaded, corresponding the length of the request body.",
 									},
 								},
+							},
+						},
+						Failures: []ResponseDescriptor{
+							{
+								Description: "There was an error processing the upload and it must be restarted.",
+								StatusCode:  http.StatusBadRequest,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeDigestInvalid,
+									ErrorCodeNameInvalid,
+									ErrorCodeBlobUploadInvalid,
+								},
 								Body: BodyDescriptor{
-									ContentType: "application/octet-stream",
-									Format:      "<binary chunk>",
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							unauthorizedResponsePush,
+							{
+								Description: "The upload is unknown to the registry. The upload must be restarted.",
+								StatusCode:  http.StatusNotFound,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeBlobUploadUnknown,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							{
+								Description: "The `Content-Range` specification cannot be accepted, either because it does not overlap with the current progress or it is invalid. The contents of the `Range` header may be used to resolve the condition.",
+								StatusCode:  http.StatusRequestedRangeNotSatisfiable,
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Location",
+										Type:        "url",
+										Format:      "/v2/<name>/blobs/uploads/<uuid>",
+										Description: "The location of the upload. Clients should assume this changes after each request. Clients should use the contents verbatim to complete the upload, adding parameters where required.",
+									},
+									{
+										Name:        "Range",
+										Type:        "header",
+										Format:      "0-<offset>",
+										Description: "Range indicating the current progress of the upload.",
+									},
 								},
 							},
 						},
@@ -862,6 +1243,48 @@ var routeDescriptors = []RouteDescriptor{
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
 							uuidParameterDescriptor,
+						},
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+							contentLengthZeroHeader,
+						},
+						Successes: []ResponseDescriptor{
+							{
+								Name:        "Upload Deleted",
+								Description: "The upload has been successfully deleted.",
+								StatusCode:  http.StatusNoContent,
+								Headers: []ParameterDescriptor{
+									contentLengthZeroHeader,
+								},
+							},
+						},
+						Failures: []ResponseDescriptor{
+							{
+								Description: "An error was encountered processing the delete. The client may ignore this error.",
+								StatusCode:  http.StatusBadRequest,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeDigestInvalid,
+									ErrorCodeNameInvalid,
+									ErrorCodeBlobUploadInvalid,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
+							unauthorizedResponse,
+							{
+								Description: "The upload is unknown to the registry. The client may ignore this error and assume the upload has been deleted.",
+								StatusCode:  http.StatusNotFound,
+								ErrorCodes: []ErrorCode{
+									ErrorCodeBlobUploadUnknown,
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format:      errorsBody,
+								},
+							},
 						},
 					},
 				},

--- a/api/v2/errors.go
+++ b/api/v2/errors.go
@@ -54,6 +54,9 @@ const (
 
 	// ErrorCodeBlobUploadUnknown is returned when an upload is unknown.
 	ErrorCodeBlobUploadUnknown
+
+	// ErrorCodeBlobUploadInvalid is returned when an upload is invalid.
+	ErrorCodeBlobUploadInvalid
 )
 
 // ParseErrorCode attempts to parse the error code string, returning

--- a/api_test.go
+++ b/api_test.go
@@ -53,7 +53,7 @@ func TestCheckAPI(t *testing.T) {
 
 	checkResponse(t, "issuing api base check", resp, http.StatusOK)
 	checkHeaders(t, resp, http.Header{
-		"Content-Type":   []string{"application/json"},
+		"Content-Type":   []string{"application/json; charset=utf-8"},
 		"Content-Length": []string{"2"},
 	})
 
@@ -221,7 +221,7 @@ func TestManifestAPI(t *testing.T) {
 
 	// TODO(stevvooe): Shoot. The error setup is not working out. The content-
 	// type headers are being set after writing the status code.
-	// if resp.Header.Get("Content-Type") != "application/json" {
+	// if resp.Header.Get("Content-Type") != "application/json; charset=utf-8" {
 	// 	t.Fatalf("unexpected content type: %v != 'application/json'",
 	// 		resp.Header.Get("Content-Type"))
 	// }

--- a/app.go
+++ b/app.go
@@ -215,7 +215,7 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 			// under which name is not set and we still allow access is when the
 			// base route is accessed. This section prevents us from making that
 			// mistake elsewhere in the code, allowing any operation to proceed.
-			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			w.WriteHeader(http.StatusForbidden)
 
 			var errs v2.Errors
@@ -227,7 +227,7 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 	if err := app.accessController.Authorized(r, accessRecords...); err != nil {
 		switch err := err.(type) {
 		case auth.Challenge:
-			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			err.ServeHTTP(w, r)
 
 			var errs v2.Errors
@@ -253,7 +253,7 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 func apiBase(w http.ResponseWriter, r *http.Request) {
 	const emptyJSON = "{}"
 	// Provide a simple /v2/ 200 OK response with empty json response.
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Content-Length", fmt.Sprint(len(emptyJSON)))
 
 	fmt.Fprint(w, emptyJSON)

--- a/app_test.go
+++ b/app_test.go
@@ -173,8 +173,8 @@ func TestNewApp(t *testing.T) {
 		t.Fatalf("unexpected status code during request: %v", err)
 	}
 
-	if req.Header.Get("Content-Type") != "application/json" {
-		t.Fatalf("unexpected content-type: %v != %v", req.Header.Get("Content-Type"), "application/json")
+	if req.Header.Get("Content-Type") != "application/json; charset=utf-8" {
+		t.Fatalf("unexpected content-type: %v != %v", req.Header.Get("Content-Type"), "application/json; charset=utf-8")
 	}
 
 	expectedAuthHeader := "Bearer realm=\"realm-test\",service=\"service-test\""

--- a/doc/SPEC.md
+++ b/doc/SPEC.md
@@ -703,6 +703,7 @@ The error codes encountered via the API are enumerated in the following table:
  `MANIFEST_UNVERIFIED` | manifest failed signature verification | During manifest upload, if the manifest fails signature verification, this error will be returned.
  `BLOB_UNKNOWN` | blob unknown to registry | This error may be returned when a blob is unknown to the registry in a specified repository. This can be returned with a standard get or if a manifest references an unknown layer during upload.
  `BLOB_UPLOAD_UNKNOWN` | blob upload unknown to registry | If a blob upload has been cancelled or was never started, this error code may be returned.
+ `BLOB_UPLOAD_INVALID` | blob upload invalid | The blob upload encountered an error and can no longer proceed.
 
 
 

--- a/doc/SPEC.md.tmpl
+++ b/doc/SPEC.md.tmpl
@@ -1,40 +1,35 @@
-# Docker Registry API V2.1
+# Docker Registry HTTP API V2
 
-> **Note**: This specification has been ported over from the proposal on
-> docker/docker#9015. Much of the language in this document is still written
-> in the proposal tense and needs to be converted.
+## Introduction
 
-## Abstract
+The _Docker Registry HTTP API_ is the protocol to facilitate distribution of
+images to the docker engine. It interacts with instances of the docker
+registry, which is a service to manage information about docker images and
+enable their distribution. The specification covers the operation of version 2
+of this API, known as _Docker Registry HTTP API V2_.
 
-> **TODO**: Merge this section into the overview/introduction.
+While the V1 registry protocol is usable, there are several problems with the
+architecture that have led to this new version. The main driver of this
+specification these changes to the docker the image format, covered in
+docker/docker#8093. The new, self-contained image manifest simplifies image
+definition and improves security. This specification will build on that work,
+leveraging new properties of the manifest format to improve performance,
+reduce bandwidth usage and decrease the likelihood of backend corruption.
 
-The docker registry is a service to manage information about docker images and
-enable their distribution. While the current registry is usable, there are
-several problems with the architecture that have led to this proposal. For
-relevant details, please see the following issues:
+For relevant details and history leading up to this specification, please see
+the following issues:
 
 - docker/docker#8093
+- docker/docker#9015
 - docker/docker-registry#612
 
-The main driver of this proposal are changes to the docker the image format,
-covered in docker/docker#8093. The new, self-contained image manifest
-simplifies the image definition and the underlying backend layout. To reduce
-bandwidth usage, the new registry will be architected to avoid uploading
-existing layers and will support resumable layer uploads.
+### Scope
 
-While out of scope for this specification, the URI layout of the new API will
-be structured to support a rich Authentication and Authorization model by
-leveraging namespaces.
-
-Furthermore, to bring docker registry in line with docker core, the registry is written in Go.
-
-## Scope
-
-> **TODO**: Merge this section into the overview/introduction.
-
-This proposal covers the URL layout and protocols of the Docker Registry V2
-JSON API. This will affect the docker core registry API and the rewrite of
-docker-registry.
+This specification covers the URL layout and protocols of the interaction
+between docker registry and docker core. This will affect the docker core
+registry API and the rewrite of docker-registry. Docker registry
+implementations may implement other API endpoints, but they are not covered by
+this specification.
 
 This includes the following features:
 
@@ -45,17 +40,39 @@ This includes the following features:
 
 While authentication and authorization support will influence this
 specification, details of the protocol will be left to a future specification.
-Other features marked as next generation will be incorporated when the initial
-support is complete. Please see the road map for details.
+Relevant header definitions and error codes are present to provide an
+indication of what a client may encounter.
 
-## Use Cases
+#### Future
 
-> **TODO**: Merge this section into the overview/introduction.
+There are features that have been discussed during the process of cutting this
+specification. The following is an incomplete list:
+
+- Immutable image references
+- Multiple architecture support
+- Migration from v2compatibility representation
+
+These may represent features that are either out of the scope of this
+specification, the purview of another specification or have been deferred to a
+future version.
+
+### Use Cases
 
 For the most part, the use cases of the former registry API apply to the new
-version. Differentiating uses cases are covered below.
+version. Differentiating use cases are covered below.
 
-### Resumable Push
+#### Image Verification
+
+A docker engine instance would like to run verified image named
+"library/ubuntu", with the tag "latest". The engine contacts the registry,
+requesting the manifest for "library/ubuntu:latest". An untrusted registry
+returns a manifest. Before proceeding to download the individual layers, the
+engine verifies the manifest's signature, ensuring that the content was
+produced from a trusted source and no tampering has occured. After each layer
+is downloaded, the engine verifies the digest of the layer, ensuring that the
+content matches that specified by the manifest.
+
+#### Resumable Push
 
 Company X's build servers lose connectivity to docker registry before
 completing an image layer transfer. After connectivity returns, the build
@@ -63,14 +80,14 @@ server attempts to re-upload the image. The registry notifies the build server
 that the upload has already been partially attempted. The build server
 responds by only sending the remaining data to complete the image file.
 
-### Resumable Pull
+#### Resumable Pull
 
 Company X is having more connectivity problems but this time in their
 deployment datacenter. When downloading an image, the connection is
 interrupted before completion. The client keeps the partial data and uses http
 `Range` requests to avoid downloading repeated data.
 
-### Layer Upload De-duplication
+#### Layer Upload De-duplication
 
 Company Y's build system creates two identical docker layers from build
 processes A and B. Build process A completes uploading the layer before B.
@@ -81,10 +98,29 @@ If process A and B upload the same layer at the same time, both operations
 will proceed and the first to complete will be stored in the registry (Note:
 we may modify this to prevent dogpile with some locking mechanism).
 
+### Changes
+
+The V2 specification has been written to work as a living document, specifying
+only what is certain and leaving what is not specified open or to future
+changes. Only non-conflicting additions should be made to the API and accepted
+changes should avoid preventing future changes from happening.
+
+This section should be updated when changes are made to the specification,
+indicating what is different. Optionally, we may start marking parts of the specification to correspond with the versions enumerated here.
+
+<dl>
+	<dt>2.0</dt>
+	<dd>
+		This is the baseline specification.
+	</dd>
+</dl>
+
 ## Overview
 
-This section covers client flows and details of the API endpoints. All
-endpoints will be prefixed by the API version and the repository name:
+This section covers client flows and details of the API endpoints. The URI
+layout of the new API is structured to support a rich authentication and
+authorization model by leveraging namespaces. All endpoints will be prefixed
+by the API version and the repository name:
 
     /v2/<name>/
 
@@ -102,10 +138,10 @@ path component is less than 30 characters. The V2 registry API does not
 enforce this. The rules for a repository name are as follows:
 
 1. A repository name is broken up into _path components_. A component of a
-   repository name must be at least two characters, optionally separated by
-   periods, dashes or underscores. More strictly, it must match the regular
-   expression `[a-z0-9]+(?:[._-][a-z0-9]+)*` and the matched result must be 2
-   or more characters in length.
+   repository name must be at least two lowercase, alpha-numeric characters,
+   optionally separated by periods, dashes or underscores. More strictly, it
+   must match the regular expression `[a-z0-9]+(?:[._-][a-z0-9]+)*` and the
+   matched result must be 2 or more characters in length.
 2. The name of a repository must have at least two path components, separated
    by a forward slash.
 3. The total length of a repository name, including slashes, must be less the
@@ -118,7 +154,8 @@ All endpoints should support aggressive http caching, compression and range
 headers, where appropriate. The new API attempts to leverage HTTP semantics
 where possible but may break from standards to implement targeted features.
 
-For detail on individual endpoints, please see the _Detail_ section.
+For detail on individual endpoints, please see the [_Detail_](#detail)
+section.
 
 ### Errors
 

--- a/doc/SPEC.md.tmpl
+++ b/doc/SPEC.md.tmpl
@@ -693,8 +693,8 @@ The error codes encountered via the API are enumerated in the following table:
 
 {{.Description}}
 
-{{if .Requests}}{{range .Requests}}
-##### {{.Name}}
+{{if .Requests}}{{range .Requests}}{{if .Name}}
+##### {{.Name}}{{end}}
 
 ```
 {{$method.Method}} {{$route.Path|prettygorilla}}{{if .QueryParameters}}?{{range .QueryParameters}}{{.Name}}={{.Format}}{{end}}{{end}}{{range .Headers}}
@@ -728,8 +728,9 @@ Content-Type: {{.Body.ContentType}}{{end}}{{if .Body.Format}}
 {{.Body.Format}}{{end}}
 ```
 
-{{.Description}}{{if .Headers}}
-The following headers will be returned on the response:
+{{.Description}}
+
+{{if .Headers}}The following headers will be returned with the response:
 
 |Name|Description|
 |----|-----------|

--- a/helpers.go
+++ b/helpers.go
@@ -10,7 +10,7 @@ import (
 // 'application/json'. If a different status code is required, call
 // ResponseWriter.WriteHeader before this function.
 func serveJSON(w http.ResponseWriter, v interface{}) error {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	enc := json.NewEncoder(w)
 
 	if err := enc.Encode(v); err != nil {

--- a/images.go
+++ b/images.go
@@ -46,7 +46,7 @@ func (imh *imageManifestHandler) GetImageManifest(w http.ResponseWriter, r *http
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Content-Length", fmt.Sprint(len(manifest.Raw)))
 	w.Write(manifest.Raw)
 }

--- a/tags.go
+++ b/tags.go
@@ -47,6 +47,8 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(tagsAPIResponse{
 		Name: th.Name,


### PR DESCRIPTION
These changes fill in a lot of missing detail in the API endpoint definitions. Please the generated `SPEC.md` file for the results. This file will be submitted to docker core for review, as a companion to docker/docker#9784.

Note that this PR contains part of the content from #7, which should be merged before this.

cc @icecrime @jfrazelle @dmp42 @dmcgowan @jlhawn 