### PR TITLE
context, registry, auth, auth/token, cmd/registry: context aware logging

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,14 +1,14 @@
 {
 	"ImportPath": "github.com/docker/distribution",
-	"GoVersion": "go1.4",
+	"GoVersion": "go1.4.1",
 	"Packages": [
 		"./..."
 	],
 	"Deps": [
 		{
 			"ImportPath": "code.google.com/p/go-uuid/uuid",
-			"Comment": "null-12",
-			"Rev": "7dda39b2e7d5e265014674c5af696ba4186679e9"
+			"Comment": "null-15",
+			"Rev": "35bc42037350f0078e3c974c6ea690f1926603ab"
 		},
 		{
 			"ImportPath": "github.com/AdRoll/goamz/aws",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -24,8 +24,8 @@
 		},
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
-			"Comment": "v0.6.1-8-gcc09837",
-			"Rev": "cc09837bcd512ffe6bb2e3f635bed138c4cd6bc8"
+			"Comment": "v0.6.4-12-g467d9d5",
+			"Rev": "467d9d55c2d2c17248441a8fc661561161f40d5e"
 		},
 		{
 			"ImportPath": "github.com/bugsnag/bugsnag-go",

--- a/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid/LICENSE
+++ b/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009 Google Inc. All rights reserved.
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid/time.go
+++ b/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid/time.go
@@ -40,15 +40,15 @@ func (t Time) UnixTime() (sec, nsec int64) {
 }
 
 // GetTime returns the current Time (100s of nanoseconds since 15 Oct 1582) and
-// adjusts the clock sequence as needed.  An error is returned if the current
-// time cannot be determined.
-func GetTime() (Time, error) {
+// clock sequence as well as adjusting the clock sequence as needed.  An error
+// is returned if the current time cannot be determined.
+func GetTime() (Time, uint16, error) {
 	defer mu.Unlock()
 	mu.Lock()
 	return getTime()
 }
 
-func getTime() (Time, error) {
+func getTime() (Time, uint16, error) {
 	t := timeNow()
 
 	// If we don't have a clock sequence already, set one.
@@ -63,7 +63,7 @@ func getTime() (Time, error) {
 		clock_seq = ((clock_seq + 1) & 0x3fff) | 0x8000
 	}
 	lasttime = now
-	return Time(now), nil
+	return Time(now), clock_seq, nil
 }
 
 // ClockSequence returns the current clock sequence, generating one if not

--- a/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid/version1.go
+++ b/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid/version1.go
@@ -19,7 +19,7 @@ func NewUUID() UUID {
 		SetNodeInterface("")
 	}
 
-	now, err := GetTime()
+	now, seq, err := GetTime()
 	if err != nil {
 		return nil
 	}
@@ -34,7 +34,7 @@ func NewUUID() UUID {
 	binary.BigEndian.PutUint32(uuid[0:], time_low)
 	binary.BigEndian.PutUint16(uuid[4:], time_mid)
 	binary.BigEndian.PutUint16(uuid[6:], time_hi)
-	binary.BigEndian.PutUint16(uuid[8:], clock_seq)
+	binary.BigEndian.PutUint16(uuid[8:], seq)
 	copy(uuid[10:], nodeID)
 
 	return uuid

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/.travis.yml
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/.travis.yml
@@ -2,9 +2,7 @@ language: go
 go:
   - 1.2
   - 1.3
+  - 1.4
   - tip
 install:
-  - go get github.com/stretchr/testify
-  - go get github.com/stvp/go-udp-testing
-  - go get github.com/tobi/airbrake-go
-  - go get github.com/getsentry/raven-go
+  - go get -t ./...

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/README.md
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/README.md
@@ -1,8 +1,8 @@
-# Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>&nbsp;[![Build Status](https://travis-ci.org/Sirupsen/logrus.svg?branch=master)](https://travis-ci.org/Sirupsen/logrus)
+# Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>&nbsp;[![Build Status](https://travis-ci.org/Sirupsen/logrus.svg?branch=master)](https://travis-ci.org/Sirupsen/logrus)&nbsp;[![godoc reference](https://godoc.org/github.com/Sirupsen/logrus?status.png)][godoc]
 
 Logrus is a structured logger for Go (golang), completely API compatible with
 the standard library logger. [Godoc][godoc]. **Please note the Logrus API is not
-yet stable (pre 1.0), the core API is unlikely change much but please version
+yet stable (pre 1.0), the core API is unlikely to change much but please version
 control your Logrus to make sure you aren't fetching latest `master` on every
 build.**
 
@@ -33,7 +33,7 @@ ocean","size":10,"time":"2014-03-10 19:57:38.562264131 -0400 EDT"}
 
 With the default `log.Formatter = new(logrus.TextFormatter)` when a TTY is not
 attached, the output is compatible with the
-[l2met](http://r.32k.io/l2met-introduction) format:
+[logfmt](http://godoc.org/github.com/kr/logfmt) format:
 
 ```text
 time="2014-04-20 15:36:23.830442383 -0400 EDT" level="info" msg="A group of walrus emerges from the ocean" animal="walrus" size=10
@@ -235,6 +235,12 @@ func init() {
 * [`github.com/nubo/hiprus`](https://github.com/nubo/hiprus)
   Send errors to a channel in hipchat.
 
+* [`github.com/sebest/logrusly`](https://github.com/sebest/logrusly)
+  Send logs to Loggly (https://www.loggly.com/)
+
+* [`github.com/johntdyer/slackrus`](https://github.com/johntdyer/slackrus)
+  Hook for Slack chat.
+
 #### Level logging
 
 Logrus has six logging levels: Debug, Info, Warning, Error, Fatal and Panic.
@@ -314,7 +320,7 @@ The built-in logging formatters are:
 
 Third party logging formatters:
 
-* [`zalgo`](https://github.com/aybabtme/logzalgo): invoking the P͉̫o̳̼̊w̖͈̰͎e̬͔̭͂r͚̼̹̲ ̫͓͉̳͈ō̠͕͖̚f̝͍̠ ͕̲̞͖͑Z̖̫̤̫ͪa͉̬͈̗l͖͎g̳̥o̰̥̅!̣͔̲̻͊̄ ̙̘̦̹̦.
+* [`zalgo`](https://github.com/aybabtme/logzalgo): invoking the P͉̫o̳̼̊w̖͈̰͎e̬͔̭͂r͚̼̹̲ ̫͓͉̳͈ō̠͕͖̚f̝͍̠ ͕̲̞͖͑Z̖̫̤̫ͪa͉̬͈̗l͖͎g̳̥o̰̥̅!̣͔̲̻͊̄ ̙̘̦̹̦.
 
 You can define your formatter by implementing the `Formatter` interface,
 requiring a `Format` method. `Format` takes an `*Entry`. `entry.Data` is a
@@ -338,6 +344,24 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
   return append(serialized, '\n'), nil
 }
 ```
+
+#### Logger as an `io.Writer`
+
+Logrus can be transormed into an `io.Writer`. That writer is the end of an `io.Pipe` and it is your responsability to close it.
+
+```go
+w := logger.Writer()
+defer w.Close()
+
+srv := http.Server{
+    // create a stdlib log.Logger that writes to
+    // logrus.Logger.
+    ErrorLog: log.New(w, "", 0),
+}
+```
+
+Each line written to that writer will be printed the usual way, using formatters
+and hooks. The level for those entries is `info`.
 
 #### Rotation
 

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/entry.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/entry.go
@@ -126,6 +126,10 @@ func (entry *Entry) Warn(args ...interface{}) {
 	}
 }
 
+func (entry *Entry) Warning(args ...interface{}) {
+	entry.Warn(args...)
+}
+
 func (entry *Entry) Error(args ...interface{}) {
 	if entry.Logger.Level >= ErrorLevel {
 		entry.log(ErrorLevel, fmt.Sprint(args...))

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/exported.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/exported.go
@@ -9,6 +9,10 @@ var (
 	std = New()
 )
 
+func StandardLogger() *Logger {
+	return std
+}
+
 // SetOutput sets the standard logger output.
 func SetOutput(out io.Writer) {
 	std.mu.Lock()

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/formatter.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/formatter.go
@@ -26,19 +26,19 @@ type Formatter interface {
 //
 // It's not exported because it's still using Data in an opinionated way. It's to
 // avoid code duplication between the two default formatters.
-func prefixFieldClashes(entry *Entry) {
-	_, ok := entry.Data["time"]
+func prefixFieldClashes(data Fields) {
+	_, ok := data["time"]
 	if ok {
-		entry.Data["fields.time"] = entry.Data["time"]
+		data["fields.time"] = data["time"]
 	}
 
-	_, ok = entry.Data["msg"]
+	_, ok = data["msg"]
 	if ok {
-		entry.Data["fields.msg"] = entry.Data["msg"]
+		data["fields.msg"] = data["msg"]
 	}
 
-	_, ok = entry.Data["level"]
+	_, ok = data["level"]
 	if ok {
-		entry.Data["fields.level"] = entry.Data["level"]
+		data["fields.level"] = data["level"]
 	}
 }

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/hooks/papertrail/papertrail.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/hooks/papertrail/papertrail.go
@@ -30,7 +30,8 @@ func NewPapertrailHook(host string, port int, appName string) (*PapertrailHook, 
 // Fire is called when a log event is fired.
 func (hook *PapertrailHook) Fire(entry *logrus.Entry) error {
 	date := time.Now().Format(format)
-	payload := fmt.Sprintf("<22> %s %s: [%s] %s", date, hook.AppName, entry.Level, entry.Message)
+	msg, _ := entry.String()
+	payload := fmt.Sprintf("<22> %s %s: %s", date, hook.AppName, msg)
 
 	bytesWritten, err := hook.UDPConn.Write([]byte(payload))
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/hooks/syslog/README.md
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/hooks/syslog/README.md
@@ -6,7 +6,7 @@
 import (
   "log/syslog"
   "github.com/Sirupsen/logrus"
-  "github.com/Sirupsen/logrus/hooks/syslog"
+  logrus_syslog "github.com/Sirupsen/logrus/hooks/syslog"
 )
 
 func main() {

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/json_formatter.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/json_formatter.go
@@ -9,12 +9,16 @@ import (
 type JSONFormatter struct{}
 
 func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
-	prefixFieldClashes(entry)
-	entry.Data["time"] = entry.Time.Format(time.RFC3339)
-	entry.Data["msg"] = entry.Message
-	entry.Data["level"] = entry.Level.String()
+	data := make(Fields, len(entry.Data)+3)
+	for k, v := range entry.Data {
+		data[k] = v
+	}
+	prefixFieldClashes(data)
+	data["time"] = entry.Time.Format(time.RFC3339)
+	data["msg"] = entry.Message
+	data["level"] = entry.Level.String()
 
-	serialized, err := json.Marshal(entry.Data)
+	serialized, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
 	}

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/logger.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/logger.go
@@ -38,7 +38,7 @@ type Logger struct {
 //      Out: os.Stderr,
 //      Formatter: new(JSONFormatter),
 //      Hooks: make(levelHooks),
-//      Level: logrus.Debug,
+//      Level: logrus.DebugLevel,
 //    }
 //
 // It's recommended to make this a global instance called `log`.

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/logrus_test.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/logrus_test.go
@@ -44,8 +44,12 @@ func LogAndAssertText(t *testing.T, log func(*Logger), assertions func(fields ma
 		}
 		kvArr := strings.Split(kv, "=")
 		key := strings.TrimSpace(kvArr[0])
-		val, err := strconv.Unquote(kvArr[1])
-		assert.NoError(t, err)
+		val := kvArr[1]
+		if kvArr[1][0] == '"' {
+			var err error
+			val, err = strconv.Unquote(val)
+			assert.NoError(t, err)
+		}
 		fields[key] = val
 	}
 	assertions(fields)
@@ -202,6 +206,38 @@ func TestDefaultFieldsAreNotPrefixed(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestDoubleLoggingDoesntPrefixPreviousFields(t *testing.T) {
+
+	var buffer bytes.Buffer
+	var fields Fields
+
+	logger := New()
+	logger.Out = &buffer
+	logger.Formatter = new(JSONFormatter)
+
+	llog := logger.WithField("context", "eating raw fish")
+
+	llog.Info("looks delicious")
+
+	err := json.Unmarshal(buffer.Bytes(), &fields)
+	assert.NoError(t, err, "should have decoded first message")
+	assert.Equal(t, len(fields), 4, "should only have msg/time/level/context fields")
+	assert.Equal(t, fields["msg"], "looks delicious")
+	assert.Equal(t, fields["context"], "eating raw fish")
+
+	buffer.Reset()
+
+	llog.Warn("omg it is!")
+
+	err = json.Unmarshal(buffer.Bytes(), &fields)
+	assert.NoError(t, err, "should have decoded second message")
+	assert.Equal(t, len(fields), 4, "should only have msg/time/level/context fields")
+	assert.Equal(t, fields["msg"], "omg it is!")
+	assert.Equal(t, fields["context"], "eating raw fish")
+	assert.Nil(t, fields["fields.msg"], "should not have prefixed previous `msg` entry")
+
 }
 
 func TestConvertLevelToString(t *testing.T) {

--- a/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_notwindows.go
+++ b/Godeps/_workspace/src/github.com/Sirupsen/logrus/terminal_notwindows.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux,!appengine darwin freebsd
+// +build linux,!appengine darwin freebsd openbsd
 
 package logrus
 

--- a/auth/silly/access.go
+++ b/auth/silly/access.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/docker/distribution/auth"
+	ctxu "github.com/docker/distribution/context"
 	"golang.org/x/net/context"
 )
 
@@ -43,7 +44,7 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 // Authorized simply checks for the existence of the authorization header,
 // responding with a bearer challenge if it doesn't exist.
 func (ac *accessController) Authorized(ctx context.Context, accessRecords ...auth.Access) (context.Context, error) {
-	req, err := auth.RequestFromContext(ctx)
+	req, err := ctxu.GetRequest(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/token/accesscontroller.go
+++ b/auth/token/accesscontroller.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/docker/distribution/auth"
+	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/libtrust"
 	"golang.org/x/net/context"
 )
@@ -224,7 +225,7 @@ func (ac *accessController) Authorized(ctx context.Context, accessItems ...auth.
 		accessSet: newAccessSet(accessItems...),
 	}
 
-	req, err := auth.RequestFromContext(ctx)
+	req, err := ctxu.GetRequest(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +265,7 @@ func (ac *accessController) Authorized(ctx context.Context, accessItems ...auth.
 		}
 	}
 
-	return context.WithValue(ctx, "auth.user", auth.UserInfo{Name: token.Claims.Subject}), nil
+	return auth.WithUser(ctx, auth.UserInfo{Name: token.Claims.Subject}), nil
 }
 
 // init handles registering the token auth backend.

--- a/context/doc.go
+++ b/context/doc.go
@@ -1,0 +1,76 @@
+// Package context provides several utilities for working with
+// golang.org/x/net/context in http requests. Primarily, the focus is on
+// logging relevent request information but this package is not limited to
+// that purpose.
+//
+// Logging
+//
+// The most useful aspect of this package is GetLogger. This function takes
+// any context.Context interface and returns the current logger from the
+// context. Canonical usage looks like this:
+//
+// 	GetLogger(ctx).Infof("something interesting happened")
+//
+// GetLogger also takes optional key arguments. The keys will be looked up in
+// the context and reported with the logger. The following example would
+// return a logger that prints the version with each log message:
+//
+// 	ctx := context.Context(context.Background(), "version", version)
+// 	GetLogger(ctx, "version").Infof("this log message has a version field")
+//
+// The above would print out a log message like this:
+//
+// 	INFO[0000] this log message has a version field        version=v2.0.0-alpha.2.m
+//
+// When used with WithLogger, we gain the ability to decorate the context with
+// loggers that have information from disparate parts of the call stack.
+// Following from the version example, we can build a new context with the
+// configured logger such that we always print the version field:
+//
+// 	ctx = WithLogger(ctx, GetLogger(ctx, "version"))
+//
+// Since the logger has been pushed to the context, we can now get the version
+// field for free with our log messages. Future calls to GetLogger on the new
+// context will have the version field:
+//
+// 	GetLogger(ctx).Infof("this log message has a version field")
+//
+// This becomes more powerful when we start stacking loggers. Let's say we
+// have the version logger from above but also want a request id. Using the
+// context above, in our request scoped function, we place another logger in
+// the context:
+//
+// 	ctx = context.WithValue(ctx, "http.request.id", "unique id") // called when building request context
+// 	ctx = WithLogger(ctx, GetLogger(ctx, "http.request.id"))
+//
+// When GetLogger is called on the new context, "http.request.id" will be
+// included as a logger field, along with the original "version" field:
+//
+// 	INFO[0000] this log message has a version field        http.request.id=unique id version=v2.0.0-alpha.2.m
+//
+// Note that this only affects the new context, the previous context, with the
+// version field, can be used independently. Put another way, the new logger,
+// added to the request context, is unique to that context and can have
+// request scoped varaibles.
+//
+// HTTP Requests
+//
+// This package also contains several methods for working with http requests.
+// The concepts are very similar to those described above. We simply place the
+// request in the context using WithRequest. This makes the request variables
+// available. GetRequestLogger can then be called to get request specific
+// variables in a log line:
+//
+// 	ctx = WithRequest(ctx, req)
+// 	GetRequestLogger(ctx).Infof("request variables")
+//
+// Like above, if we want to include the request data in all log messages in
+// the context, we push the logger to a new context and use that one:
+//
+// 	ctx = WithLogger(ctx, GetRequestLogger(ctx))
+//
+// The concept is fairly powerful and ensures that calls throughout the stack
+// can be traced in log messages. Using the fields like "http.request.id", one
+// can analyze call flow for a particular request with a simple grep of the
+// logs.
+package context

--- a/context/http.go
+++ b/context/http.go
@@ -1,0 +1,270 @@
+package context
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"code.google.com/p/go-uuid/uuid"
+	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
+)
+
+// Common errors used with this package.
+var (
+	ErrNoRequestContext = errors.New("no http request in context")
+)
+
+// WithRequest places the request on the context. The context of the request
+// is assigned a unique id, available at "http.request.id". The request itself
+// is available at "http.request". Other common attributes are available under
+// the prefix "http.request.". If a request is already present on the context,
+// this method will panic.
+func WithRequest(ctx context.Context, r *http.Request) context.Context {
+	if ctx.Value("http.request") != nil {
+		// NOTE(stevvooe): This needs to be considered a programming error. It
+		// is unlikely that we'd want to have more than one request in
+		// context.
+		panic("only one request per context")
+	}
+
+	return &httpRequestContext{
+		Context:   ctx,
+		startedAt: time.Now(),
+		id:        uuid.New(), // assign the request a unique.
+		r:         r,
+	}
+}
+
+// GetRequest returns the http request in the given context. Returns
+// ErrNoRequestContext if the context does not have an http request associated
+// with it.
+func GetRequest(ctx context.Context) (*http.Request, error) {
+	if r, ok := ctx.Value("http.request").(*http.Request); r != nil && ok {
+		return r, nil
+	}
+	return nil, ErrNoRequestContext
+}
+
+// GetRequestID attempts to resolve the current request id, if possible. An
+// error is return if it is not available on the context.
+func GetRequestID(ctx context.Context) string {
+	return GetStringValue(ctx, "http.request.id")
+}
+
+// WithResponseWriter returns a new context and response writer that makes
+// interesting response statistics available within the context.
+func WithResponseWriter(ctx context.Context, w http.ResponseWriter) (context.Context, http.ResponseWriter) {
+	irw := &instrumentedResponseWriter{
+		ResponseWriter: w,
+		Context:        ctx,
+	}
+
+	return irw, irw
+}
+
+// getVarsFromRequest let's us change request vars implementation for testing
+// and maybe future changes.
+var getVarsFromRequest = mux.Vars
+
+// WithVars extracts gorilla/mux vars and makes them available on the returned
+// context. Variables are available at keys with the prefix "vars.". For
+// example, if looking for the variable "name", it can be accessed as
+// "vars.name". Implementations that are accessing values need not know that
+// the underlying context is implemented with gorilla/mux vars.
+func WithVars(ctx context.Context, r *http.Request) context.Context {
+	return &muxVarsContext{
+		Context: ctx,
+		vars:    getVarsFromRequest(r),
+	}
+}
+
+// GetRequestLogger returns a logger that contains fields from the request in
+// the current context. If the request is not available in the context, no
+// fields will display. Request loggers can safely be pushed onto the context.
+func GetRequestLogger(ctx context.Context) Logger {
+	return GetLogger(ctx,
+		"http.request.id",
+		"http.request.method",
+		"http.request.host",
+		"http.request.uri",
+		"http.request.referer",
+		"http.request.useragent",
+		"http.request.remoteaddr",
+		"http.request.contenttype")
+}
+
+// GetResponseLogger reads the current response stats and builds a logger.
+// Because the values are read at call time, pushing a logger returned from
+// this function on the context will lead to missing or invalid data. Only
+// call this at the end of a request, after the response has been written.
+func GetResponseLogger(ctx context.Context) Logger {
+	l := getLogrusLogger(ctx,
+		"http.response.written",
+		"http.response.status",
+		"http.response.contenttype")
+
+	duration := Since(ctx, "http.request.startedat")
+
+	if duration > 0 {
+		l = l.WithField("http.response.duration", duration)
+	}
+
+	return l
+}
+
+// httpRequestContext makes information about a request available to context.
+type httpRequestContext struct {
+	context.Context
+
+	startedAt time.Time
+	id        string
+	r         *http.Request
+}
+
+// Value returns a keyed element of the request for use in the context. To get
+// the request itself, query "request". For other components, access them as
+// "request.<component>". For example, r.RequestURI
+func (ctx *httpRequestContext) Value(key interface{}) interface{} {
+	if keyStr, ok := key.(string); ok {
+		if keyStr == "http.request" {
+			return ctx.r
+		}
+
+		parts := strings.Split(keyStr, ".")
+
+		if len(parts) != 3 {
+			goto fallback
+		}
+
+		switch parts[2] {
+		case "uri":
+			return ctx.r.RequestURI
+		case "remoteaddr":
+			return ctx.r.RemoteAddr
+		case "method":
+			return ctx.r.Method
+		case "host":
+			return ctx.r.Host
+		case "referer":
+			referer := ctx.r.Referer()
+			if referer != "" {
+				return referer
+			}
+		case "useragent":
+			return ctx.r.UserAgent()
+		case "id":
+			return ctx.id
+		case "startedat":
+			return ctx.startedAt
+		case "contenttype":
+			ct := ctx.r.Header.Get("Content-Type")
+			if ct != "" {
+				return ct
+			}
+		}
+	}
+
+fallback:
+	return ctx.Context.Value(key)
+}
+
+type muxVarsContext struct {
+	context.Context
+	vars map[string]string
+}
+
+func (ctx *muxVarsContext) Value(key interface{}) interface{} {
+	if keyStr, ok := key.(string); ok {
+		if keyStr == "vars" {
+			return ctx.vars
+		}
+
+		if strings.HasPrefix(keyStr, "vars.") {
+			keyStr = strings.TrimPrefix(keyStr, "vars.")
+		}
+
+		if v, ok := ctx.vars[keyStr]; ok {
+			return v
+		}
+	}
+
+	return ctx.Context.Value(key)
+}
+
+// instrumentedResponseWriter provides response writer information in a
+// context.
+type instrumentedResponseWriter struct {
+	http.ResponseWriter
+	context.Context
+
+	mu      sync.Mutex
+	status  int
+	written int64
+}
+
+func (irw *instrumentedResponseWriter) Write(p []byte) (n int, err error) {
+	n, err = irw.ResponseWriter.Write(p)
+
+	irw.mu.Lock()
+	irw.written += int64(n)
+
+	// Guess the likely status if not set.
+	if irw.status == 0 {
+		irw.status = http.StatusOK
+	}
+
+	irw.mu.Unlock()
+
+	return
+}
+
+func (irw *instrumentedResponseWriter) WriteHeader(status int) {
+	irw.ResponseWriter.WriteHeader(status)
+
+	irw.mu.Lock()
+	irw.status = status
+	irw.mu.Unlock()
+}
+
+func (irw *instrumentedResponseWriter) Flush() {
+	if flusher, ok := irw.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (irw *instrumentedResponseWriter) Value(key interface{}) interface{} {
+	if keyStr, ok := key.(string); ok {
+		if keyStr == "http.response" {
+			return irw.ResponseWriter
+		}
+
+		parts := strings.Split(keyStr, ".")
+
+		if len(parts) != 3 {
+			goto fallback
+		}
+
+		irw.mu.Lock()
+		defer irw.mu.Unlock()
+
+		switch parts[2] {
+		case "written":
+			return irw.written
+		case "status":
+			if irw.status != 0 {
+				return irw.status
+			}
+		case "contenttype":
+			contentType := irw.Header().Get("Content-Type")
+			if contentType != "" {
+				return contentType
+			}
+		}
+	}
+
+fallback:
+	return irw.Context.Value(key)
+}

--- a/context/http_test.go
+++ b/context/http_test.go
@@ -1,0 +1,207 @@
+package context
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+func TestWithRequest(t *testing.T) {
+	var req http.Request
+
+	start := time.Now()
+	req.Method = "GET"
+	req.Host = "example.com"
+	req.RequestURI = "/test-test"
+	req.Header = make(http.Header)
+	req.Header.Set("Referer", "foo.com/referer")
+	req.Header.Set("User-Agent", "test/0.1")
+
+	ctx := WithRequest(context.Background(), &req)
+	for _, testcase := range []struct {
+		key      string
+		expected interface{}
+	}{
+		{
+			key:      "http.request",
+			expected: &req,
+		},
+		{
+			key: "http.request.id",
+		},
+		{
+			key:      "http.request.method",
+			expected: req.Method,
+		},
+		{
+			key:      "http.request.host",
+			expected: req.Host,
+		},
+		{
+			key:      "http.request.uri",
+			expected: req.RequestURI,
+		},
+		{
+			key:      "http.request.referer",
+			expected: req.Referer(),
+		},
+		{
+			key:      "http.request.useragent",
+			expected: req.UserAgent(),
+		},
+		{
+			key:      "http.request.remoteaddr",
+			expected: req.RemoteAddr,
+		},
+		{
+			key: "http.request.startedat",
+		},
+	} {
+		v := ctx.Value(testcase.key)
+
+		if v == nil {
+			t.Fatalf("value not found for %q", testcase.key)
+		}
+
+		if testcase.expected != nil && v != testcase.expected {
+			t.Fatalf("%s: %v != %v", testcase.key, v, testcase.expected)
+		}
+
+		// Key specific checks!
+		switch testcase.key {
+		case "http.request.id":
+			if _, ok := v.(string); !ok {
+				t.Fatalf("request id not a string: %v", v)
+			}
+		case "http.request.startedat":
+			vt, ok := v.(time.Time)
+			if !ok {
+				t.Fatalf("value not a time: %v", v)
+			}
+
+			now := time.Now()
+			if vt.After(now) {
+				t.Fatalf("time generated too late: %v > %v", vt, now)
+			}
+
+			if vt.Before(start) {
+				t.Fatalf("time generated too early: %v < %v", vt, start)
+			}
+		}
+	}
+}
+
+type testResponseWriter struct {
+	flushed bool
+	status  int
+	written int64
+	header  http.Header
+}
+
+func (trw *testResponseWriter) Header() http.Header {
+	if trw.header == nil {
+		trw.header = make(http.Header)
+	}
+
+	return trw.header
+}
+
+func (trw *testResponseWriter) Write(p []byte) (n int, err error) {
+	if trw.status == 0 {
+		trw.status = http.StatusOK
+	}
+
+	n = len(p)
+	trw.written += int64(n)
+	return
+}
+
+func (trw *testResponseWriter) WriteHeader(status int) {
+	trw.status = status
+}
+
+func (trw *testResponseWriter) Flush() {
+	trw.flushed = true
+}
+
+func TestWithResponseWriter(t *testing.T) {
+	trw := testResponseWriter{}
+	ctx, rw := WithResponseWriter(context.Background(), &trw)
+
+	if ctx.Value("http.response") != &trw {
+		t.Fatalf("response not available in context: %v != %v", ctx.Value("http.response"), &trw)
+	}
+
+	if n, err := rw.Write(make([]byte, 1024)); err != nil {
+		t.Fatalf("unexpected error writing: %v", err)
+	} else if n != 1024 {
+		t.Fatalf("unexpected number of bytes written: %v != %v", n, 1024)
+	}
+
+	if ctx.Value("http.response.status") != http.StatusOK {
+		t.Fatalf("unexpected response status in context: %v != %v", ctx.Value("http.response.status"), http.StatusOK)
+	}
+
+	if ctx.Value("http.response.written") != int64(1024) {
+		t.Fatalf("unexpected number reported bytes written: %v != %v", ctx.Value("http.response.written"), 1024)
+	}
+
+	// Make sure flush propagates
+	rw.(http.Flusher).Flush()
+
+	if !trw.flushed {
+		t.Fatalf("response writer not flushed")
+	}
+
+	// Write another status and make sure context is correct. This normally
+	// wouldn't work except for in this contrived testcase.
+	rw.WriteHeader(http.StatusBadRequest)
+
+	if ctx.Value("http.response.status") != http.StatusBadRequest {
+		t.Fatalf("unexpected response status in context: %v != %v", ctx.Value("http.response.status"), http.StatusBadRequest)
+	}
+}
+
+func TestWithVars(t *testing.T) {
+	var req http.Request
+	vars := map[string]string{
+		"foo": "asdf",
+		"bar": "qwer",
+	}
+
+	getVarsFromRequest = func(r *http.Request) map[string]string {
+		if r != &req {
+			t.Fatalf("unexpected request: %v != %v", r, req)
+		}
+
+		return vars
+	}
+
+	ctx := WithVars(context.Background(), &req)
+	for _, testcase := range []struct {
+		key      string
+		expected interface{}
+	}{
+		{
+			key:      "vars",
+			expected: vars,
+		},
+		{
+			key:      "vars.foo",
+			expected: "asdf",
+		},
+		{
+			key:      "vars.bar",
+			expected: "qwer",
+		},
+	} {
+		v := ctx.Value(testcase.key)
+
+		if !reflect.DeepEqual(v, testcase.expected) {
+			t.Fatalf("%q: %v != %v", testcase.key, v, testcase.expected)
+		}
+	}
+}

--- a/context/logger.go
+++ b/context/logger.go
@@ -1,0 +1,88 @@
+package context
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+// Logger provides a leveled-logging interface.
+type Logger interface {
+	// standard logger methods
+	Print(args ...interface{})
+	Printf(format string, args ...interface{})
+	Println(args ...interface{})
+
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Fatalln(args ...interface{})
+
+	Panic(args ...interface{})
+	Panicf(format string, args ...interface{})
+	Panicln(args ...interface{})
+
+	// Leveled methods, from logrus
+	Debug(args ...interface{})
+	Debugf(format string, args ...interface{})
+	Debugln(args ...interface{})
+
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Errorln(args ...interface{})
+
+	Info(args ...interface{})
+	Infof(format string, args ...interface{})
+	Infoln(args ...interface{})
+
+	Warn(args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warnln(args ...interface{})
+}
+
+// WithLogger creates a new context with provided logger.
+func WithLogger(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, "logger", logger)
+}
+
+// GetLogger returns the logger from the current context, if present. If one
+// or more keys are provided, they will be resolved on the context and
+// included in the logger. While context.Value takes an interface, any key
+// argument passed to GetLogger will be passed to fmt.Sprint when expanded as
+// a logging key field. If context keys are integer constants, for example,
+// its recommended that a String method is implemented.
+func GetLogger(ctx context.Context, keys ...interface{}) Logger {
+	return getLogrusLogger(ctx, keys...)
+}
+
+// GetLogrusLogger returns the logrus logger for the context. If one more keys
+// are provided, they will be resolved on the context and included in the
+// logger. Only use this function if specific logrus functionality is
+// required.
+func getLogrusLogger(ctx context.Context, keys ...interface{}) *logrus.Entry {
+	var logger *logrus.Entry
+
+	// Get a logger, if it is present.
+	loggerInterface := ctx.Value("logger")
+	if loggerInterface != nil {
+		if lgr, ok := loggerInterface.(*logrus.Entry); ok {
+			logger = lgr
+		}
+	}
+
+	if logger == nil {
+		// If no logger is found, just return the standard logger.
+		logger = logrus.NewEntry(logrus.StandardLogger())
+	}
+
+	fields := logrus.Fields{}
+
+	for _, key := range keys {
+		v := ctx.Value(key)
+		if v != nil {
+			fields[fmt.Sprint(key)] = v
+		}
+	}
+
+	return logger.WithFields(fields)
+}

--- a/context/util.go
+++ b/context/util.go
@@ -1,0 +1,34 @@
+package context
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// Since looks up key, which should be a time.Time, and returns the duration
+// since that time. If the key is not found, the value returned will be zero.
+// This is helpful when inferring metrics related to context execution times.
+func Since(ctx context.Context, key interface{}) time.Duration {
+	startedAtI := ctx.Value(key)
+	if startedAtI != nil {
+		if startedAt, ok := startedAtI.(time.Time); ok {
+			return time.Since(startedAt)
+		}
+	}
+
+	return 0
+}
+
+// GetStringValue returns a string value from the context. The empty string
+// will be returned if not found.
+func GetStringValue(ctx context.Context, key string) (value string) {
+	stringi := ctx.Value(key)
+	if stringi != nil {
+		if valuev, ok := stringi.(string); ok {
+			value = valuev
+		}
+	}
+
+	return value
+}

--- a/registry/basicauth.go
+++ b/registry/basicauth.go
@@ -1,0 +1,11 @@
+// +build go1.4
+
+package registry
+
+import (
+	"net/http"
+)
+
+func basicAuth(r *http.Request) (username, password string, ok bool) {
+	return r.BasicAuth()
+}

--- a/registry/basicauth_prego14.go
+++ b/registry/basicauth_prego14.go
@@ -1,0 +1,41 @@
+// +build !go1.4
+
+package registry
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+)
+
+// NOTE(stevvooe): This is basic auth support from go1.4 present to ensure we
+// can compile on go1.3 and earlier.
+
+// BasicAuth returns the username and password provided in the request's
+// Authorization header, if the request uses HTTP Basic Authentication.
+// See RFC 2617, Section 2.
+func basicAuth(r *http.Request) (username, password string, ok bool) {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return
+	}
+	return parseBasicAuth(auth)
+}
+
+// parseBasicAuth parses an HTTP Basic Authentication string.
+// "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" returns ("Aladdin", "open sesame", true).
+func parseBasicAuth(auth string) (username, password string, ok bool) {
+	if !strings.HasPrefix(auth, "Basic ") {
+		return
+	}
+	c, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+	if err != nil {
+		return
+	}
+	cs := string(c)
+	s := strings.IndexByte(cs, ':')
+	if s < 0 {
+		return
+	}
+	return cs[:s], cs[s+1:], true
+}

--- a/registry/images.go
+++ b/registry/images.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/docker/distribution/api/v2"
+	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/storage"
@@ -17,10 +18,8 @@ import (
 func imageManifestDispatcher(ctx *Context, r *http.Request) http.Handler {
 	imageManifestHandler := &imageManifestHandler{
 		Context: ctx,
-		Tag:     ctx.vars["tag"],
+		Tag:     getTag(ctx),
 	}
-
-	imageManifestHandler.log = imageManifestHandler.log.WithField("tag", imageManifestHandler.Tag)
 
 	return handlers.MethodHandler{
 		"GET":    http.HandlerFunc(imageManifestHandler.GetImageManifest),
@@ -38,6 +37,7 @@ type imageManifestHandler struct {
 
 // GetImageManifest fetches the image manifest from the storage backend, if it exists.
 func (imh *imageManifestHandler) GetImageManifest(w http.ResponseWriter, r *http.Request) {
+	ctxu.GetLogger(imh).Debug("GetImageManifest")
 	manifests := imh.Repository.Manifests()
 	manifest, err := manifests.Get(imh.Tag)
 
@@ -54,6 +54,7 @@ func (imh *imageManifestHandler) GetImageManifest(w http.ResponseWriter, r *http
 
 // PutImageManifest validates and stores and image in the registry.
 func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http.Request) {
+	ctxu.GetLogger(imh).Debug("PutImageManifest")
 	manifests := imh.Repository.Manifests()
 	dec := json.NewDecoder(r.Body)
 
@@ -98,6 +99,7 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 
 // DeleteImageManifest removes the image with the given tag from the registry.
 func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *http.Request) {
+	ctxu.GetLogger(imh).Debug("DeleteImageManifest")
 	manifests := imh.Repository.Manifests()
 	if err := manifests.Delete(imh.Tag); err != nil {
 		switch err := err.(type) {

--- a/storage/blobstore.go
+++ b/storage/blobstore.go
@@ -3,10 +3,10 @@ package storage
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
-
+	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/storagedriver"
+	"golang.org/x/net/context"
 )
 
 // TODO(stevvooe): Currently, the blobStore implementation used by the
@@ -19,6 +19,7 @@ import (
 // backend links.
 type blobStore struct {
 	*registry
+	ctx context.Context
 }
 
 // exists reports whether or not the path exists. If the driver returns error
@@ -110,7 +111,7 @@ func (bs *blobStore) resolve(path string) (string, error) {
 func (bs *blobStore) put(p []byte) (digest.Digest, error) {
 	dgst, err := digest.FromBytes(p)
 	if err != nil {
-		logrus.Errorf("error digesting content: %v, %s", err, string(p))
+		ctxu.GetLogger(bs.ctx).Errorf("error digesting content: %v, %s", err, string(p))
 		return "", err
 	}
 

--- a/storage/layer_test.go
+++ b/storage/layer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/distribution/storagedriver"
 	"github.com/docker/distribution/storagedriver/inmemory"
 	"github.com/docker/distribution/testutil"
+	"golang.org/x/net/context"
 )
 
 // TestSimpleLayerUpload covers the layer upload process, exercising common
@@ -30,10 +31,11 @@ func TestSimpleLayerUpload(t *testing.T) {
 		t.Fatalf("error allocating upload store: %v", err)
 	}
 
+	ctx := context.Background()
 	imageName := "foo/bar"
 	driver := inmemory.New()
 	registry := NewRegistryWithDriver(driver)
-	ls := registry.Repository(imageName).Layers()
+	ls := registry.Repository(ctx, imageName).Layers()
 
 	h := sha256.New()
 	rd := io.TeeReader(randomDataReader, h)
@@ -133,10 +135,11 @@ func TestSimpleLayerUpload(t *testing.T) {
 // open, read, seek, read works. More specific edge cases should be covered in
 // other tests.
 func TestSimpleLayerRead(t *testing.T) {
+	ctx := context.Background()
 	imageName := "foo/bar"
 	driver := inmemory.New()
 	registry := NewRegistryWithDriver(driver)
-	ls := registry.Repository(imageName).Layers()
+	ls := registry.Repository(ctx, imageName).Layers()
 
 	randomLayerReader, tarSumStr, err := testutil.CreateRandomTarFile()
 	if err != nil {
@@ -237,10 +240,11 @@ func TestSimpleLayerRead(t *testing.T) {
 
 // TestLayerUploadZeroLength uploads zero-length
 func TestLayerUploadZeroLength(t *testing.T) {
+	ctx := context.Background()
 	imageName := "foo/bar"
 	driver := inmemory.New()
 	registry := NewRegistryWithDriver(driver)
-	ls := registry.Repository(imageName).Layers()
+	ls := registry.Repository(ctx, imageName).Layers()
 
 	upload, err := ls.Upload()
 	if err != nil {

--- a/storage/layerstore.go
+++ b/storage/layerstore.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"code.google.com/p/go-uuid/uuid"
+	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/storagedriver"
@@ -14,6 +15,8 @@ type layerStore struct {
 }
 
 func (ls *layerStore) Exists(digest digest.Digest) (bool, error) {
+	ctxu.GetLogger(ls.repository.ctx).Debug("(*layerStore).Exists")
+
 	// Because this implementation just follows blob links, an existence check
 	// is pretty cheap by starting and closing a fetch.
 	_, err := ls.Fetch(digest)
@@ -31,6 +34,7 @@ func (ls *layerStore) Exists(digest digest.Digest) (bool, error) {
 }
 
 func (ls *layerStore) Fetch(dgst digest.Digest) (Layer, error) {
+	ctxu.GetLogger(ls.repository.ctx).Debug("(*layerStore).Fetch")
 	bp, err := ls.path(dgst)
 	if err != nil {
 		return nil, err
@@ -52,6 +56,7 @@ func (ls *layerStore) Fetch(dgst digest.Digest) (Layer, error) {
 // is already in progress or the layer has already been uploaded, this
 // will return an error.
 func (ls *layerStore) Upload() (LayerUpload, error) {
+	ctxu.GetLogger(ls.repository.ctx).Debug("(*layerStore).Upload")
 
 	// NOTE(stevvooe): Consider the issues with allowing concurrent upload of
 	// the same two layers. Should it be disallowed? For now, we allow both
@@ -89,6 +94,7 @@ func (ls *layerStore) Upload() (LayerUpload, error) {
 // Resume continues an in progress layer upload, returning the current
 // state of the upload.
 func (ls *layerStore) Resume(uuid string) (LayerUpload, error) {
+	ctxu.GetLogger(ls.repository.ctx).Debug("(*layerStore).Resume")
 	startedAtPath, err := ls.repository.registry.pm.path(uploadStartedAtPathSpec{
 		name: ls.repository.Name(),
 		uuid: uuid,

--- a/storage/layerupload.go
+++ b/storage/layerupload.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/storagedriver"
 	"github.com/docker/docker/pkg/tarsum"
@@ -44,6 +45,7 @@ func (luc *layerUploadController) StartedAt() time.Time {
 // contents of the uploaded layer. The checksum should be provided in the
 // format <algorithm>:<hex digest>.
 func (luc *layerUploadController) Finish(digest digest.Digest) (Layer, error) {
+	ctxu.GetLogger(luc.layerStore.repository.ctx).Debug("(*layerUploadController).Finish")
 	canonical, err := luc.validateLayer(digest)
 	if err != nil {
 		return nil, err
@@ -68,6 +70,7 @@ func (luc *layerUploadController) Finish(digest digest.Digest) (Layer, error) {
 
 // Cancel the layer upload process.
 func (luc *layerUploadController) Cancel() error {
+	ctxu.GetLogger(luc.layerStore.repository.ctx).Debug("(*layerUploadController).Cancel")
 	if err := luc.removeResources(); err != nil {
 		return err
 	}

--- a/storage/manifeststore.go
+++ b/storage/manifeststore.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/libtrust"
@@ -77,14 +78,17 @@ var _ ManifestService = &manifestStore{}
 // }
 
 func (ms *manifestStore) Tags() ([]string, error) {
+	ctxu.GetLogger(ms.repository.ctx).Debug("(*manifestStore).Tags")
 	return ms.tagStore.tags()
 }
 
 func (ms *manifestStore) Exists(tag string) (bool, error) {
+	ctxu.GetLogger(ms.repository.ctx).Debug("(*manifestStore).Exists")
 	return ms.tagStore.exists(tag)
 }
 
 func (ms *manifestStore) Get(tag string) (*manifest.SignedManifest, error) {
+	ctxu.GetLogger(ms.repository.ctx).Debug("(*manifestStore).Get")
 	dgst, err := ms.tagStore.resolve(tag)
 	if err != nil {
 		return nil, err
@@ -94,6 +98,8 @@ func (ms *manifestStore) Get(tag string) (*manifest.SignedManifest, error) {
 }
 
 func (ms *manifestStore) Put(tag string, manifest *manifest.SignedManifest) error {
+	ctxu.GetLogger(ms.repository.ctx).Debug("(*manifestStore).Put")
+
 	// TODO(stevvooe): Add check here to see if the revision is already
 	// present in the repository. If it is, we should merge the signatures, do
 	// a shallow verify (or a full one, doesn't matter) and return an error
@@ -118,6 +124,8 @@ func (ms *manifestStore) Put(tag string, manifest *manifest.SignedManifest) erro
 // semantics in the future, but this will maintain consistency. The underlying
 // blobs are left alone.
 func (ms *manifestStore) Delete(tag string) error {
+	ctxu.GetLogger(ms.repository.ctx).Debug("(*manifestStore).Delete")
+
 	revisions, err := ms.tagStore.revisions(tag)
 	if err != nil {
 		return err

--- a/storage/manifeststore_test.go
+++ b/storage/manifeststore_test.go
@@ -6,20 +6,21 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/distribution/testutil"
-
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/storagedriver/inmemory"
+	"github.com/docker/distribution/testutil"
 	"github.com/docker/libtrust"
+	"golang.org/x/net/context"
 )
 
 func TestManifestStorage(t *testing.T) {
+	ctx := context.Background()
 	name := "foo/bar"
 	tag := "thetag"
 	driver := inmemory.New()
 	registry := NewRegistryWithDriver(driver)
-	repo := registry.Repository(name)
+	repo := registry.Repository(ctx, name)
 	ms := repo.Manifests()
 
 	exists, err := ms.Exists(tag)

--- a/storage/notifications/listener_test.go
+++ b/storage/notifications/listener_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/distribution/storagedriver/inmemory"
 	"github.com/docker/distribution/testutil"
 	"github.com/docker/libtrust"
+	"golang.org/x/net/context"
 )
 
 func TestListener(t *testing.T) {
@@ -18,7 +19,8 @@ func TestListener(t *testing.T) {
 	tl := &testListener{
 		ops: make(map[string]int),
 	}
-	repository := Listen(registry.Repository("foo/bar"), tl)
+	ctx := context.Background()
+	repository := Listen(registry.Repository(ctx, "foo/bar"), tl)
 
 	// Now take the registry through a number of operations
 	checkExerciseRepository(t, repository)

--- a/storage/registry.go
+++ b/storage/registry.go
@@ -1,6 +1,9 @@
 package storage
 
-import "github.com/docker/distribution/storagedriver"
+import (
+	"github.com/docker/distribution/storagedriver"
+	"golang.org/x/net/context"
+)
 
 // registry is the top-level implementation of Registry for use in the storage
 // package. All instances should descend from this object.
@@ -32,8 +35,9 @@ func NewRegistryWithDriver(driver storagedriver.StorageDriver) Registry {
 // Repository returns an instance of the repository tied to the registry.
 // Instances should not be shared between goroutines but are cheap to
 // allocate. In general, they should be request scoped.
-func (reg *registry) Repository(name string) Repository {
+func (reg *registry) Repository(ctx context.Context, name string) Repository {
 	return &repository{
+		ctx:      ctx,
 		registry: reg,
 		name:     name,
 	}
@@ -42,6 +46,7 @@ func (reg *registry) Repository(name string) Repository {
 // repository provides name-scoped access to various services.
 type repository struct {
 	*registry
+	ctx  context.Context
 	name string
 }
 

--- a/storage/services.go
+++ b/storage/services.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
+	"golang.org/x/net/context"
 )
 
 // TODO(stevvooe): These types need to be moved out of the storage package.
@@ -12,7 +13,7 @@ type Registry interface {
 	// Repository should return a reference to the named repository. The
 	// registry may or may not have the repository but should always return a
 	// reference.
-	Repository(name string) Repository
+	Repository(ctx context.Context, name string) Repository
 }
 
 // Repository is a named collection of manifests and layers.


### PR DESCRIPTION
The new context package supports context-aware logging, integrating with logrus. Several utilities are provided to associate http requests with a context, ensuring that one can trace log messages all the way through a context-aware call stack.

With the creation of that package, we've integrated contextual logging into the registry web application. Idiomatic context use is attempted within the current webapp layout. The functionality is centered around making lifecycle objects (application and request context) into contexts themselves. Relevant data has been moved into the context where appropriate.  We still have some work to do to factor out the registry.Context object and the dispatching functionality to remove some awkward portions.

The api tests were slightly refactored to use a test environment to eliminate common code.

logrus and uuid have been updated, accordingly.

Closes #86.