### PR TITLE
Add Docker Distribution API Version header

### DIFF
--- a/registry/app.go
+++ b/registry/app.go
@@ -88,6 +88,8 @@ func NewApp(configuration configuration.Configuration) *App {
 }
 
 func (app *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Set a header with the Docker Distribution API Version for all responses.
+	w.Header().Add("Docker-Distribution-API-Version", "registry/2.0")
 	app.router.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
Setting a header for all responses can help clients better determine
if the server speaks the legacy v1 API or the v2 API. It is important
that the header be set *BEFORE* routing the request.

Docker-DCO-1.1-Signed-off-by: Josh Hawn <josh.hawn@docker.com> (github: jlhawn)