### PR TITLE
Address server errors received during layer upload

### DIFF
--- a/api/v2/descriptors.go
+++ b/api/v2/descriptors.go
@@ -1332,9 +1332,9 @@ var errorDescriptors = []ErrorDescriptor{
 	{
 		Code:    ErrorCodeNameInvalid,
 		Value:   "NAME_INVALID",
-		Message: "manifest name did not match URI",
-		Description: `During a manifest upload, if the name in the manifest
-		does not match the uri name, this error will be returned.`,
+		Message: "invalid repository name",
+		Description: `Invalid repository name encountered either during
+		manifest validation or any API operation.`,
 		HTTPStatusCodes: []int{http.StatusBadRequest, http.StatusNotFound},
 	},
 	{

--- a/api/v2/descriptors.go
+++ b/api/v2/descriptors.go
@@ -1263,7 +1263,6 @@ var routeDescriptors = []RouteDescriptor{
 								Description: "An error was encountered processing the delete. The client may ignore this error.",
 								StatusCode:  http.StatusBadRequest,
 								ErrorCodes: []ErrorCode{
-									ErrorCodeDigestInvalid,
 									ErrorCodeNameInvalid,
 									ErrorCodeBlobUploadInvalid,
 								},

--- a/digest/digest.go
+++ b/digest/digest.go
@@ -13,6 +13,11 @@ import (
 	"github.com/docker/docker/pkg/tarsum"
 )
 
+const (
+	// DigestTarSumV1EmptyTar is the digest for the empty tar file.
+	DigestTarSumV1EmptyTar = "tarsum.v1+sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
 // Digest allows simple protection of hex formatted digest strings, prefixed
 // by their algorithm. Strings of type Digest have some guarantee of being in
 // the correct format and it provides quick access to the components of a

--- a/doc/SPEC.md
+++ b/doc/SPEC.md
@@ -2539,7 +2539,6 @@ The error codes that may be included in the response body are enumerated below:
 
 |Code|Message|Description|
 -------|----|------|------------
-| `DIGEST_INVALID` | provided digest did not match uploaded content | When a blob is uploaded, the registry will check that the content matches the digest provided by the client. The error may include a detail structure with the key "digest", including the invalid digest string. This error may also be returned when a manifest includes an invalid layer digest. |
 | `NAME_INVALID` | manifest name did not match URI | During a manifest upload, if the name in the manifest does not match the uri name, this error will be returned. |
 | `BLOB_UPLOAD_INVALID` | blob upload invalid | The blob upload encountered an error and can no longer proceed. |
 

--- a/registry/layerupload.go
+++ b/registry/layerupload.go
@@ -198,13 +198,6 @@ func (luh *layerUploadHandler) PutLayerUploadComplete(w http.ResponseWriter, r *
 	layer, err := luh.Upload.Finish(dgst)
 	if err != nil {
 		switch err := err.(type) {
-		case storage.ErrLayerUploadUnavailable:
-			w.WriteHeader(http.StatusBadRequest)
-			// TODO(stevvooe): Arguably, we may want to add an error code to
-			// cover this condition. It is not always a client error but it
-			// may be. For now, we effectively throw out the upload and have
-			// them start over.
-			luh.Errors.Push(v2.ErrorCodeBlobUploadInvalid, err.Err)
 		case storage.ErrLayerInvalidDigest:
 			w.WriteHeader(http.StatusBadRequest)
 			luh.Errors.Push(v2.ErrorCodeDigestInvalid, err)

--- a/storage/filewriter.go
+++ b/storage/filewriter.go
@@ -99,9 +99,6 @@ func (fw *fileWriter) Seek(offset int64, whence int) (int64, error) {
 
 	if newOffset < 0 {
 		err = fmt.Errorf("cannot seek to negative position")
-	} else if newOffset > fw.size {
-		fw.offset = newOffset
-		fw.size = newOffset
 	} else {
 		// No problems, set the offset.
 		fw.offset = newOffset

--- a/storage/layer.go
+++ b/storage/layer.go
@@ -94,3 +94,14 @@ type ErrLayerInvalidSize struct {
 func (err ErrLayerInvalidSize) Error() string {
 	return fmt.Sprintf("invalid layer size: %d", err.Size)
 }
+
+// ErrLayerUploadUnavailable signals missing upload data, either when no data
+// has been received or when the backend reports the data as missing. This is
+// different from ErrLayerUploadUnknown.
+type ErrLayerUploadUnavailable struct {
+	Err error
+}
+
+func (err ErrLayerUploadUnavailable) Error() string {
+	return fmt.Sprintf("layer upload unavialable: %v", err)
+}

--- a/storage/layer.go
+++ b/storage/layer.go
@@ -80,28 +80,10 @@ func (err ErrUnknownLayer) Error() string {
 // ErrLayerInvalidDigest returned when tarsum check fails.
 type ErrLayerInvalidDigest struct {
 	Digest digest.Digest
+	Reason error
 }
 
 func (err ErrLayerInvalidDigest) Error() string {
-	return fmt.Sprintf("invalid digest for referenced layer: %v", err.Digest)
-}
-
-// ErrLayerInvalidSize returned when length check fails.
-type ErrLayerInvalidSize struct {
-	Size int64
-}
-
-func (err ErrLayerInvalidSize) Error() string {
-	return fmt.Sprintf("invalid layer size: %d", err.Size)
-}
-
-// ErrLayerUploadUnavailable signals missing upload data, either when no data
-// has been received or when the backend reports the data as missing. This is
-// different from ErrLayerUploadUnknown.
-type ErrLayerUploadUnavailable struct {
-	Err error
-}
-
-func (err ErrLayerUploadUnavailable) Error() string {
-	return fmt.Sprintf("layer upload unavialable: %v", err)
+	return fmt.Sprintf("invalid digest for referenced layer: %v, %v",
+		err.Digest, err.Reason)
 }

--- a/storage/revisionstore.go
+++ b/storage/revisionstore.go
@@ -57,8 +57,6 @@ func (rs *revisionStore) get(revision digest.Digest) (*manifest.SignedManifest, 
 		return nil, err
 	}
 
-	logrus.Infof("retrieved signatures: %v", string(signatures[0]))
-
 	jsig, err := libtrust.NewJSONSignature(content, signatures...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This changeset addresses intermittent internal server errors encountered during pushes.  The root cause has been isolated to layers that result in identical, empty filesystems but may have some path declarations (imaginge "./"), resulting in different tarsums. The main error message reported during these upload problems was a 500 error, which was not correct.  Further investigation showed the errors to be rooted in digest verification when finishing uploads.

Inspection of the surrounding code also identified a few issues. PutLayerChunk was slightly refactered into PutLayerUploadComplete. Helper methods were avoided to make handler less confusing. This simplification leveraged an earlier change in the spec that moved non-complete chunk uploads to the PATCH method. Simple logging was also added in the unknown error case that should help to avoid mysterious 500 errors in the future. This is bolstered by the addition of the ErrLayerUploadUnavailable which differentiates unknown layers from short or missing data.

At the same time, the glaring omission of a proper layer upload cancel method was rectified. This has been added in this change so it is not missed in the future.

In the future, we may want to refactor the handler code to be more straightforward, hopefully letting us avoid these problems in the future.

Added test cases that reproduce these errors and drove these changes include the following:

1. Push a layer with an empty body results in invalid blob upload.
2. Push a layer with a different tarsum (in this case, empty tar)
3. Deleting a layer upload works.
4. Getting status on a deleted layer upload returns 404.

Common functionality was grouped into shared functions to remove repitition. The API tests will still require future love.

Also, an erroneous error code included in the delete API specification for layer uploads was removed.

Closes #112.