### PR TITLE
Update the Dockerfile to use the Godeps versions of libraries and to explicitly use golang:1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM golang
-
-COPY . /go/src/github.com/docker/distribution
-
-# Fetch any dependencies to run the registry
-RUN go get github.com/docker/distribution/...
-RUN go install github.com/docker/distribution/cmd/registry
+FROM golang:1.4
 
 ENV CONFIG_PATH /etc/docker/registry/config.yml
-COPY ./cmd/registry/config.yml $CONFIG_PATH
+RUN mkdir -pv "$(dirname $CONFIG_PATH)"
+
+ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
+WORKDIR $DISTRIBUTION_DIR
+COPY . $DISTRIBUTION_DIR
+ENV GOPATH $GOPATH:$DISTRIBUTION_DIR/Godeps/_workspace
+
+RUN go install -v ./cmd/registry
+
+RUN cp -lv ./cmd/registry/config.yml $CONFIG_PATH
 
 EXPOSE 5000
-ENV PATH /go/bin
 CMD registry $CONFIG_PATH


### PR DESCRIPTION
This speeds up the build (and makes it more consistent) since it doesn't have to clone a bunch of repos. :+1:

With this change, my final image is ~493.8 MB (versus ~567.7 MB when I build from master).

Also:
```console
$ time docker build --no-cache .
...
real	0m38.081s
user	0m0.027s
sys	0m0.029s
```

Versus:
```console
$ time docker build --no-cache https://github.com/docker/distribution.git
...
real	1m31.629s
user	0m0.145s
sys	0m0.082s
```
(most of which is spent in `Step 2 : RUN go get github.com/docker/distribution/...`)