### PR TITLE
Allow single name component repository names

### DIFF
--- a/api/v2/names.go
+++ b/api/v2/names.go
@@ -17,7 +17,7 @@ const (
 
 	// RepositoryNameMinComponents is the minimum number of slash-delimited
 	// components that a repository name must have
-	RepositoryNameMinComponents = 2
+	RepositoryNameMinComponents = 1
 
 	// RepositoryNameMaxComponents is the maximum number of slash-delimited
 	// components that a repository name must have
@@ -41,9 +41,9 @@ var RepositoryNameComponentAnchoredRegexp = regexp.MustCompile(`^` + RepositoryN
 // Looking path prefixes and s3 limitation of 1024, this should likely be
 // around 512 bytes. 256 bytes might be more manageable.
 
-// RepositoryNameRegexp builds on RepositoryNameComponentRegexp to allow 2 to
+// RepositoryNameRegexp builds on RepositoryNameComponentRegexp to allow 1 to
 // 5 path components, separated by a forward slash.
-var RepositoryNameRegexp = regexp.MustCompile(`(?:` + RepositoryNameComponentRegexp.String() + `/){1,4}` + RepositoryNameComponentRegexp.String())
+var RepositoryNameRegexp = regexp.MustCompile(`(?:` + RepositoryNameComponentRegexp.String() + `/){0,4}` + RepositoryNameComponentRegexp.String())
 
 // TagNameRegexp matches valid tag names. From docker/docker:graph/tags.go.
 var TagNameRegexp = regexp.MustCompile(`[\w][\w.-]{0,127}`)

--- a/api/v2/names_test.go
+++ b/api/v2/names_test.go
@@ -10,6 +10,9 @@ func TestRepositoryNameRegexp(t *testing.T) {
 		err   error
 	}{
 		{
+			input: "short",
+		},
+		{
 			input: "simple/name",
 		},
 		{
@@ -41,7 +44,6 @@ func TestRepositoryNameRegexp(t *testing.T) {
 		},
 		{
 			input: "asdf",
-			err:   ErrRepositoryNameMissingComponents,
 		},
 		{
 			input: "asdf$$^/aa",
@@ -58,7 +60,7 @@ func TestRepositoryNameRegexp(t *testing.T) {
 		},
 		{
 			input: "a",
-			err:   ErrRepositoryNameMissingComponents,
+			err:   ErrRepositoryNameComponentShort,
 		},
 		{
 			input: "a-/a/a/a",

--- a/api/v2/routes_test.go
+++ b/api/v2/routes_test.go
@@ -53,6 +53,14 @@ func TestRouter(t *testing.T) {
 		},
 		{
 			RouteName:  RouteNameManifest,
+			RequestURI: "/v2/foo/manifests/bar",
+			Vars: map[string]string{
+				"name": "foo",
+				"tag":  "bar",
+			},
+		},
+		{
+			RouteName:  RouteNameManifest,
 			RequestURI: "/v2/foo/bar/manifests/tag",
 			Vars: map[string]string{
 				"name": "foo/bar",


### PR DESCRIPTION
Will allow images with a single name component, on the client side they may appear as <private repo>/myapp