### PR TITLE
update modtime on WriteAt for inmemory driver

### DIFF
--- a/storagedriver/inmemory/mfs.go
+++ b/storagedriver/inmemory/mfs.go
@@ -299,6 +299,7 @@ func (f *file) WriteAt(p []byte, offset int64) (n int, err error) {
 		f.data = data
 	}
 
+	f.mod = time.Now()
 	f.data = f.data[:off+len(p)]
 
 	return copy(f.data[off:off+len(p)], p), nil


### PR DESCRIPTION
discovered in the new `TestStatCall` (#77). currently breaks CI for #77.

cc: @stevvooe @BrianBland @AndreyKostov 