### PR TITLE
Rename auth.token.{rootCertBundle -> rootcertbundle}

### DIFF
--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -146,7 +146,7 @@ type tokenAccessOptions struct {
 func checkOptions(options map[string]interface{}) (tokenAccessOptions, error) {
 	var opts tokenAccessOptions
 
-	keys := []string{"realm", "issuer", "service", "rootCertBundle"}
+	keys := []string{"realm", "issuer", "service", "rootcertbundle"}
 	vals := make([]string, 0, len(keys))
 	for _, key := range keys {
 		val, ok := options[key].(string)

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -261,7 +261,7 @@ func TestAccessController(t *testing.T) {
 		"realm":          realm,
 		"issuer":         issuer,
 		"service":        service,
-		"rootCertBundle": rootCertBundleFilename,
+		"rootcertbundle": rootCertBundleFilename,
 	}
 
 	accessController, err := newAccessController(options)


### PR DESCRIPTION
This is necessary so that rootcertbundle setting can be overridden by an
environment variable (e.g. REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE)