### PR TITLE
[IPC/Client] Get rid of an unnecessary stopChan sending

### DIFF
--- a/storagedriver/ipc/client.go
+++ b/storagedriver/ipc/client.go
@@ -158,7 +158,6 @@ func (driver *StorageDriverClient) Stop() error {
 		killErr = driver.subprocess.Process.Kill()
 	}
 	if driver.stopChan != nil {
-		driver.stopChan <- struct{}{}
 		close(driver.stopChan)
 	}
 


### PR DESCRIPTION
There's no need to send `struct{}{}` to notify a waiting goroutine with an infinite loop about the stop.
It's enough to close stopChan. Moreover it could lead to a deadlock if `driver.Stop` is called before `driver.handleSubprocessExit`.