### PR TITLE
storagedriver/s3: Change the default signature to v2 auth

### DIFF
--- a/storagedriver/s3/s3.go
+++ b/storagedriver/s3/s3.go
@@ -136,7 +136,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		}
 	}
 
-	v4AuthBool := true
+	v4AuthBool := false
 	v4Auth, ok := parameters["v4auth"]
 	if ok {
 		v4AuthBool, ok = v4Auth.(bool)


### PR DESCRIPTION
The reason we prefer v2 is that it performs better since it does not
hash the payloads.