### PR TITLE
Add TestPutContentMultipleTimes to storage driver suite

### DIFF
--- a/storagedriver/testsuites/testsuites.go
+++ b/storagedriver/testsuites/testsuites.go
@@ -735,6 +735,27 @@ func (suite *DriverSuite) TestStatCall(c *check.C) {
 	}
 }
 
+// TestPutContentMultipleTimes checks that if storage driver can overwrite the content
+// in the subsequent puts. Validates that PutContent does not have to work
+// with an offset like WriteStream does and overwrites the file entirely
+// rather than writing the data to the [0,len(data)) of the file.
+func (suite *DriverSuite) TestPutContentMultipleTimes(c *check.C) {
+	filename := randomPath(32)
+	contents := randomContents(4096)
+
+	defer suite.StorageDriver.Delete(firstPart(filename))
+	err := suite.StorageDriver.PutContent(filename, contents)
+	c.Assert(err, check.IsNil)
+
+	contents = randomContents(2048) // upload a different, smaller file
+	err = suite.StorageDriver.PutContent(filename, contents)
+	c.Assert(err, check.IsNil)
+
+	readContents, err := suite.StorageDriver.GetContent(filename)
+	c.Assert(err, check.IsNil)
+	c.Assert(readContents, check.DeepEquals, contents)
+}
+
 // TestConcurrentStreamReads checks that multiple clients can safely read from
 // the same file simultaneously with various offsets.
 func (suite *DriverSuite) TestConcurrentStreamReads(c *check.C) {


### PR DESCRIPTION
I thought having this might be a good check of the requirements expected from **PutContent**.

i.e. some implementation like

     PutContent(path, data) error {
          return d.WriteStream(path, 0, data)
     }

would be an erroneous implementation as PutContent should delete old contents and should support multiple writes (at offset=0 of the file –whereas WriteStream does not require it).

Adding this small test helped me avoid a potential pitfall in writing the Azure storage driver. cc: @stevvooe @BrianBland 

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>