### PR TITLE
Makes LayerUpload an io.ReaderFrom

### DIFF
--- a/storage/layer.go
+++ b/storage/layer.go
@@ -33,6 +33,7 @@ type Layer interface {
 // LayerService.Resume.
 type LayerUpload interface {
 	io.WriteSeeker
+	io.ReaderFrom
 	io.Closer
 
 	// Name of the repository under which the layer will be linked.


### PR DESCRIPTION
This allows wrappers of LayerUpload to implement io.ReadFrom, which
prevents io.Copy on LayerUpload implementations from using repeated 32kB
Writes.

This has a huge performance implication, especially for s3/azure storage
drivers.

@stevvooe