### PR TITLE
Add a README file and make encrypt and rootdirectory optional parameters

### DIFF
--- a/storagedriver/s3/README.md
+++ b/storagedriver/s3/README.md
@@ -1,0 +1,22 @@
+Docker-Registry S3 Storage Driver
+=========================================
+
+An implementation of the `storagedriver.StorageDriver` interface which uses Amazon S3 for object storage.
+
+## Parameters
+
+`accesskey`: Your aws access key.
+
+`secretkey`: Your aws secret key.
+
+**Note** You can provide empty strings for your access and secret keys if you plan on running the driver on an ec2 instance and will handle authentication with the instance's credentials.
+
+`region`: The name of the aws region in which you would like to store objects (for example `us-east-1`). For a list of regions, you can look at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
+
+`bucket`: The name of your s3 bucket where you wish to store objects (needs to already be created prior to driver initialization).
+
+`encrypt`: (optional) Whether you would like your data encrypted on the server side (defaults to true if not specified).
+
+`secure`: (optional) Whether you would like to transfer data over ssl or not. Defaults to true (meaning transfering over ssl) if not specified. Note that while setting this to false will improve performance, it is not recommended due to security concerns.
+
+`rootdirectory`: (optional) The root directory tree in which all registry files will be stored. Defaults to the empty string (bucket root).

--- a/storagedriver/s3/s3.go
+++ b/storagedriver/s3/s3.go
@@ -87,19 +87,18 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		return nil, fmt.Errorf("No bucket parameter provided")
 	}
 
+	encryptBool := true
 	encrypt, ok := parameters["encrypt"]
-	if !ok {
-		return nil, fmt.Errorf("No encrypt parameter provided")
-	}
-
-	encryptBool, ok := encrypt.(bool)
-	if !ok {
-		return nil, fmt.Errorf("The encrypt parameter should be a boolean")
+	if ok {
+		encryptBool, ok = encrypt.(bool)
+		if !ok {
+			return nil, fmt.Errorf("The encrypt parameter should be a boolean")
+		}
 	}
 
 	rootDirectory, ok := parameters["rootdirectory"]
 	if !ok {
-		return nil, fmt.Errorf("No rootdirectory parameter provided")
+		rootDirectory = ""
 	}
 
 	return New(fmt.Sprint(accessKey), fmt.Sprint(secretKey), fmt.Sprint(bucket), fmt.Sprint(rootDirectory), region, encryptBool)


### PR DESCRIPTION
....

Note that the README currently contains details about the secure parameter which is part of a
separate pull request. I feel confident adding it here since I am certain we will eventually add
the secure parameter. Also note that encrypt now defaults to true and rootdirectory defaults to
the empty string.