### PR TITLE
Event and Sink definition with endpoint notification

### DIFF
--- a/storage/notifications/endpoint.go
+++ b/storage/notifications/endpoint.go
@@ -1,0 +1,127 @@
+package notifications
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+// EventsMediaType is the mediatype for the json event envelope. If the Event
+// or Envelope struct changes, the version number should be incremented.
+const EventsMediaType = "application/vnd.docker.distribution.events.v1+json"
+
+// Envelope defines the fields of a json event envelope message.
+type Envelope struct {
+	Events []Event `json:"events,omitempty"`
+}
+
+// Endpoint implements a single-flight, http notificaiton endpoint. This is
+// very lightweight in that it only makes an attempt at an http request.
+// Reliability should be provided by the caller.
+type Endpoint struct {
+	name string
+	url  string
+
+	// TODO(stevvooe): Allow one to configure the media type accepted by this
+	// endpoint and choose the serialization based on that.
+	metrics EndpointMetrics
+	mu      sync.Mutex
+}
+
+var _ Sink = &Endpoint{}
+
+// EndpointMetrics track various actions taken by the endpoint, typically by
+// number of events.
+type EndpointMetrics struct {
+	Events      int         // total events attempted, including repeats
+	Successes   int         // total events written successfully
+	Failures    int         // total events failed
+	StatusCodes map[int]int // status code histogram, per call event
+}
+
+// NewEndpoint returns an endpoint prepared for action.
+func NewEndpoint(name, u string) *Endpoint {
+	e := Endpoint{
+		name: name,
+		url:  u,
+	}
+
+	e.metrics.StatusCodes = make(map[int]int)
+
+	return &e
+}
+
+// Name returns the name of the endpoint, generally used for debugging.
+func (e *Endpoint) Name() string {
+	return e.name
+}
+
+// URL returns the url of the endpoint.
+func (e *Endpoint) URL() string {
+	return e.url
+}
+
+// Accept makes an attempt to notify the endpoint, returning an error if it
+// fails. It is the caller's responsibility to retry on error. The events are
+// accepted or rejected as a group.
+func (e *Endpoint) Write(events ...Event) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.metrics.Events += len(events)
+
+	envelope := Envelope{
+		Events: events,
+	}
+
+	p, err := json.MarshalIndent(envelope, "", "   ")
+	if err != nil {
+		e.metrics.Failures++
+		return fmt.Errorf("%v: error marshaling event envelope: %v", e, err)
+	}
+
+	body := bytes.NewReader(p)
+	resp, err := http.Post(e.URL(), EventsMediaType, body)
+	if err != nil {
+		e.metrics.Failures++
+		return fmt.Errorf("%v: error posting: %v", e, err)
+	}
+
+	e.metrics.StatusCodes[resp.StatusCode]++
+
+	// The notifier will treat any 2xx or 3xx response as accepted by the
+	// endpoint.
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 400:
+		e.metrics.Successes++
+
+		// TODO(stevvooe): This is a little accepting: we may want to support
+		// unsupport media type responses with retries using the correct media
+		// type. There may also be cases that will never work.
+
+		return nil
+	default:
+		e.metrics.Failures++
+		return fmt.Errorf("%v: response status %v unaccepted", e, resp.Status)
+	}
+}
+
+// ReadMetrics populates em with metrics from the endpoint.
+func (e *Endpoint) ReadMetrics(em *EndpointMetrics) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	*em = e.metrics
+
+	// Map still need to copied in a threadsafe manner.
+	em.StatusCodes = make(map[int]int)
+	for k, v := range e.metrics.StatusCodes {
+		em.StatusCodes[k] = v
+	}
+}
+
+func (e *Endpoint) String() string {
+	return fmt.Sprintf("notification.Endpoint{Name: %q, URL: %q}", e.Name(), e.URL())
+}

--- a/storage/notifications/endpoint_test.go
+++ b/storage/notifications/endpoint_test.go
@@ -1,0 +1,280 @@
+package notifications
+
+import (
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"code.google.com/p/go-uuid/uuid"
+)
+
+// TestEndpoint mocks out an http endpoint and notifies it under a couple of
+// conditions, ensuring correct behavior.
+func TestEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if r.Method != "POST" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			t.Fatalf("unexpected request method: %v", r.Method)
+			return
+		}
+
+		// Extract the content type and make sure it matches
+		contentType := r.Header.Get("Content-Type")
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			t.Fatalf("error parsing media type: %v, contenttype=%q", err, contentType)
+			return
+		}
+
+		if mediaType != EventsMediaType {
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			t.Fatalf("incorrect media type: %q != %q", mediaType, EventsMediaType)
+			return
+		}
+
+		var envelope Envelope
+		dec := json.NewDecoder(r.Body)
+		if err := dec.Decode(&envelope); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			t.Fatalf("error decoding request body: %v", err)
+			return
+		}
+
+		// Let caller choose the status
+		status, err := strconv.Atoi(r.FormValue("status"))
+		if err != nil {
+			t.Logf("error parsing status: %v", err)
+
+			// May just be empty, set status to 200
+			status = http.StatusOK
+		}
+
+		w.WriteHeader(status)
+	}))
+
+	endpoint := NewEndpoint("", server.URL)
+	var expectedMetrics EndpointMetrics
+	expectedMetrics.StatusCodes = make(map[int]int)
+
+	for attempt, tc := range []struct {
+		events     []Event // events to send
+		url        string
+		failure    bool // true if there should be a failure.
+		statusCode int  // if not set, no status code should be incremented.
+	}{
+		{
+			statusCode: http.StatusOK,
+			events: []Event{
+				createTestEvent("push", "library/test", "manifest")},
+		},
+		{
+			statusCode: http.StatusOK,
+			events: []Event{
+				createTestEvent("push", "library/test", "manifest"),
+				createTestEvent("push", "library/test", "layer"),
+				createTestEvent("push", "library/test", "layer"),
+			},
+		},
+		{
+			statusCode: http.StatusTemporaryRedirect,
+		},
+		{
+			statusCode: http.StatusBadRequest,
+			failure:    true,
+		},
+		{
+			// Case where connection never goes through.
+			url:     "http://shoudlntresolve/",
+			failure: true,
+		},
+	} {
+
+		expectedMetrics.Events += len(tc.events)
+
+		if tc.failure {
+			expectedMetrics.Failures++
+		} else {
+			expectedMetrics.Successes++
+		}
+
+		if tc.statusCode > 0 {
+			expectedMetrics.StatusCodes[tc.statusCode]++
+		}
+
+		// Normally this isn't okay, but we can set this in the test.
+		endpoint.name = fmt.Sprintf("test-%d", attempt)
+
+		url := tc.url
+		if url == "" {
+			url = server.URL + "/"
+		}
+		// setup endpoint to respond with expected status code.
+		url += fmt.Sprintf("?status=%v", tc.statusCode)
+		endpoint.url = url
+
+		if endpoint.Name() != endpoint.name {
+			t.Fatalf("endpoint name should match method return: %q != %q", endpoint.Name(), endpoint.name)
+		}
+
+		// Try a simple event emission.
+		err := endpoint.Write(tc.events...)
+
+		if !tc.failure {
+			if err != nil {
+				t.Fatalf("unexpected error send event: %v", err)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("the endpoint should have rejected the request")
+			}
+		}
+
+		var metrics EndpointMetrics
+		endpoint.ReadMetrics(&metrics)
+
+		if !reflect.DeepEqual(metrics, expectedMetrics) {
+			t.Fatalf("metrics not as expected: %#v != %#v", metrics, expectedMetrics)
+		}
+	}
+
+}
+
+// TestEventJSONFormat provides silly test to detect if the event format or
+// envelope has changed. If this code fails, the revision of the protocol may
+// need to be incremented.
+func TestEventEnvelopeJSONFormat(t *testing.T) {
+	var expected = strings.TrimSpace(`
+{
+   "events": [
+      {
+         "uuid": "asdf-asdf-asdf-asdf-0",
+         "timestamp": "2006-01-02T15:04:05Z",
+         "action": "push",
+         "target": {
+            "type": "manifest",
+            "name": "library/test",
+            "digest": "sha256:0123456789abcdef0",
+            "tag": "latest",
+            "url": "http://example.com/v2/library/test/manifests/latest"
+         },
+         "actor": {
+            "name": "test-actor",
+            "addr": "hostname.local"
+         },
+         "source": {
+            "addr": "hostname.local",
+            "host": "registrycluster.local"
+         }
+      },
+      {
+         "uuid": "asdf-asdf-asdf-asdf-1",
+         "timestamp": "2006-01-02T15:04:05Z",
+         "action": "push",
+         "target": {
+            "type": "blob",
+            "name": "library/test",
+            "digest": "tarsum.v2+sha256:0123456789abcdef1",
+            "url": "http://example.com/v2/library/test/manifests/latest"
+         },
+         "actor": {
+            "name": "test-actor",
+            "addr": "hostname.local"
+         },
+         "source": {
+            "addr": "hostname.local",
+            "host": "registrycluster.local"
+         }
+      },
+      {
+         "uuid": "asdf-asdf-asdf-asdf-2",
+         "timestamp": "2006-01-02T15:04:05Z",
+         "action": "push",
+         "target": {
+            "type": "blob",
+            "name": "library/test",
+            "digest": "tarsum.v2+sha256:0123456789abcdef2",
+            "url": "http://example.com/v2/library/test/manifests/latest"
+         },
+         "actor": {
+            "name": "test-actor",
+            "addr": "hostname.local"
+         },
+         "source": {
+            "addr": "hostname.local",
+            "host": "registrycluster.local"
+         }
+      }
+   ]
+}
+	`)
+
+	tm, err := time.Parse(time.RFC3339, time.RFC3339[:len(time.RFC3339)-5])
+	if err != nil {
+		t.Fatalf("error creating time: %v", err)
+	}
+
+	var prototype Event
+	prototype.Action = "push"
+	prototype.Timestamp = tm
+	prototype.Actor.Addr = "hostname.local"
+	prototype.Actor.Name = "test-actor"
+	prototype.Source.Addr = "hostname.local"
+	prototype.Source.Host = "registrycluster.local"
+
+	var manifestPush Event
+	manifestPush = prototype
+	manifestPush.UUID = "asdf-asdf-asdf-asdf-0"
+	manifestPush.Target.Digest = "sha256:0123456789abcdef0"
+	manifestPush.Target.Type = "manifest"
+	manifestPush.Target.Name = "library/test"
+	manifestPush.Target.Tag = "latest"
+	manifestPush.Target.URL = "http://example.com/v2/library/test/manifests/latest"
+
+	var layerPush0 Event
+	layerPush0 = prototype
+	layerPush0.UUID = "asdf-asdf-asdf-asdf-1"
+	layerPush0.Target.Digest = "tarsum.v2+sha256:0123456789abcdef1"
+	layerPush0.Target.Type = "blob"
+	layerPush0.Target.Name = "library/test"
+	layerPush0.Target.URL = "http://example.com/v2/library/test/manifests/latest"
+
+	var layerPush1 Event
+	layerPush1 = prototype
+	layerPush1.UUID = "asdf-asdf-asdf-asdf-2"
+	layerPush1.Target.Digest = "tarsum.v2+sha256:0123456789abcdef2"
+	layerPush1.Target.Type = "blob"
+	layerPush1.Target.Name = "library/test"
+	layerPush1.Target.URL = "http://example.com/v2/library/test/manifests/latest"
+
+	var envelope Envelope
+	envelope.Events = append(envelope.Events, manifestPush, layerPush0, layerPush1)
+
+	p, err := json.MarshalIndent(envelope, "", "   ")
+	if err != nil {
+		t.Fatalf("unexpected error marshaling envelope: %v", err)
+	}
+	if string(p) != expected {
+		t.Fatalf("format has changed\n%s\n != \n%s", string(p), expected)
+	}
+}
+
+func createTestEvent(action, repo, typ string) Event {
+	var event Event
+
+	event.UUID = uuid.New()
+	event.Timestamp = time.Now().UTC()
+	event.Action = action
+	event.Target.Type = typ
+	event.Target.Name = repo
+
+	return event
+}

--- a/storage/notifications/event.go
+++ b/storage/notifications/event.go
@@ -1,0 +1,82 @@
+package notifications
+
+import (
+	"time"
+
+	"github.com/docker/distribution/digest"
+)
+
+// Event provides the fields required to describe a registry event.
+type Event struct {
+	// UUID provides a unique identifier for the event.
+	UUID string `json:"uuid,omitempty"`
+
+	// Timestamp is the time at which the event occurred.
+	Timestamp time.Time `json:"timestamp,omitempty"`
+
+	// Action indicates what action encompasses the provided event.
+	Action string `json:"action,omitempty"`
+
+	// Target uniquely describes the target of the event.
+	Target struct {
+		// Type should be "manifest" or "blob"
+		Type string `json:"type,omitempty"`
+
+		// Name identifies the named repository.
+		Name string `json:"name,omitempty"`
+
+		// Digest should identify the object in the repository.
+		Digest digest.Digest `json:"digest,omitempty"`
+
+		// Tag is present if the operation involved a tagged manifest.
+		Tag string `json:"tag,omitempty"`
+
+		// URL provides a link to the content on the relevant repository instance.
+		URL string `json:"url,omitempty"`
+	} `json:"target,omitempty"`
+
+	// Actor specifies the agent that initiated the event. For most
+	// situations, this could be from the authorizaton context of the request.
+	Actor struct {
+		// Name corresponds to the subject or username associated with the
+		// request context that generated the event.
+		Name string `json:"name,omitempty"`
+
+		// Addr contains the ip or hostname and possibly port of the client
+		// connection that initiated the event.
+		Addr string `json:"addr,omitempty"`
+	} `json:"actor,omitempty"`
+
+	// Source identifies the registry node that generated the event. Put
+	// differently, while the actor "initiates" the event, the source
+	// "generates" it.
+	Source struct {
+		// Addr contains the ip or hostname and the port of the registry node
+		// that generated the event. Generally, this will be resolved by
+		// os.Hostname() along with the running port.
+		Addr string `json:"addr,omitempty"`
+
+		// Host is the dns name of the registry cluster, as configured.
+		Host string `json:"host,omitempty"`
+
+		// TODO(stevvooe): Host configuration not yet present. Will require a
+		// url builder configured with the hostname for this implementation.
+
+		// TODO(stevvooe): Future fields:
+		//  RequestID: but this is not yet implemented in webapp.
+
+	} `json:"source,omitempty"`
+}
+
+// Sink accepts and sends events.
+type Sink interface {
+	// Write writes one or more events to the sink. If no error is returned,
+	// the caller will assume that all events have been committed and will not
+	// try to send them again. If an error is received, the caller may retry
+	// sending the event. The caller should cede the slice of memory to the
+	// sink and not modify it after calling this method.
+	Write(events ...Event) error
+
+	// TODO(stevvooe): The event type should be separate from the json format
+	// for this interface but we'll leave as is for now.
+}


### PR DESCRIPTION
This changeset defines the json format and event sink. An implementation of the
endpoint notifier is included to demonstrate the notification protocol. Work
still needs to be done to connect the decoration component with the event sink
reliably.

cc @jlhawn

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Connects to #42.