### PR TITLE
Basic skeleton for `dist` binary

### DIFF
--- a/cmd/dist/list.go
+++ b/cmd/dist/list.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/codegangsta/cli"
+
+var (
+	commandList = cli.Command{
+		Name:   "images",
+		Usage:  "List available images",
+		Action: imageList,
+	}
+)
+
+func imageList(c *cli.Context) {
+}

--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+
+	"github.com/codegangsta/cli"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "dist"
+	app.Usage = "Package and ship Docker content"
+
+	app.Action = commandList.Action
+	app.Commands = []cli.Command{
+		commandList,
+		commandPull,
+		commandPush,
+	}
+	app.Run(os.Args)
+}

--- a/cmd/dist/pull.go
+++ b/cmd/dist/pull.go
@@ -1,0 +1,21 @@
+package main
+
+import "github.com/codegangsta/cli"
+
+var (
+	commandPull = cli.Command{
+		Name:   "pull",
+		Usage:  "Pull and verify an image from a registry",
+		Action: imagePull,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "r,registry",
+				Value: "hub.docker.io",
+				Usage: "Registry to use (e.g.: localhost:5000)",
+			},
+		},
+	}
+)
+
+func imagePull(c *cli.Context) {
+}

--- a/cmd/dist/push.go
+++ b/cmd/dist/push.go
@@ -1,0 +1,21 @@
+package main
+
+import "github.com/codegangsta/cli"
+
+var (
+	commandPush = cli.Command{
+		Name:   "push",
+		Usage:  "Push an image to a registry",
+		Action: imagePush,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "r,registry",
+				Value: "hub.docker.io",
+				Usage: "Registry to use (e.g.: localhost:5000)",
+			},
+		},
+	}
+)
+
+func imagePush(*cli.Context) {
+}


### PR DESCRIPTION
This implements the basic structure of the `dist` binary following the UX proposal in #43 so it **will** be subject to change, but provides a working base nevertheless.

### General usage
```
$ ./dist --help
NAME:
   dist - Package and ship Docker content

USAGE:
   dist [global options] command [command options] [arguments...]

VERSION:
   0.0.0

AUTHOR:
  Author - <unknown@email>

COMMANDS:
   list		List available images
   pull		Pull and verify an image from a registry
   push		Push an image to a registry
   help, h	Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h		show help
   --version, -v	print the version
```

### List images
```
$ ./dist list --help
NAME:
   list - List available images

USAGE:
   command list [arguments...]
```

### Pull images
```
$ ./dist pull --help
NAME:
   pull - Pull and verify an image from a registry

USAGE:
   command pull [command options] [arguments...]

OPTIONS:
   -r, --registry "hub.docker.io"	Registry to use (e.g.: localhost:5000)
```

### Push images
```
$ ./dist push --help
NAME:
   push - Push an image to a registry

USAGE:
   command push [command options] [arguments...]

OPTIONS:
   -r, --registry "hub.docker.io"	Registry to use (e.g.: localhost:5000)
```