### PR TITLE
Replace unsupported hashes with supported

### DIFF
--- a/digest/digest.go
+++ b/digest/digest.go
@@ -123,7 +123,7 @@ func (d Digest) Validate() error {
 	}
 
 	switch s[:i] {
-	case "md5", "sha1", "sha256":
+	case "sha256", "sha384", "sha512":
 		break
 	default:
 		return ErrDigestUnsupported

--- a/digest/digest_test.go
+++ b/digest/digest_test.go
@@ -34,9 +34,9 @@ func TestParseDigest(t *testing.T) {
 			hex:       "e58fcf7418d4390dec8e8fb69d88c06ec07039d651fedd3aa72af9972e7d046b",
 		},
 		{
-			input:     "md5:d41d8cd98f00b204e9800998ecf8427e",
-			algorithm: "md5",
-			hex:       "d41d8cd98f00b204e9800998ecf8427e",
+			input:     "sha384:d3fc7881460b7e22e3d172954463dddd7866d17597e7248453c48b3e9d26d9596bf9c4a9cf8072c9d5bad76e19af801d",
+			algorithm: "sha384",
+			hex:       "d3fc7881460b7e22e3d172954463dddd7866d17597e7248453c48b3e9d26d9596bf9c4a9cf8072c9d5bad76e19af801d",
 		},
 		{
 			// empty hex

--- a/digest/verifiers.go
+++ b/digest/verifiers.go
@@ -1,9 +1,8 @@
 package digest
 
 import (
-	"crypto/md5"
-	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"hash"
 	"io"
 	"io/ioutil"
@@ -32,7 +31,7 @@ type Verifier interface {
 func NewDigestVerifier(d Digest) Verifier {
 	alg := d.Algorithm()
 	switch alg {
-	case "md5", "sha1", "sha256":
+	case "sha256", "sha384", "sha512":
 		return hashVerifier{
 			hash:   newHash(alg),
 			digest: d,
@@ -97,10 +96,10 @@ func newHash(name string) hash.Hash {
 	switch name {
 	case "sha256":
 		return sha256.New()
-	case "sha1":
-		return sha1.New()
-	case "md5":
-		return md5.New()
+	case "sha384":
+		return sha512.New384()
+	case "sha512":
+		return sha512.New()
 	default:
 		panic("unsupport algorithm: " + name)
 	}


### PR DESCRIPTION
Remote md5 and sha1 hashes which are not supported by distribution.
Add more secure hashes sha384 and sha512.