### PR TITLE
[Client] Fix error in parsing of 'Range' header.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -19,6 +19,37 @@ type testBlob struct {
 	contents []byte
 }
 
+func TestRangeHeaderParser(t *testing.T) {
+	const (
+		malformedRangeHeader = "bytes=0-A/C"
+		emptyRangeHeader     = ""
+		rFirst               = 100
+		rSecond              = 200
+	)
+
+	var (
+		wellformedRangeHeader = fmt.Sprintf("bytes=0-%d/%d", rFirst, rSecond)
+	)
+
+	if _, _, err := parseRangeHeader(malformedRangeHeader); err == nil {
+		t.Fatalf("malformedRangeHeader: error expected, got nil")
+	}
+
+	if _, _, err := parseRangeHeader(emptyRangeHeader); err == nil {
+		t.Fatalf("emptyRangeHeader: error expected, got nil")
+	}
+
+	first, second, err := parseRangeHeader(wellformedRangeHeader)
+	if err != nil {
+		t.Fatalf("wellformedRangeHeader: unexpected error %v", err)
+	}
+
+	if first != rFirst || second != rSecond {
+		t.Fatalf("Range has been parsed unproperly: %d/%d", first, second)
+	}
+
+}
+
 func TestPush(t *testing.T) {
 	name := "hello/world"
 	tag := "sometag"


### PR DESCRIPTION
* Result of ```regexp.FindStringSubmatch``` must be checked to be not nil.
Otherwise it leads to `index out of range`.
* Range header regexp is compiled only once to speedup (5x) the parsing.
* Replace `strconv.ParseInt(s, 10, 0)` with a shorthand `strconv.Atoi`
* Add test for the parsing
```
BenchmarkCompiledEachTime	  200000	     12966 ns/op
BenchmarkOnceCompiled	 1000000	      2543 ns/op
```