### PR TITLE
registry/storage/driver/s3: fix paths return by List

### DIFF
--- a/registry/storage/driver/s3/s3.go
+++ b/registry/storage/driver/s3/s3.go
@@ -597,11 +597,11 @@ func (d *driver) List(path string) ([]string, error) {
 
 	for {
 		for _, key := range listResponse.Contents {
-			files = append(files, strings.Replace(key.Key, d.s3Path(""), "", 1))
+			files = append(files, "/"+strings.Replace(key.Key, d.s3Path(""), "", 1))
 		}
 
 		for _, commonPrefix := range listResponse.CommonPrefixes {
-			directories = append(directories, strings.Replace(commonPrefix[0:len(commonPrefix)-1], d.s3Path(""), "", 1))
+			directories = append(directories, "/"+strings.Replace(commonPrefix[0:len(commonPrefix)-1], d.s3Path(""), "", 1))
 		}
 
 		if listResponse.IsTruncated {


### PR DESCRIPTION
The S3 listing returns paths without the leading "/", which makes the validation against `storagedriver.PathRegexp` fail. This change fixes the issue by prepending "/" to all paths returned by S3.