### PR TITLE
Fixes an IAM role authentication bug

### DIFF
--- a/storagedriver/s3/s3.go
+++ b/storagedriver/s3/s3.go
@@ -82,8 +82,14 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	// Providing no values for these is valid in case the user is authenticating
 	// with an IAM on an ec2 instance (in which case the instance credentials will
 	// be summoned when GetAuth is called)
-	accessKey, _ := parameters["accesskey"]
-	secretKey, _ := parameters["secretkey"]
+	accessKey, ok := parameters["accesskey"]
+	if !ok {
+		accessKey = ""
+	}
+	secretKey, ok := parameters["secretkey"]
+	if !ok {
+		secretKey = ""
+	}
 
 	regionName, ok := parameters["region"]
 	if !ok || fmt.Sprint(regionName) == "" {


### PR DESCRIPTION
More specifically, the driver panics if initialized with
FromParameters with no accesskey or secretkey.