### PR TITLE
Refactor storage API to be registry oriented

### DIFF
--- a/registry/context.go
+++ b/registry/context.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/api/v2"
+	"github.com/docker/distribution/storage"
 )
 
 // Context should contain the request specific context for use in across
@@ -12,9 +13,9 @@ type Context struct {
 	// App points to the application structure that created this context.
 	*App
 
-	// Name is the prefix for the current request. Corresponds to the
-	// namespace/repository associated with the image.
-	Name string
+	// Repository is the repository for the current request. All requests
+	// should be scoped to a single repository. This field may be nil.
+	Repository storage.Repository
 
 	// Errors is a collection of errors encountered during the request to be
 	// returned to the client API. If errors are added to the collection, the

--- a/registry/images.go
+++ b/registry/images.go
@@ -38,8 +38,8 @@ type imageManifestHandler struct {
 
 // GetImageManifest fetches the image manifest from the storage backend, if it exists.
 func (imh *imageManifestHandler) GetImageManifest(w http.ResponseWriter, r *http.Request) {
-	manifests := imh.services.Manifests()
-	manifest, err := manifests.Get(imh.Name, imh.Tag)
+	manifests := imh.Repository.Manifests()
+	manifest, err := manifests.Get(imh.Tag)
 
 	if err != nil {
 		imh.Errors.Push(v2.ErrorCodeManifestUnknown, err)
@@ -54,7 +54,7 @@ func (imh *imageManifestHandler) GetImageManifest(w http.ResponseWriter, r *http
 
 // PutImageManifest validates and stores and image in the registry.
 func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http.Request) {
-	manifests := imh.services.Manifests()
+	manifests := imh.Repository.Manifests()
 	dec := json.NewDecoder(r.Body)
 
 	var manifest manifest.SignedManifest
@@ -64,7 +64,7 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 		return
 	}
 
-	if err := manifests.Put(imh.Name, imh.Tag, &manifest); err != nil {
+	if err := manifests.Put(imh.Tag, &manifest); err != nil {
 		// TODO(stevvooe): These error handling switches really need to be
 		// handled by an app global mapper.
 		switch err := err.(type) {
@@ -96,8 +96,8 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 
 // DeleteImageManifest removes the image with the given tag from the registry.
 func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *http.Request) {
-	manifests := imh.services.Manifests()
-	if err := manifests.Delete(imh.Name, imh.Tag); err != nil {
+	manifests := imh.Repository.Manifests()
+	if err := manifests.Delete(imh.Tag); err != nil {
 		switch err := err.(type) {
 		case storage.ErrUnknownManifest:
 			imh.Errors.Push(v2.ErrorCodeManifestUnknown, err)

--- a/registry/layer.go
+++ b/registry/layer.go
@@ -42,9 +42,8 @@ type layerHandler struct {
 // GetLayer fetches the binary data from backend storage returns it in the
 // response.
 func (lh *layerHandler) GetLayer(w http.ResponseWriter, r *http.Request) {
-	layers := lh.services.Layers()
-
-	layer, err := layers.Fetch(lh.Name, lh.Digest)
+	layers := lh.Repository.Layers()
+	layer, err := layers.Fetch(lh.Digest)
 
 	if err != nil {
 		switch err := err.(type) {

--- a/registry/tags.go
+++ b/registry/tags.go
@@ -33,14 +33,14 @@ type tagsAPIResponse struct {
 // GetTags returns a json list of tags for a specific image name.
 func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	manifests := th.services.Manifests()
+	manifests := th.Repository.Manifests()
 
-	tags, err := manifests.Tags(th.Name)
+	tags, err := manifests.Tags()
 	if err != nil {
 		switch err := err.(type) {
 		case storage.ErrUnknownRepository:
 			w.WriteHeader(404)
-			th.Errors.Push(v2.ErrorCodeNameUnknown, map[string]string{"name": th.Name})
+			th.Errors.Push(v2.ErrorCodeNameUnknown, map[string]string{"name": th.Repository.Name()})
 		default:
 			th.Errors.PushErr(err)
 		}
@@ -51,7 +51,7 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(tagsAPIResponse{
-		Name: th.Name,
+		Name: th.Repository.Name(),
 		Tags: tags,
 	}); err != nil {
 		th.Errors.PushErr(err)

--- a/storage/blobstore.go
+++ b/storage/blobstore.go
@@ -18,8 +18,7 @@ import (
 // abstraction, providing utility methods that support creating and traversing
 // backend links.
 type blobStore struct {
-	driver storagedriver.StorageDriver
-	pm     *pathMapper
+	*registry
 }
 
 // exists reports whether or not the path exists. If the driver returns error

--- a/storage/layerstore.go
+++ b/storage/layerstore.go
@@ -10,15 +10,13 @@ import (
 )
 
 type layerStore struct {
-	driver     storagedriver.StorageDriver
-	pathMapper *pathMapper
-	blobStore  *blobStore
+	repository *repository
 }
 
-func (ls *layerStore) Exists(name string, digest digest.Digest) (bool, error) {
+func (ls *layerStore) Exists(digest digest.Digest) (bool, error) {
 	// Because this implementation just follows blob links, an existence check
 	// is pretty cheap by starting and closing a fetch.
-	_, err := ls.Fetch(name, digest)
+	_, err := ls.Fetch(digest)
 
 	if err != nil {
 		switch err.(type) {
@@ -32,20 +30,20 @@ func (ls *layerStore) Exists(name string, digest digest.Digest) (bool, error) {
 	return true, nil
 }
 
-func (ls *layerStore) Fetch(name string, dgst digest.Digest) (Layer, error) {
-	bp, err := ls.path(name, dgst)
+func (ls *layerStore) Fetch(dgst digest.Digest) (Layer, error) {
+	bp, err := ls.path(dgst)
 	if err != nil {
 		return nil, err
 	}
 
-	fr, err := newFileReader(ls.driver, bp)
+	fr, err := newFileReader(ls.repository.driver, bp)
 	if err != nil {
 		return nil, err
 	}
 
 	return &layerReader{
 		fileReader: *fr,
-		name:       name,
+		name:       ls.repository.Name(),
 		digest:     dgst,
 	}, nil
 }
@@ -53,7 +51,7 @@ func (ls *layerStore) Fetch(name string, dgst digest.Digest) (Layer, error) {
 // Upload begins a layer upload, returning a handle. If the layer upload
 // is already in progress or the layer has already been uploaded, this
 // will return an error.
-func (ls *layerStore) Upload(name string) (LayerUpload, error) {
+func (ls *layerStore) Upload() (LayerUpload, error) {
 
 	// NOTE(stevvooe): Consider the issues with allowing concurrent upload of
 	// the same two layers. Should it be disallowed? For now, we allow both
@@ -62,8 +60,8 @@ func (ls *layerStore) Upload(name string) (LayerUpload, error) {
 	uuid := uuid.New()
 	startedAt := time.Now().UTC()
 
-	path, err := ls.pathMapper.path(uploadDataPathSpec{
-		name: name,
+	path, err := ls.repository.registry.pm.path(uploadDataPathSpec{
+		name: ls.repository.Name(),
 		uuid: uuid,
 	})
 
@@ -71,8 +69,8 @@ func (ls *layerStore) Upload(name string) (LayerUpload, error) {
 		return nil, err
 	}
 
-	startedAtPath, err := ls.pathMapper.path(uploadStartedAtPathSpec{
-		name: name,
+	startedAtPath, err := ls.repository.registry.pm.path(uploadStartedAtPathSpec{
+		name: ls.repository.Name(),
 		uuid: uuid,
 	})
 
@@ -81,18 +79,18 @@ func (ls *layerStore) Upload(name string) (LayerUpload, error) {
 	}
 
 	// Write a startedat file for this upload
-	if err := ls.driver.PutContent(startedAtPath, []byte(startedAt.Format(time.RFC3339))); err != nil {
+	if err := ls.repository.driver.PutContent(startedAtPath, []byte(startedAt.Format(time.RFC3339))); err != nil {
 		return nil, err
 	}
 
-	return ls.newLayerUpload(name, uuid, path, startedAt)
+	return ls.newLayerUpload(uuid, path, startedAt)
 }
 
 // Resume continues an in progress layer upload, returning the current
 // state of the upload.
-func (ls *layerStore) Resume(name, uuid string) (LayerUpload, error) {
-	startedAtPath, err := ls.pathMapper.path(uploadStartedAtPathSpec{
-		name: name,
+func (ls *layerStore) Resume(uuid string) (LayerUpload, error) {
+	startedAtPath, err := ls.repository.registry.pm.path(uploadStartedAtPathSpec{
+		name: ls.repository.Name(),
 		uuid: uuid,
 	})
 
@@ -100,7 +98,7 @@ func (ls *layerStore) Resume(name, uuid string) (LayerUpload, error) {
 		return nil, err
 	}
 
-	startedAtBytes, err := ls.driver.GetContent(startedAtPath)
+	startedAtBytes, err := ls.repository.driver.GetContent(startedAtPath)
 	if err != nil {
 		switch err := err.(type) {
 		case storagedriver.PathNotFoundError:
@@ -115,8 +113,8 @@ func (ls *layerStore) Resume(name, uuid string) (LayerUpload, error) {
 		return nil, err
 	}
 
-	path, err := ls.pathMapper.path(uploadDataPathSpec{
-		name: name,
+	path, err := ls.repository.pm.path(uploadDataPathSpec{
+		name: ls.repository.Name(),
 		uuid: uuid,
 	})
 
@@ -124,33 +122,32 @@ func (ls *layerStore) Resume(name, uuid string) (LayerUpload, error) {
 		return nil, err
 	}
 
-	return ls.newLayerUpload(name, uuid, path, startedAt)
+	return ls.newLayerUpload(uuid, path, startedAt)
 }
 
 // newLayerUpload allocates a new upload controller with the given state.
-func (ls *layerStore) newLayerUpload(name, uuid, path string, startedAt time.Time) (LayerUpload, error) {
-	fw, err := newFileWriter(ls.driver, path)
+func (ls *layerStore) newLayerUpload(uuid, path string, startedAt time.Time) (LayerUpload, error) {
+	fw, err := newFileWriter(ls.repository.driver, path)
 	if err != nil {
 		return nil, err
 	}
 
 	return &layerUploadController{
 		layerStore: ls,
-		name:       name,
 		uuid:       uuid,
 		startedAt:  startedAt,
 		fileWriter: *fw,
 	}, nil
 }
 
-func (ls *layerStore) path(name string, dgst digest.Digest) (string, error) {
+func (ls *layerStore) path(dgst digest.Digest) (string, error) {
 	// We must traverse this path through the link to enforce ownership.
-	layerLinkPath, err := ls.pathMapper.path(layerLinkPathSpec{name: name, digest: dgst})
+	layerLinkPath, err := ls.repository.registry.pm.path(layerLinkPathSpec{name: ls.repository.Name(), digest: dgst})
 	if err != nil {
 		return "", err
 	}
 
-	blobPath, err := ls.blobStore.resolve(layerLinkPath)
+	blobPath, err := ls.repository.blobStore.resolve(layerLinkPath)
 
 	if err != nil {
 		switch err := err.(type) {

--- a/storage/registry.go
+++ b/storage/registry.go
@@ -1,0 +1,75 @@
+package storage
+
+import "github.com/docker/distribution/storagedriver"
+
+// registry is the top-level implementation of Registry for use in the storage
+// package. All instances should descend from this object.
+type registry struct {
+	driver    storagedriver.StorageDriver
+	pm        *pathMapper
+	blobStore *blobStore
+}
+
+// NewRegistryWithDriver creates a new registry instance from the provided
+// driver. The resulting registry may be shared by multiple goroutines but is
+// cheap to allocate.
+func NewRegistryWithDriver(driver storagedriver.StorageDriver) Registry {
+	bs := &blobStore{}
+
+	reg := &registry{
+		driver:    driver,
+		blobStore: bs,
+
+		// TODO(sday): This should be configurable.
+		pm: defaultPathMapper,
+	}
+
+	reg.blobStore.registry = reg
+
+	return reg
+}
+
+// Repository returns an instance of the repository tied to the registry.
+// Instances should not be shared between goroutines but are cheap to
+// allocate. In general, they should be request scoped.
+func (reg *registry) Repository(name string) Repository {
+	return &repository{
+		registry: reg,
+		name:     name,
+	}
+}
+
+// repository provides name-scoped access to various services.
+type repository struct {
+	*registry
+	name string
+}
+
+// Name returns the name of the repository.
+func (repo *repository) Name() string {
+	return repo.name
+}
+
+// Manifests returns an instance of ManifestService. Instantiation is cheap and
+// may be context sensitive in the future. The instance should be used similar
+// to a request local.
+func (repo *repository) Manifests() ManifestService {
+	return &manifestStore{
+		repository: repo,
+		revisionStore: &revisionStore{
+			repository: repo,
+		},
+		tagStore: &tagStore{
+			repository: repo,
+		},
+	}
+}
+
+// Layers returns an instance of the LayerService. Instantiation is cheap and
+// may be context sensitive in the future. The instance should be used similar
+// to a request local.
+func (repo *repository) Layers() LayerService {
+	return &layerStore{
+		repository: repo,
+	}
+}

--- a/storage/services.go
+++ b/storage/services.go
@@ -3,101 +3,81 @@ package storage
 import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
-	"github.com/docker/distribution/storagedriver"
 )
 
-// Services provides various services with application-level operations for
-// use across backend storage drivers.
-type Services struct {
-	driver     storagedriver.StorageDriver
-	pathMapper *pathMapper
+// TODO(stevvooe): These types need to be moved out of the storage package.
+
+// Registry represents a collection of repositories, addressable by name.
+type Registry interface {
+	// Repository should return a reference to the named repository. The
+	// registry may or may not have the repository but should always return a
+	// reference.
+	Repository(name string) Repository
 }
 
-// NewServices creates a new Services object to access docker objects stored
-// in the underlying driver.
-func NewServices(driver storagedriver.StorageDriver) *Services {
+// Repository is a named collection of manifests and layers.
+type Repository interface {
+	// Name returns the name of the repository.
+	Name() string
 
-	return &Services{
-		driver: driver,
-		// TODO(sday): This should be configurable.
-		pathMapper: defaultPathMapper,
-	}
-}
+	// Manifests returns a reference to this repository's manifest service.
+	Manifests() ManifestService
 
-// Layers returns an instance of the LayerService. Instantiation is cheap and
-// may be context sensitive in the future. The instance should be used similar
-// to a request local.
-func (ss *Services) Layers() LayerService {
-	return &layerStore{
-		driver: ss.driver,
-		blobStore: &blobStore{
-			driver: ss.driver,
-			pm:     ss.pathMapper,
-		},
-		pathMapper: ss.pathMapper,
-	}
-}
-
-// Manifests returns an instance of ManifestService. Instantiation is cheap and
-// may be context sensitive in the future. The instance should be used similar
-// to a request local.
-func (ss *Services) Manifests() ManifestService {
-	// TODO(stevvooe): Lose this kludge. An intermediary object is clearly
-	// missing here. This initialization is a mess.
-	bs := &blobStore{
-		driver: ss.driver,
-		pm:     ss.pathMapper,
-	}
-
-	return &manifestStore{
-		driver:     ss.driver,
-		pathMapper: ss.pathMapper,
-		revisionStore: &revisionStore{
-			driver:     ss.driver,
-			pathMapper: ss.pathMapper,
-			blobStore:  bs,
-		},
-		tagStore: &tagStore{
-			driver:     ss.driver,
-			blobStore:  bs,
-			pathMapper: ss.pathMapper,
-		},
-		blobStore:    bs,
-		layerService: ss.Layers()}
+	// Layers returns a reference to this repository's layers service.
+	Layers() LayerService
 }
 
 // ManifestService provides operations on image manifests.
 type ManifestService interface {
 	// Tags lists the tags under the named repository.
-	Tags(name string) ([]string, error)
+	Tags() ([]string, error)
 
 	// Exists returns true if the manifest exists.
-	Exists(name, tag string) (bool, error)
+	Exists(tag string) (bool, error)
 
 	// Get retrieves the named manifest, if it exists.
-	Get(name, tag string) (*manifest.SignedManifest, error)
+	Get(tag string) (*manifest.SignedManifest, error)
 
 	// Put creates or updates the named manifest.
-	Put(name, tag string, manifest *manifest.SignedManifest) error
+	// Put(tag string, manifest *manifest.SignedManifest) (digest.Digest, error)
+	Put(tag string, manifest *manifest.SignedManifest) error
 
 	// Delete removes the named manifest, if it exists.
-	Delete(name, tag string) error
+	Delete(tag string) error
+
+	// TODO(stevvooe): There are several changes that need to be done to this
+	// interface:
+	//
+	//	1. Get(tag string) should be GetByTag(tag string)
+	//	2. Put(tag string, manifest *manifest.SignedManifest) should be
+	//       Put(manifest *manifest.SignedManifest). The method can read the
+	//       tag on manifest to automatically tag it in the repository.
+	//	3. Need a GetByDigest(dgst digest.Digest) method.
+	//	4. Allow explicit tagging with Tag(digest digest.Digest, tag string)
+	//	5. Support reading tags with a re-entrant reader to avoid large
+	//       allocations in the registry.
+	//	6. Long-term: Provide All() method that lets one scroll through all of
+	//       the manifest entries.
+	//	7. Long-term: break out concept of signing from manifests. This is
+	//       really a part of the distribution sprint.
+	//	8. Long-term: Manifest should be an interface. This code shouldn't
+	//       really be concerned with the storage format.
 }
 
 // LayerService provides operations on layer files in a backend storage.
 type LayerService interface {
 	// Exists returns true if the layer exists.
-	Exists(name string, digest digest.Digest) (bool, error)
+	Exists(digest digest.Digest) (bool, error)
 
 	// Fetch the layer identifed by TarSum.
-	Fetch(name string, digest digest.Digest) (Layer, error)
+	Fetch(digest digest.Digest) (Layer, error)
 
 	// Upload begins a layer upload to repository identified by name,
 	// returning a handle.
-	Upload(name string) (LayerUpload, error)
+	Upload() (LayerUpload, error)
 
 	// Resume continues an in progress layer upload, returning a handle to the
 	// upload. The caller should seek to the latest desired upload location
 	// before proceeding.
-	Resume(name, uuid string) (LayerUpload, error)
+	Resume(uuid string) (LayerUpload, error)
 }


### PR DESCRIPTION
In support of making the storage API ready for supporting notifications and mirroring, we've begun the process of paring down the storage model. The process started by creating a central Registry interface. From there, the common name argument on the LayerService and ManifestService was factored into a Repository interface. The rest of the changes directly follow from this.

An interface wishlist was added, suggesting a direction to take the registry package that should support the distribution project's future goals. As these objects move out of the storage package and we implement a Registry backed by the http client, these design choices will start getting validation.

Connects to #42.

Signed-off-by: Stephen J Day <stephen.day@docker.com