### PR TITLE
Refactor backend storage layout to meet new requirements (addresses #25, #46)

### DIFF
--- a/digest/verifiers_test.go
+++ b/digest/verifiers_test.go
@@ -30,7 +30,7 @@ func TestDigestVerifier(t *testing.T) {
 		t.Fatalf("error creating tarfile: %v", err)
 	}
 
-	digest, err = FromReader(tf)
+	digest, err = FromTarArchive(tf)
 	if err != nil {
 		t.Fatalf("error digesting tarsum: %v", err)
 	}

--- a/storage/blobstore.go
+++ b/storage/blobstore.go
@@ -1,0 +1,159 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/storagedriver"
+)
+
+// TODO(stevvooe): Currently, the blobStore implementation used by the
+// manifest store. The layer store should be refactored to better leverage the
+// blobStore, reducing duplicated code.
+
+// blobStore implements a generalized blob store over a driver, supporting the
+// read side and link management. This object is intentionally a leaky
+// abstraction, providing utility methods that support creating and traversing
+// backend links.
+type blobStore struct {
+	driver storagedriver.StorageDriver
+	pm     *pathMapper
+}
+
+// exists reports whether or not the path exists. If the driver returns error
+// other than storagedriver.PathNotFound, an error may be returned.
+func (bs *blobStore) exists(dgst digest.Digest) (bool, error) {
+	path, err := bs.path(dgst)
+
+	if err != nil {
+		return false, err
+	}
+
+	ok, err := exists(bs.driver, path)
+	if err != nil {
+		return false, err
+	}
+
+	return ok, nil
+}
+
+// get retrieves the blob by digest, returning it a byte slice. This should
+// only be used for small objects.
+func (bs *blobStore) get(dgst digest.Digest) ([]byte, error) {
+	bp, err := bs.path(dgst)
+	if err != nil {
+		return nil, err
+	}
+
+	return bs.driver.GetContent(bp)
+}
+
+// link links the path to the provided digest by writing the digest into the
+// target file.
+func (bs *blobStore) link(path string, dgst digest.Digest) error {
+	if exists, err := bs.exists(dgst); err != nil {
+		return err
+	} else if !exists {
+		return fmt.Errorf("cannot link non-existent blob")
+	}
+
+	// The contents of the "link" file are the exact string contents of the
+	// digest, which is specified in that package.
+	return bs.driver.PutContent(path, []byte(dgst))
+}
+
+// linked reads the link at path and returns the content.
+func (bs *blobStore) linked(path string) ([]byte, error) {
+	linked, err := bs.readlink(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return bs.get(linked)
+}
+
+// readlink returns the linked digest at path.
+func (bs *blobStore) readlink(path string) (digest.Digest, error) {
+	content, err := bs.driver.GetContent(path)
+	if err != nil {
+		return "", err
+	}
+
+	linked, err := digest.ParseDigest(string(content))
+	if err != nil {
+		return "", err
+	}
+
+	if exists, err := bs.exists(linked); err != nil {
+		return "", err
+	} else if !exists {
+		return "", fmt.Errorf("link %q invalid: blob %s does not exist", path, linked)
+	}
+
+	return linked, nil
+}
+
+// resolve reads the digest link at path and returns the blob store link.
+func (bs *blobStore) resolve(path string) (string, error) {
+	dgst, err := bs.readlink(path)
+	if err != nil {
+		return "", err
+	}
+
+	return bs.path(dgst)
+}
+
+// put stores the content p in the blob store, calculating the digest. If the
+// content is already present, only the digest will be returned. This should
+// only be used for small objects, such as manifests.
+func (bs *blobStore) put(p []byte) (digest.Digest, error) {
+	dgst, err := digest.FromBytes(p)
+	if err != nil {
+		logrus.Errorf("error digesting content: %v, %s", err, string(p))
+		return "", err
+	}
+
+	bp, err := bs.path(dgst)
+	if err != nil {
+		return "", err
+	}
+
+	// If the content already exists, just return the digest.
+	if exists, err := bs.exists(dgst); err != nil {
+		return "", err
+	} else if exists {
+		return dgst, nil
+	}
+
+	return dgst, bs.driver.PutContent(bp, p)
+}
+
+// path returns the canonical path for the blob identified by digest. The blob
+// may or may not exist.
+func (bs *blobStore) path(dgst digest.Digest) (string, error) {
+	bp, err := bs.pm.path(blobDataPathSpec{
+		digest: dgst,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return bp, nil
+}
+
+// exists provides a utility method to test whether or not
+func exists(driver storagedriver.StorageDriver, path string) (bool, error) {
+	if _, err := driver.Stat(path); err != nil {
+		switch err := err.(type) {
+		case storagedriver.PathNotFoundError:
+			return false, nil
+		default:
+			return false, err
+		}
+	}
+
+	return true, nil
+}

--- a/storage/layer_test.go
+++ b/storage/layer_test.go
@@ -31,13 +31,18 @@ func TestSimpleLayerUpload(t *testing.T) {
 	}
 
 	imageName := "foo/bar"
-
+	driver := inmemory.New()
+	pm := &pathMapper{
+		root:    "/storage/testing",
+		version: storagePathVersion,
+	}
 	ls := &layerStore{
-		driver: inmemory.New(),
-		pathMapper: &pathMapper{
-			root:    "/storage/testing",
-			version: storagePathVersion,
+		driver: driver,
+		blobStore: &blobStore{
+			driver: driver,
+			pm:     pm,
 		},
+		pathMapper: pm,
 	}
 
 	h := sha256.New()
@@ -140,12 +145,17 @@ func TestSimpleLayerUpload(t *testing.T) {
 func TestSimpleLayerRead(t *testing.T) {
 	imageName := "foo/bar"
 	driver := inmemory.New()
+	pm := &pathMapper{
+		root:    "/storage/testing",
+		version: storagePathVersion,
+	}
 	ls := &layerStore{
 		driver: driver,
-		pathMapper: &pathMapper{
-			root:    "/storage/testing",
-			version: storagePathVersion,
+		blobStore: &blobStore{
+			driver: driver,
+			pm:     pm,
 		},
+		pathMapper: pm,
 	}
 
 	randomLayerReader, tarSumStr, err := testutil.CreateRandomTarFile()
@@ -307,7 +317,7 @@ func writeTestLayer(driver storagedriver.StorageDriver, pathMapper *pathMapper, 
 
 	blobDigestSHA := digest.NewDigest("sha256", h)
 
-	blobPath, err := pathMapper.path(blobPathSpec{
+	blobPath, err := pathMapper.path(blobDataPathSpec{
 		digest: dgst,
 	})
 

--- a/storage/layerupload.go
+++ b/storage/layerupload.go
@@ -112,7 +112,7 @@ func (luc *layerUploadController) validateLayer(dgst digest.Digest) (digest.Dige
 	// sink. Instead, its read driven. This might be okay.
 
 	// Calculate an updated digest with the latest version.
-	canonical, err := digest.FromReader(tr)
+	canonical, err := digest.FromTarArchive(tr)
 	if err != nil {
 		return "", err
 	}
@@ -128,7 +128,7 @@ func (luc *layerUploadController) validateLayer(dgst digest.Digest) (digest.Dige
 // identified by dgst. The layer should be validated before commencing the
 // move.
 func (luc *layerUploadController) moveLayer(dgst digest.Digest) error {
-	blobPath, err := luc.layerStore.pathMapper.path(blobPathSpec{
+	blobPath, err := luc.layerStore.pathMapper.path(blobDataPathSpec{
 		digest: dgst,
 	})
 

--- a/storage/paths.go
+++ b/storage/paths.go
@@ -188,7 +188,7 @@ func (pm *pathMapper) path(spec pathSpec) (string, error) {
 			return "", err
 		}
 
-		return path.Join(root, "current/link"), nil
+		return path.Join(root, "current", "link"), nil
 	case manifestTagIndexPathSpec:
 		root, err := pm.path(manifestTagPathSpec{
 			name: v.name,

--- a/storage/paths.go
+++ b/storage/paths.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/storagedriver"
 )
 
 const storagePathVersion = "v2"
@@ -14,13 +13,21 @@ const storagePathVersion = "v2"
 // pathMapper maps paths based on "object names" and their ids. The "object
 // names" mapped by pathMapper are internal to the storage system.
 //
-// The path layout in the storage backend will be roughly as follows:
+// The path layout in the storage backend is roughly as follows:
 //
 //		<root>/v2
 //			-> repositories/
 // 				-><name>/
 // 					-> manifests/
-// 						<manifests by tag name>
+// 						revisions
+//							-> <manifest digest path>
+//								-> link
+//								-> signatures
+// 									<algorithm>/<digest>/link
+// 						tags/<tag>
+//							-> current/link
+// 							-> index
+//								-> <algorithm>/<hex digest>/link
 // 					-> layers/
 // 						<layer links to blob store>
 // 					-> uploads/<uuid>
@@ -29,20 +36,61 @@ const storagePathVersion = "v2"
 //			-> blob/<algorithm>
 //				<split directory content addressable storage>
 //
-// There are few important components to this path layout. First, we have the
-// repository store identified by name. This contains the image manifests and
-// a layer store with links to CAS blob ids. Upload coordination data is also
-// stored here. Outside of the named repo area, we have the the blob store. It
-// contains the actual layer data and any other data that can be referenced by
-// a CAS id.
+// The storage backend layout is broken up into a content- addressable blob
+// store and repositories. The content-addressable blob store holds most data
+// throughout the backend, keyed by algorithm and digests of the underlying
+// content. Access to the blob store is controled through links from the
+// repository to blobstore.
+//
+// A repository is made up of layers, manifests and tags. The layers component
+// is just a directory of layers which are "linked" into a repository. A layer
+// can only be accessed through a qualified repository name if it is linked in
+// the repository. Uploads of layers are managed in the uploads directory,
+// which is key by upload uuid. When all data for an upload is received, the
+// data is moved into the blob store and the upload directory is deleted.
+// Abandoned uploads can be garbage collected by reading the startedat file
+// and removing uploads that have been active for longer than a certain time.
+//
+// The third component of the repository directory is the manifests store,
+// which is made up of a revision store and tag store. Manifests are stored in
+// the blob store and linked into the revision store. Signatures are separated
+// from the manifest payload data and linked into the blob store, as well.
+// While the registry can save all revisions of a manifest, no relationship is
+// implied as to the ordering of changes to a manifest. The tag store provides
+// support for name, tag lookups of manifests, using "current/link" under a
+// named tag directory. An index is maintained to support deletions of all
+// revisions of a given manifest tag.
 //
 // We cover the path formats implemented by this path mapper below.
 //
-// 	manifestPathSpec: <root>/v2/repositories/<name>/manifests/<tag>
-// 	layerLinkPathSpec: <root>/v2/repositories/<name>/layers/tarsum/<tarsum version>/<tarsum hash alg>/<tarsum hash>
-// 	blobPathSpec: <root>/v2/blob/<algorithm>/<first two hex bytes of digest>/<hex digest>
-// 	uploadDataPathSpec: <root>/v2/repositories/<name>/uploads/<uuid>/data
-// 	uploadStartedAtPathSpec: <root>/v2/repositories/<name>/uploads/<uuid>/startedat
+//	Manifests:
+//
+// 	manifestRevisionPathSpec:      <root>/v2/repositories/<name>/manifests/revisions/<algorithm>/<hex digest>/
+// 	manifestRevisionLinkPathSpec:  <root>/v2/repositories/<name>/manifests/revisions/<algorithm>/<hex digest>/link
+// 	manifestSignaturesPathSpec:    <root>/v2/repositories/<name>/manifests/revisions/<algorithm>/<hex digest>/signatures/
+// 	manifestSignatureLinkPathSpec: <root>/v2/repositories/<name>/manifests/revisions/<algorithm>/<hex digest>/signatures/<algorithm>/<hex digest>/link
+//
+//	Tags:
+//
+// 	manifestTagsPathSpec:          <root>/v2/repositories/<name>/manifests/tags/
+// 	manifestTagPathSpec:           <root>/v2/repositories/<name>/manifests/tags/<tag>/
+// 	manifestTagCurrentPathSpec:    <root>/v2/repositories/<name>/manifests/tags/<tag>/current/link
+// 	manifestTagIndexPathSpec:      <root>/v2/repositories/<name>/manifests/tags/<tag>/index/
+// 	manifestTagIndexEntryPathSpec: <root>/v2/repositories/<name>/manifests/tags/<tag>/index/<algorithm>/<hex digest>/link
+//
+// 	Layers:
+//
+// 	layerLinkPathSpec:             <root>/v2/repositories/<name>/layers/tarsum/<tarsum version>/<tarsum hash alg>/<tarsum hash>/link
+//
+//	Uploads:
+//
+// 	uploadDataPathSpec:             <root>/v2/repositories/<name>/uploads/<uuid>/data
+// 	uploadStartedAtPathSpec:        <root>/v2/repositories/<name>/uploads/<uuid>/startedat
+//
+//	Blob Store:
+//
+// 	blobPathSpec:                   <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>
+// 	blobDataPathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
 //
 // For more information on the semantic meaning of each path and their
 // contents, please see the path spec documentation.
@@ -75,13 +123,99 @@ func (pm *pathMapper) path(spec pathSpec) (string, error) {
 	repoPrefix := append(rootPrefix, "repositories")
 
 	switch v := spec.(type) {
-	case manifestTagsPath:
-		return path.Join(append(repoPrefix, v.name, "manifests")...), nil
-	case manifestPathSpec:
-		// TODO(sday): May need to store manifest by architecture.
-		return path.Join(append(repoPrefix, v.name, "manifests", v.tag)...), nil
+
+	case manifestRevisionPathSpec:
+		components, err := digestPathComponents(v.revision, false)
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(append(append(repoPrefix, v.name, "manifests", "revisions"), components...)...), nil
+	case manifestRevisionLinkPathSpec:
+		root, err := pm.path(manifestRevisionPathSpec{
+			name:     v.name,
+			revision: v.revision,
+		})
+
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(root, "link"), nil
+	case manifestSignaturesPathSpec:
+		root, err := pm.path(manifestRevisionPathSpec{
+			name:     v.name,
+			revision: v.revision,
+		})
+
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(root, "signatures"), nil
+	case manifestSignatureLinkPathSpec:
+		root, err := pm.path(manifestSignaturesPathSpec{
+			name:     v.name,
+			revision: v.revision,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		signatureComponents, err := digestPathComponents(v.signature, false)
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(root, path.Join(append(signatureComponents, "link")...)), nil
+	case manifestTagsPathSpec:
+		return path.Join(append(repoPrefix, v.name, "manifests", "tags")...), nil
+	case manifestTagPathSpec:
+		root, err := pm.path(manifestTagsPathSpec{
+			name: v.name,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(root, v.tag), nil
+	case manifestTagCurrentPathSpec:
+		root, err := pm.path(manifestTagPathSpec{
+			name: v.name,
+			tag:  v.tag,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(root, "current/link"), nil
+	case manifestTagIndexPathSpec:
+		root, err := pm.path(manifestTagPathSpec{
+			name: v.name,
+			tag:  v.tag,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(root, "index"), nil
+	case manifestTagIndexEntryPathSpec:
+		root, err := pm.path(manifestTagIndexPathSpec{
+			name: v.name,
+			tag:  v.tag,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		components, err := digestPathComponents(v.revision, false)
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(root, path.Join(append(components, "link")...)), nil
 	case layerLinkPathSpec:
-		components, err := digestPathComoponents(v.digest)
+		components, err := digestPathComponents(v.digest, false)
 		if err != nil {
 			return "", err
 		}
@@ -94,21 +228,17 @@ func (pm *pathMapper) path(spec pathSpec) (string, error) {
 
 		layerLinkPathComponents := append(repoPrefix, v.name, "layers")
 
-		return path.Join(append(layerLinkPathComponents, components...)...), nil
-	case blobPathSpec:
-		components, err := digestPathComoponents(v.digest)
+		return path.Join(path.Join(append(layerLinkPathComponents, components...)...), "link"), nil
+	case blobDataPathSpec:
+		components, err := digestPathComponents(v.digest, true)
 		if err != nil {
 			return "", err
 		}
 
-		// For now, only map tarsum paths.
-		if components[0] != "tarsum" {
-			// Only tarsum is supported, for now
-			return "", fmt.Errorf("unsupported content digest: %v", v.digest)
-		}
-
-		blobPathPrefix := append(rootPrefix, "blob")
+		components = append(components, "data")
+		blobPathPrefix := append(rootPrefix, "blobs")
 		return path.Join(append(blobPathPrefix, components...)...), nil
+
 	case uploadDataPathSpec:
 		return path.Join(append(repoPrefix, v.name, "uploads", v.uuid, "data")...), nil
 	case uploadStartedAtPathSpec:
@@ -126,22 +256,91 @@ type pathSpec interface {
 	pathSpec()
 }
 
-// manifestTagsPath describes the path elements required to point to the
-// directory with all manifest tags under the repository.
-type manifestTagsPath struct {
+// manifestRevisionPathSpec describes the components of the directory path for
+// a manifest revision.
+type manifestRevisionPathSpec struct {
+	name     string
+	revision digest.Digest
+}
+
+func (manifestRevisionPathSpec) pathSpec() {}
+
+// manifestRevisionLinkPathSpec describes the path components required to look
+// up the data link for a revision of a manifest. If this file is not present,
+// the manifest blob is not available in the given repo. The contents of this
+// file should just be the digest.
+type manifestRevisionLinkPathSpec struct {
+	name     string
+	revision digest.Digest
+}
+
+func (manifestRevisionLinkPathSpec) pathSpec() {}
+
+// manifestSignaturesPathSpec decribes the path components for the directory
+// containing all the signatures for the target blob. Entries are named with
+// the underlying key id.
+type manifestSignaturesPathSpec struct {
+	name     string
+	revision digest.Digest
+}
+
+func (manifestSignaturesPathSpec) pathSpec() {}
+
+// manifestSignatureLinkPathSpec decribes the path components used to look up
+// a signature file by the hash of its blob.
+type manifestSignatureLinkPathSpec struct {
+	name      string
+	revision  digest.Digest
+	signature digest.Digest
+}
+
+func (manifestSignatureLinkPathSpec) pathSpec() {}
+
+// manifestTagsPathSpec describes the path elements required to point to the
+// manifest tags directory.
+type manifestTagsPathSpec struct {
 	name string
 }
 
-func (manifestTagsPath) pathSpec() {}
+func (manifestTagsPathSpec) pathSpec() {}
 
-// manifestPathSpec describes the path elements used to build a manifest path.
-// The contents should be a signed manifest json file.
-type manifestPathSpec struct {
+// manifestTagPathSpec describes the path elements required to point to the
+// manifest tag links files under a repository. These contain a blob id that
+// can be used to look up the data and signatures.
+type manifestTagPathSpec struct {
 	name string
 	tag  string
 }
 
-func (manifestPathSpec) pathSpec() {}
+func (manifestTagPathSpec) pathSpec() {}
+
+// manifestTagCurrentPathSpec describes the link to the current revision for a
+// given tag.
+type manifestTagCurrentPathSpec struct {
+	name string
+	tag  string
+}
+
+func (manifestTagCurrentPathSpec) pathSpec() {}
+
+// manifestTagCurrentPathSpec describes the link to the index of revisions
+// with the given tag.
+type manifestTagIndexPathSpec struct {
+	name string
+	tag  string
+}
+
+func (manifestTagIndexPathSpec) pathSpec() {}
+
+// manifestTagIndexEntryPathSpec describes the link to a revisions of a
+// manifest with given tag within the index.
+type manifestTagIndexEntryPathSpec struct {
+	name     string
+	tag      string
+	revision digest.Digest
+}
+
+func (manifestTagIndexEntryPathSpec) pathSpec() {}
 
 // layerLink specifies a path for a layer link, which is a file with a blob
 // id. The layer link will contain a content addressable blob id reference
@@ -172,13 +371,20 @@ var blobAlgorithmReplacer = strings.NewReplacer(
 	";", "/",
 )
 
-// blobPath contains the path for the registry global blob store. For now,
-// this contains layer data, exclusively.
-type blobPathSpec struct {
+// // blobPathSpec contains the path for the registry global blob store.
+// type blobPathSpec struct {
+// 	digest digest.Digest
+// }
+
+// func (blobPathSpec) pathSpec() {}
+
+// blobDataPathSpec contains the path for the registry global blob store. For
+// now, this contains layer data, exclusively.
+type blobDataPathSpec struct {
 	digest digest.Digest
 }
 
-func (blobPathSpec) pathSpec() {}
+func (blobDataPathSpec) pathSpec() {}
 
 // uploadDataPathSpec defines the path parameters of the data file for
 // uploads.
@@ -203,18 +409,21 @@ type uploadStartedAtPathSpec struct {
 
 func (uploadStartedAtPathSpec) pathSpec() {}
 
-// digestPathComoponents provides a consistent path breakdown for a given
+// digestPathComponents provides a consistent path breakdown for a given
 // digest. For a generic digest, it will be as follows:
 //
-// 	<algorithm>/<first two bytes of digest>/<full digest>
+// 	<algorithm>/<hex digest>
 //
 // Most importantly, for tarsum, the layout looks like this:
 //
-// 	tarsum/<version>/<digest algorithm>/<first two bytes of digest>/<full digest>
+// 	tarsum/<version>/<digest algorithm>/<full digest>
 //
-// This is slightly specialized to store an extra version path for version 0
-// tarsums.
-func digestPathComoponents(dgst digest.Digest) ([]string, error) {
+// If multilevel is true, the first two bytes of the digest will separate
+// groups of digest folder. It will be as follows:
+//
+// 	<algorithm>/<first two bytes of digest>/<full digest>
+//
+func digestPathComponents(dgst digest.Digest, multilevel bool) ([]string, error) {
 	if err := dgst.Validate(); err != nil {
 		return nil, err
 	}
@@ -222,10 +431,14 @@ func digestPathComoponents(dgst digest.Digest) ([]string, error) {
 	algorithm := blobAlgorithmReplacer.Replace(dgst.Algorithm())
 	hex := dgst.Hex()
 	prefix := []string{algorithm}
-	suffix := []string{
-		hex[:2], // Breaks heirarchy up.
-		hex,
+
+	var suffix []string
+
+	if multilevel {
+		suffix = append(suffix, hex[:2])
 	}
+
+	suffix = append(suffix, hex)
 
 	if tsi, err := digest.ParseTarSum(dgst.String()); err == nil {
 		// We have a tarsum!
@@ -242,32 +455,4 @@ func digestPathComoponents(dgst digest.Digest) ([]string, error) {
 	}
 
 	return append(prefix, suffix...), nil
-}
-
-// resolveBlobPath looks up the blob location in the repositories from a
-// layer/blob link file, returning blob path or an error on failure.
-func resolveBlobPath(driver storagedriver.StorageDriver, pm *pathMapper, name string, dgst digest.Digest) (string, error) {
-	pathSpec := layerLinkPathSpec{name: name, digest: dgst}
-	layerLinkPath, err := pm.path(pathSpec)
-
-	if err != nil {
-		return "", err
-	}
-
-	layerLinkContent, err := driver.GetContent(layerLinkPath)
-	if err != nil {
-		return "", err
-	}
-
-	// NOTE(stevvooe): The content of the layer link should match the digest.
-	// This layer of indirection is for name-based content protection.
-
-	linked, err := digest.ParseDigest(string(layerLinkContent))
-	if err != nil {
-		return "", err
-	}
-
-	bp := blobPathSpec{digest: linked}
-
-	return pm.path(bp)
 }

--- a/storage/revisionstore.go
+++ b/storage/revisionstore.go
@@ -1,0 +1,217 @@
+package storage
+
+import (
+	"encoding/json"
+	"path"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/storagedriver"
+	"github.com/docker/libtrust"
+)
+
+// revisionStore supports storing and managing manifest revisions.
+type revisionStore struct {
+	driver     storagedriver.StorageDriver
+	pathMapper *pathMapper
+	blobStore  *blobStore
+}
+
+// exists returns true if the revision is available in the named repository.
+func (rs *revisionStore) exists(name string, revision digest.Digest) (bool, error) {
+	revpath, err := rs.pathMapper.path(manifestRevisionPathSpec{
+		name:     name,
+		revision: revision,
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	exists, err := exists(rs.driver, revpath)
+	if err != nil {
+		return false, err
+	}
+
+	return exists, nil
+}
+
+// get retrieves the manifest, keyed by revision digest.
+func (rs *revisionStore) get(name string, revision digest.Digest) (*manifest.SignedManifest, error) {
+	// Ensure that this revision is available in this repository.
+	if exists, err := rs.exists(name, revision); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, ErrUnknownManifestRevision{
+			Name:     name,
+			Revision: revision,
+		}
+	}
+
+	content, err := rs.blobStore.get(revision)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch the signatures for the manifest
+	signatures, err := rs.getSignatures(name, revision)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("retrieved signatures: %v", string(signatures[0]))
+
+	jsig, err := libtrust.NewJSONSignature(content, signatures...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the pretty JWS
+	raw, err := jsig.PrettySignature("signatures")
+	if err != nil {
+		return nil, err
+	}
+
+	var sm manifest.SignedManifest
+	if err := json.Unmarshal(raw, &sm); err != nil {
+		return nil, err
+	}
+
+	return &sm, nil
+}
+
+// put stores the manifest in the repository, if not already present. Any
+// updated signatures will be stored, as well.
+func (rs *revisionStore) put(name string, sm *manifest.SignedManifest) (digest.Digest, error) {
+	jsig, err := libtrust.ParsePrettySignature(sm.Raw, "signatures")
+	if err != nil {
+		return "", err
+	}
+
+	// Resolve the payload in the manifest.
+	payload, err := jsig.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	// Digest and store the manifest payload in the blob store.
+	revision, err := rs.blobStore.put(payload)
+	if err != nil {
+		logrus.Errorf("error putting payload into blobstore: %v", err)
+		return "", err
+	}
+
+	// Link the revision into the repository.
+	if err := rs.link(name, revision); err != nil {
+		return "", err
+	}
+
+	// Grab each json signature and store them.
+	signatures, err := jsig.Signatures()
+	if err != nil {
+		return "", err
+	}
+
+	for _, signature := range signatures {
+		if err := rs.putSignature(name, revision, signature); err != nil {
+			return "", err
+		}
+	}
+
+	return revision, nil
+}
+
+// link links the revision into the repository.
+func (rs *revisionStore) link(name string, revision digest.Digest) error {
+	revisionPath, err := rs.pathMapper.path(manifestRevisionLinkPathSpec{
+		name:     name,
+		revision: revision,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if exists, err := exists(rs.driver, revisionPath); err != nil {
+		return err
+	} else if exists {
+		// Revision has already been linked!
+		return nil
+	}
+
+	return rs.blobStore.link(revisionPath, revision)
+}
+
+// delete removes the specified manifest revision from storage.
+func (rs *revisionStore) delete(name string, revision digest.Digest) error {
+	revisionPath, err := rs.pathMapper.path(manifestRevisionPathSpec{
+		name:     name,
+		revision: revision,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return rs.driver.Delete(revisionPath)
+}
+
+// getSignatures retrieves all of the signature blobs for the specified
+// manifest revision.
+func (rs *revisionStore) getSignatures(name string, revision digest.Digest) ([][]byte, error) {
+	signaturesPath, err := rs.pathMapper.path(manifestSignaturesPathSpec{
+		name:     name,
+		revision: revision,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Need to append signature digest algorithm to path to get all items.
+	// Perhaps, this should be in the pathMapper but it feels awkward. This
+	// can be eliminated by implementing listAll on drivers.
+	signaturesPath = path.Join(signaturesPath, "sha256")
+
+	signaturePaths, err := rs.driver.List(signaturesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var signatures [][]byte
+	for _, sigPath := range signaturePaths {
+		// Append the link portion
+		sigPath = path.Join(sigPath, "link")
+
+		// TODO(stevvooe): These fetches should be parallelized for performance.
+		p, err := rs.blobStore.linked(sigPath)
+		if err != nil {
+			return nil, err
+		}
+
+		signatures = append(signatures, p)
+	}
+
+	return signatures, nil
+}
+
+// putSignature stores the signature for the provided manifest revision.
+func (rs *revisionStore) putSignature(name string, revision digest.Digest, signature []byte) error {
+	signatureDigest, err := rs.blobStore.put(signature)
+	if err != nil {
+		return err
+	}
+
+	signaturePath, err := rs.pathMapper.path(manifestSignatureLinkPathSpec{
+		name:      name,
+		revision:  revision,
+		signature: signatureDigest,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return rs.blobStore.link(signaturePath, signatureDigest)
+}

--- a/storage/tagstore.go
+++ b/storage/tagstore.go
@@ -1,0 +1,159 @@
+package storage
+
+import (
+	"path"
+
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/storagedriver"
+)
+
+// tagStore provides methods to manage manifest tags in a backend storage driver.
+type tagStore struct {
+	driver     storagedriver.StorageDriver
+	blobStore  *blobStore
+	pathMapper *pathMapper
+}
+
+// tags lists the manifest tags for the specified repository.
+func (ts *tagStore) tags(name string) ([]string, error) {
+	p, err := ts.pathMapper.path(manifestTagPathSpec{
+		name: name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var tags []string
+	entries, err := ts.driver.List(p)
+	if err != nil {
+		switch err := err.(type) {
+		case storagedriver.PathNotFoundError:
+			return nil, ErrUnknownRepository{Name: name}
+		default:
+			return nil, err
+		}
+	}
+
+	for _, entry := range entries {
+		_, filename := path.Split(entry)
+
+		tags = append(tags, filename)
+	}
+
+	return tags, nil
+}
+
+// exists returns true if the specified manifest tag exists in the repository.
+func (ts *tagStore) exists(name, tag string) (bool, error) {
+	tagPath, err := ts.pathMapper.path(manifestTagCurrentPathSpec{
+		name: name,
+		tag:  tag,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	exists, err := exists(ts.driver, tagPath)
+	if err != nil {
+		return false, err
+	}
+
+	return exists, nil
+}
+
+// tag tags the digest with the given tag, updating the the store to point at
+// the current tag. The digest must point to a manifest.
+func (ts *tagStore) tag(name, tag string, revision digest.Digest) error {
+	indexEntryPath, err := ts.pathMapper.path(manifestTagIndexEntryPathSpec{
+		name:     name,
+		tag:      tag,
+		revision: revision,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	currentPath, err := ts.pathMapper.path(manifestTagCurrentPathSpec{
+		name: name,
+		tag:  tag,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Link into the index
+	if err := ts.blobStore.link(indexEntryPath, revision); err != nil {
+		return err
+	}
+
+	// Overwrite the current link
+	return ts.blobStore.link(currentPath, revision)
+}
+
+// resolve the current revision for name and tag.
+func (ts *tagStore) resolve(name, tag string) (digest.Digest, error) {
+	currentPath, err := ts.pathMapper.path(manifestTagCurrentPathSpec{
+		name: name,
+		tag:  tag,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	if exists, err := exists(ts.driver, currentPath); err != nil {
+		return "", err
+	} else if !exists {
+		return "", ErrUnknownManifest{Name: name, Tag: tag}
+	}
+
+	revision, err := ts.blobStore.readlink(currentPath)
+	if err != nil {
+		return "", err
+	}
+
+	return revision, nil
+}
+
+// revisions returns all revisions with the specified name and tag.
+func (ts *tagStore) revisions(name, tag string) ([]digest.Digest, error) {
+	manifestTagIndexPath, err := ts.pathMapper.path(manifestTagIndexPathSpec{
+		name: name,
+		tag:  tag,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(stevvooe): Need to append digest alg to get listing of revisions.
+	manifestTagIndexPath = path.Join(manifestTagIndexPath, "sha256")
+
+	entries, err := ts.driver.List(manifestTagIndexPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var revisions []digest.Digest
+	for _, entry := range entries {
+		revisions = append(revisions, digest.NewDigestFromHex("sha256", path.Base(entry)))
+	}
+
+	return revisions, nil
+}
+
+// delete removes the tag from repository, including the history of all
+// revisions that have the specified tag.
+func (ts *tagStore) delete(name, tag string) error {
+	tagPath, err := ts.pathMapper.path(manifestTagPathSpec{
+		name: name,
+		tag:  tag,
+	})
+	if err != nil {
+		return err
+	}
+
+	return ts.driver.Delete(tagPath)
+}


### PR DESCRIPTION
Several requirements for storing registry data have been compiled and the backend layout has been refactored to comply. Specifically, we now store most data as blobs that are linked from repositories. All data access is traversed through repositories. Manifest updates are no longer destructive and support references by digest or tag. Signatures for manifests are now stored externally to the manifest payload to allow merging of signatures posted at different time.

The design is detailed in the documentation for pathMapper.

This change refactors the storage backend to use the new path layout. To facilitate this, manifest storage has been separated into a revision store and tag store, supported by a more general blob store. The blob store is a hybrid object, effectively providing both small object access, keyed by content address, as well as methods that can be used to manage and traverse links to underlying blobs. This covers common operations used in the revision store and tag store, such as linking and traversal. The blob store can also be updated to better support layer reading but this refactoring has been left for another day.

The revision store and tag store support the manifest store's compound view of data. These underlying stores provide facilities for richer access models, such as content-addressable access and a richer tagging model. The highlight of this change is the ability to sign a manifest from different hosts and have the registry merge and serve those signatures as part of the manifest package.

Various other items, such as the delegate layer handler, were updated to more directly use the blob store or other mechanism to fit with the changes.

Detecting tar files then falling back for calculating digests turned out to be fairly unreliable. Likely, the implementation was broken for content that was not a tarfile. Also, for the use case of the registry, it is really not needed. This functionality has been removed in FromReader and FromBytes. FromTarArchive has been added for convenience.

This work supports #25 and #46. This PR is dependent on docker/libtrust#49, which may need some discussion before merging.


<!---
@huboard:{"order":12.5,"milestone_order":64,"custom_state":""}
-->
