### PR TITLE
Encode repository names used in backend paths

### DIFF
--- a/storage/paths_test.go
+++ b/storage/paths_test.go
@@ -21,14 +21,14 @@ func TestPathMapper(t *testing.T) {
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/manifests/revisions/sha256/abcdef0123456789",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/manifests/revisions/sha256/abcdef0123456789",
 		},
 		{
 			spec: manifestRevisionLinkPathSpec{
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/manifests/revisions/sha256/abcdef0123456789/link",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/manifests/revisions/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: manifestSignatureLinkPathSpec{
@@ -36,41 +36,41 @@ func TestPathMapper(t *testing.T) {
 				revision:  "sha256:abcdef0123456789",
 				signature: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/manifests/revisions/sha256/abcdef0123456789/signatures/sha256/abcdef0123456789/link",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/manifests/revisions/sha256/abcdef0123456789/signatures/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: manifestSignaturesPathSpec{
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/manifests/revisions/sha256/abcdef0123456789/signatures",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/manifests/revisions/sha256/abcdef0123456789/signatures",
 		},
 		{
 			spec: manifestTagsPathSpec{
 				name: "foo/bar",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/manifests/tags",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/manifests/tags",
 		},
 		{
 			spec: manifestTagPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/manifests/tags/thetag",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/manifests/tags/thetag",
 		},
 		{
 			spec: manifestTagCurrentPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/manifests/tags/thetag/current/link",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/manifests/tags/thetag/current/link",
 		},
 		{
 			spec: manifestTagIndexPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/manifests/tags/thetag/index",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/manifests/tags/thetag/index",
 		},
 		{
 			spec: manifestTagIndexEntryPathSpec{
@@ -78,14 +78,14 @@ func TestPathMapper(t *testing.T) {
 				tag:      "thetag",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/manifests/tags/thetag/index/sha256/abcdef0123456789/link",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/manifests/tags/thetag/index/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: layerLinkPathSpec{
 				name:   "foo/bar",
 				digest: "tarsum.v1+test:abcdef",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/layers/tarsum/v1/test/abcdef/link",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/layers/tarsum/v1/test/abcdef/link",
 		},
 		{
 			spec: blobDataPathSpec{
@@ -105,14 +105,14 @@ func TestPathMapper(t *testing.T) {
 				name: "foo/bar",
 				uuid: "asdf-asdf-asdf-adsf",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/uploads/asdf-asdf-asdf-adsf/data",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/uploads/asdf-asdf-asdf-adsf/data",
 		},
 		{
 			spec: uploadStartedAtPathSpec{
 				name: "foo/bar",
 				uuid: "asdf-asdf-asdf-adsf",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/uploads/asdf-asdf-asdf-adsf/startedat",
+			expected: "/pathmapper-test/repositories/cpnmubr2c5p0/uploads/asdf-asdf-asdf-adsf/startedat",
 		},
 	} {
 		p, err := pm.path(testcase.spec)


### PR DESCRIPTION
To protect the the backend from external user input and ensure that names
cannot be crafted to gain access to other repoistories, we've elected to encode
the repotory names in base32hex. This is a convenient encoding that is compact,
case-insensitive and maintains lexical sorting of ascii data. Encode and decode
functions have been adding that removes and recovers padding and ensures the
round trip is conistent.

This has the drawback that reading backend paths becomes more challenging.
Using an encoding, rather than escapes provides flexibility in choosing future
constraints for repository names. Effectively, without changing the path name
support on the backend, we can have almost anything in the name of a
repository.

This will break existing repositories with active migration. One can repush
exisiting images or simply change the paths from clear text to encoded using
the backend driver.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @dmp42 @BrianBland

Closes #124.