### PR TITLE
Relaxes storagedriver path constraints

### DIFF
--- a/storagedriver/storagedriver.go
+++ b/storagedriver/storagedriver.go
@@ -71,16 +71,12 @@ type StorageDriver interface {
 	Delete(path string) error
 }
 
-// PathComponentRegexp is the regular expression which each repository path
-// component must match.
-// A component of a repository path must be at least two characters, optionally
-// separated by periods, dashes or underscores.
-var PathComponentRegexp = regexp.MustCompile(`[a-z0-9]+([._-]?[a-z0-9])+`)
-
-// PathRegexp is the regular expression which each repository path must match.
-// A repository path is absolute, beginning with a slash and containing a
-// positive number of path components separated by slashes.
-var PathRegexp = regexp.MustCompile(`^(/[a-z0-9]+([._-]?[a-z0-9])+)+$`)
+// PathRegexp is the regular expression which each file path must match.
+// A file path is absolute, beginning with a slash and containing a
+// positive number of path components separated by slashes, where each component
+// is restricted to lowercase alphanumeric characters, optionally separated by
+// a period, underscore, or hyphen.
+var PathRegexp = regexp.MustCompile(`^(/[a-z0-9]+([._-][a-z0-9]+)*)+$`)
 
 // PathNotFoundError is returned when operating on a nonexistent path.
 type PathNotFoundError struct {

--- a/storagedriver/testsuites/testsuites.go
+++ b/storagedriver/testsuites/testsuites.go
@@ -122,7 +122,7 @@ func (suite *DriverSuite) TearDownTest(c *check.C) {
 // storage driver.
 func (suite *DriverSuite) TestValidPaths(c *check.C) {
 	contents := randomContents(64)
-	validFiles := []string{"/aa", "/a.a", "/0-9/abcdefg", "/abcdefg/z.75", "/abc/1.2.3.4.5-6_zyx/123.z", "/docker/docker-registry"}
+	validFiles := []string{"/a", "/2", "/aa", "/a.a", "/0-9/abcdefg", "/abcdefg/z.75", "/abc/1.2.3.4.5-6_zyx/123.z/4", "/docker/docker-registry"}
 
 	for _, filename := range validFiles {
 		err := suite.StorageDriver.PutContent(filename, contents)
@@ -139,7 +139,7 @@ func (suite *DriverSuite) TestValidPaths(c *check.C) {
 // storage driver.
 func (suite *DriverSuite) TestInvalidPaths(c *check.C) {
 	contents := randomContents(64)
-	invalidFiles := []string{"", "/", "abc", "123.abc", "/abc./abc", "/.abc", "/a--b", "/a-.b", "/_.abc", "/a/bcd", "/abc_123/d", "/Docker/docker-registry"}
+	invalidFiles := []string{"", "/", "abc", "123.abc", "/abc./abc", "/.abc", "/a--b", "/a-.b", "/_.abc", "//bcd", "/abc_123/", "/Docker/docker-registry"}
 
 	for _, filename := range invalidFiles {
 		err := suite.StorageDriver.PutContent(filename, contents)
@@ -1015,14 +1015,13 @@ var separatorChars = []byte("._-")
 func randomPath(length int64) string {
 	path := "/"
 	for int64(len(path)) < length {
-		chunkLength := rand.Int63n(length-int64(len(path)+1)) + 2
+		chunkLength := rand.Int63n(length-int64(len(path))) + 1
 		chunk := randomFilename(chunkLength)
 		path += chunk
-		if length-int64(len(path)) == 1 {
+		remaining := length - int64(len(path))
+		if remaining == 1 {
 			path += randomFilename(1)
-		} else if length-int64(len(path)) == 2 {
-			path += randomFilename(2)
-		} else if length-int64(len(path)) > 2 {
+		} else if remaining > 1 {
 			path += "/"
 		}
 	}


### PR DESCRIPTION
No longer requires that file paths match the repository naming scheme,
but instead allows path components as short as a single character, as to
accommodate for single-character tag names.

Fixes #47