### PR TITLE
registry/handlers: support prefixed registry app

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -38,6 +38,8 @@ type Configuration struct {
 		// Addr specifies the bind address for the registry instance.
 		Addr string `yaml:"addr,omitempty"`
 
+		Prefix string `yaml:"prefix,omitempty"`
+
 		// Secret specifies the secret key which HMAC tokens are created with.
 		Secret string `yaml:"secret,omitempty"`
 

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -1410,13 +1410,18 @@ var errorDescriptors = []ErrorDescriptor{
 
 var errorCodeToDescriptors map[ErrorCode]ErrorDescriptor
 var idToDescriptors map[string]ErrorDescriptor
+var routeDescriptorsMap map[string]RouteDescriptor
 
 func init() {
 	errorCodeToDescriptors = make(map[ErrorCode]ErrorDescriptor, len(errorDescriptors))
 	idToDescriptors = make(map[string]ErrorDescriptor, len(errorDescriptors))
+	routeDescriptorsMap = make(map[string]RouteDescriptor, len(routeDescriptors))
 
 	for _, descriptor := range errorDescriptors {
 		errorCodeToDescriptors[descriptor.Code] = descriptor
 		idToDescriptors[descriptor.Value] = descriptor
+	}
+	for _, descriptor := range routeDescriptors {
+		routeDescriptorsMap[descriptor.Name] = descriptor
 	}
 }

--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -25,12 +25,23 @@ var allEndpoints = []string{
 // methods. This can be used directly by both server implementations and
 // clients.
 func Router() *mux.Router {
-	router := mux.NewRouter().
-		StrictSlash(true)
+	return RouterWithPrefix("")
+}
+
+// RouterWithPrefix builds a gorilla router with a configured prefix
+// on all routes.
+func RouterWithPrefix(prefix string) *mux.Router {
+	rootRouter := mux.NewRouter()
+	router := rootRouter
+	if prefix != "" {
+		router = router.PathPrefix(prefix).Subrouter()
+	}
+
+	router.StrictSlash(true)
 
 	for _, descriptor := range routeDescriptors {
 		router.Path(descriptor.Path).Name(descriptor.Name)
 	}
 
-	return router
+	return rootRouter
 }

--- a/registry/api/v2/routes_test.go
+++ b/registry/api/v2/routes_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -24,8 +25,16 @@ type routeTestCase struct {
 //
 // This may go away as the application structure comes together.
 func TestRouter(t *testing.T) {
+	baseTestRouter(t, "")
+}
 
-	router := Router()
+func TestRouterWithPrefix(t *testing.T) {
+	baseTestRouter(t, "/prefix/")
+}
+
+func baseTestRouter(t *testing.T, prefix string) {
+
+	router := RouterWithPrefix(prefix)
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testCase := routeTestCase{
@@ -147,6 +156,8 @@ func TestRouter(t *testing.T) {
 			StatusCode: http.StatusNotFound,
 		},
 	} {
+		testcase.RequestURI = strings.TrimSuffix(prefix, "/") + testcase.RequestURI
+
 		// Register the endpoint
 		route := router.GetRoute(testcase.RouteName)
 		if route == nil {

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -64,7 +64,7 @@ func NewApp(ctx context.Context, configuration configuration.Configuration) *App
 		Config:     configuration,
 		Context:    ctx,
 		InstanceID: uuid.New(),
-		router:     v2.Router(),
+		router:     v2.RouterWithPrefix(configuration.HTTP.Prefix),
 	}
 
 	app.Context = ctxu.WithLogger(app.Context, ctxu.GetLogger(app, "app.id"))


### PR DESCRIPTION
This allows the docker registry to run somewhere other than the root of the server

Connects to #29.