### PR TITLE
Add native TLS support to registry

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -47,9 +47,16 @@ func main() {
 	handler = handlers.CombinedLoggingHandler(os.Stdout, handler)
 	log.SetLevel(logLevel(config.Loglevel))
 
-	log.Infof("listening on %v", config.HTTP.Addr)
-	if err := http.ListenAndServe(config.HTTP.Addr, handler); err != nil {
-		log.Fatalln(err)
+	if config.HTTP.TLS.Certificate == "" {
+		log.Infof("listening on %v", config.HTTP.Addr)
+		if err := http.ListenAndServe(config.HTTP.Addr, handler); err != nil {
+			log.Fatalln(err)
+		}
+	} else {
+		log.Infof("listening on %v, tls", config.HTTP.Addr)
+		if err := http.ListenAndServeTLS(config.HTTP.Addr, config.HTTP.TLS.Certificate, config.HTTP.TLS.Key, handler); err != nil {
+			log.Fatalln(err)
+		}
 	}
 }
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -38,6 +38,22 @@ type Configuration struct {
 
 		// Secret specifies the secret key which HMAC tokens are created with.
 		Secret string `yaml:"secret"`
+
+		// TLS instructs the http server to listen with a TLS configuration.
+		// This only support simple tls configuration with a cert and key.
+		// Mostly, this is useful for testing situations or simple deployments
+		// that require tls. If more complex configurations are required, use
+		// a proxy or make a proposal to add support here.
+		TLS struct {
+			// Certificate specifies the path to an x509 certificate file to
+			// be used for TLS.
+			Certificate string `yaml:"certificate"`
+
+			// Key specifies the path to the x509 key file, which should
+			// contain the private portion for the file specified in
+			// Certificate.
+			Key string `yaml:"key"`
+		} `yaml:"tls"`
 	} `yaml:"http"`
 }
 


### PR DESCRIPTION
This changeset provides simple tls support for a registry instance. Simply
providing a cert and key file are enough to get a tls registry running. If the
certs are trusted by the client, tls can be used throughout the push and pull
process.

If more complex TLS options are required, it is recommend that a proxy be used.
Contributions will be accepted to add more features, if necessary.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #95.