### PR TITLE
doc/spec, registry: immutable manifest reference support

### DIFF
--- a/doc/spec/api.md.tmpl
+++ b/doc/spec/api.md.tmpl
@@ -106,9 +106,20 @@ changes. Only non-conflicting additions should be made to the API and accepted
 changes should avoid preventing future changes from happening.
 
 This section should be updated when changes are made to the specification,
-indicating what is different. Optionally, we may start marking parts of the specification to correspond with the versions enumerated here.
+indicating what is different. Optionally, we may start marking parts of the
+specification to correspond with the versions enumerated here.
 
 <dl>
+	<dt>2.0.1</dt>
+	<dd>
+		<ul>
+			<li>Added support for immutable manifest references in manifest endpoints.</li>
+			<li>Deleting a manifest by tag has been deprecated.</li>
+			<li>Specified `Docker-Content-Digest` header for appropriate entities.</li>
+			<li>Added error code for unsupported operations.</li>
+		</ul>
+	</dd>
+
 	<dt>2.0</dt>
 	<dd>
 		This is the baseline specification.
@@ -235,10 +246,11 @@ the V2 registry API, keyed by their tarsum digest.
 The image manifest can be fetched with the following url:
 
 ```
-GET /v2/<name>/manifests/<tag>
+GET /v2/<name>/manifests/<reference>
 ```
 
-The "name" and "tag" parameter identify the image and are required.
+The `name` and `reference` parameter identify the image and are required. The
+reference may include a tag or digest.
 
 A `404 Not Found` response will be returned if the image is unknown to the
 registry. If the image exists and the response is successful, the image
@@ -330,6 +342,7 @@ http specification). The response will look as follows:
 ```
 200 OK
 Content-Length: <length of blob>
+Docker-Content-Digest: <digest>
 ```
 
 When this response is received, the client can assume that the layer is
@@ -509,10 +522,14 @@ will receive a `201 Created` response:
 201 Created
 Location: /v2/<name>/blobs/<tarsum>
 Content-Length: 0
+Docker-Content-Digest: <digest>
 ```
 
 The `Location` header will contain the registry URL to access the accepted
-layer file.
+layer file. The `Docker-Content-Digest` header returns the canonical digest of
+the uploaded blob which may differ from the provided digest. Most clients may
+ignore the value but if it is used, the client should verify the value against
+the uploaded blob data.
 
 ###### Digest Parameter
 
@@ -574,7 +591,7 @@ client must restart the upload process.
 Once all of the layers for an image are uploaded, the client can upload the
 image manifest. An image can be pushed using the following request format:
 
-    PUT /v2/<name>/manifests/<tag>
+    PUT /v2/<name>/manifests/<reference>
 
     {
        "name": <name>,
@@ -591,8 +608,8 @@ image manifest. An image can be pushed using the following request format:
        ...
     }
 
-The `name` and `tag` fields of the response body must match those specified in
-the URL.
+The `name` and `reference` fields of the response body must match those specified in
+the URL. The `reference` field may be a "tag" or a "digest".
 
 If there is a problem with pushing the manifest, a relevant 4xx response will
 be returned with a JSON error message. Please see the _PUT Manifest section
@@ -641,13 +658,14 @@ reduce copying.
 
 ### Deleting an Image
 
-An image may be deleted from the registry via its `name` and `tag`. A delete
-may be issued with the following request format:
+An image may be deleted from the registry via its `name` and `reference`. A
+delete may be issued with the following request format:
 
-    DELETE /v2/<name>/manifests/<tag>
+    DELETE /v2/<name>/manifests/<reference>
 
-If the image exists and has been successfully deleted, the following response
-will be issued:
+For deletes, `reference` *must* be a digest or the delete will fail. If the
+image exists and has been successfully deleted, the following response will be
+issued:
 
     202 Accepted
     Content-Length: None

--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -67,8 +67,8 @@ type manifestServiceListener struct {
 	parent *repositoryListener
 }
 
-func (msl *manifestServiceListener) Get(tag string) (*manifest.SignedManifest, error) {
-	sm, err := msl.ManifestService.Get(tag)
+func (msl *manifestServiceListener) Get(dgst digest.Digest) (*manifest.SignedManifest, error) {
+	sm, err := msl.ManifestService.Get(dgst)
 	if err == nil {
 		if err := msl.parent.listener.ManifestPulled(msl.parent.Repository, sm); err != nil {
 			logrus.Errorf("error dispatching manifest pull to listener: %v", err)
@@ -78,8 +78,8 @@ func (msl *manifestServiceListener) Get(tag string) (*manifest.SignedManifest, e
 	return sm, err
 }
 
-func (msl *manifestServiceListener) Put(tag string, sm *manifest.SignedManifest) error {
-	err := msl.ManifestService.Put(tag, sm)
+func (msl *manifestServiceListener) Put(sm *manifest.SignedManifest) error {
+	err := msl.ManifestService.Put(sm)
 
 	if err == nil {
 		if err := msl.parent.listener.ManifestPushed(msl.parent.Repository, sm); err != nil {
@@ -88,6 +88,17 @@ func (msl *manifestServiceListener) Put(tag string, sm *manifest.SignedManifest)
 	}
 
 	return err
+}
+
+func (msl *manifestServiceListener) GetByTag(tag string) (*manifest.SignedManifest, error) {
+	sm, err := msl.ManifestService.GetByTag(tag)
+	if err == nil {
+		if err := msl.parent.listener.ManifestPulled(msl.parent.Repository, sm); err != nil {
+			logrus.Errorf("error dispatching manifest pull to listener: %v", err)
+		}
+	}
+
+	return sm, err
 }
 
 type layerServiceListener struct {

--- a/registry.go
+++ b/registry.go
@@ -34,38 +34,41 @@ type Repository interface {
 
 // ManifestService provides operations on image manifests.
 type ManifestService interface {
+	// Exists returns true if the manifest exists.
+	Exists(dgst digest.Digest) (bool, error)
+
+	// Get retrieves the identified by the digest, if it exists.
+	Get(dgst digest.Digest) (*manifest.SignedManifest, error)
+
+	// Delete removes the manifest, if it exists.
+	Delete(dgst digest.Digest) error
+
+	// Put creates or updates the manifest.
+	Put(manifest *manifest.SignedManifest) error
+
+	// TODO(stevvooe): The methods after this message should be moved to a
+	// discrete TagService, per active proposals.
+
 	// Tags lists the tags under the named repository.
 	Tags() ([]string, error)
 
-	// Exists returns true if the manifest exists.
-	Exists(tag string) (bool, error)
+	// ExistsByTag returns true if the manifest exists.
+	ExistsByTag(tag string) (bool, error)
 
-	// Get retrieves the named manifest, if it exists.
-	Get(tag string) (*manifest.SignedManifest, error)
-
-	// Put creates or updates the named manifest.
-	// Put(tag string, manifest *manifest.SignedManifest) (digest.Digest, error)
-	Put(tag string, manifest *manifest.SignedManifest) error
-
-	// Delete removes the named manifest, if it exists.
-	Delete(tag string) error
+	// GetByTag retrieves the named manifest, if it exists.
+	GetByTag(tag string) (*manifest.SignedManifest, error)
 
 	// TODO(stevvooe): There are several changes that need to be done to this
 	// interface:
 	//
-	//	1. Get(tag string) should be GetByTag(tag string)
-	//	2. Put(tag string, manifest *manifest.SignedManifest) should be
-	//       Put(manifest *manifest.SignedManifest). The method can read the
-	//       tag on manifest to automatically tag it in the repository.
-	//	3. Need a GetByDigest(dgst digest.Digest) method.
-	//	4. Allow explicit tagging with Tag(digest digest.Digest, tag string)
-	//	5. Support reading tags with a re-entrant reader to avoid large
+	//	1. Allow explicit tagging with Tag(digest digest.Digest, tag string)
+	//	2. Support reading tags with a re-entrant reader to avoid large
 	//       allocations in the registry.
-	//	6. Long-term: Provide All() method that lets one scroll through all of
+	//	3. Long-term: Provide All() method that lets one scroll through all of
 	//       the manifest entries.
-	//	7. Long-term: break out concept of signing from manifests. This is
+	//	4. Long-term: break out concept of signing from manifests. This is
 	//       really a part of the distribution sprint.
-	//	8. Long-term: Manifest should be an interface. This code shouldn't
+	//	5. Long-term: Manifest should be an interface. This code shouldn't
 	//       really be concerned with the storage format.
 }
 

--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -13,6 +13,9 @@ const (
 	// ErrorCodeUnknown is a catch-all for errors not defined below.
 	ErrorCodeUnknown ErrorCode = iota
 
+	// ErrorCodeUnsupported is returned when an operation is not supported.
+	ErrorCodeUnsupported
+
 	// ErrorCodeUnauthorized is returned if a request is not authorized.
 	ErrorCodeUnauthorized
 

--- a/registry/api/v2/routes_test.go
+++ b/registry/api/v2/routes_test.go
@@ -39,16 +39,24 @@ func TestRouter(t *testing.T) {
 			RouteName:  RouteNameManifest,
 			RequestURI: "/v2/foo/manifests/bar",
 			Vars: map[string]string{
-				"name": "foo",
-				"tag":  "bar",
+				"name":      "foo",
+				"reference": "bar",
 			},
 		},
 		{
 			RouteName:  RouteNameManifest,
 			RequestURI: "/v2/foo/bar/manifests/tag",
 			Vars: map[string]string{
-				"name": "foo/bar",
-				"tag":  "tag",
+				"name":      "foo/bar",
+				"reference": "tag",
+			},
+		},
+		{
+			RouteName:  RouteNameManifest,
+			RequestURI: "/v2/foo/bar/manifests/sha256:abcdef01234567890",
+			Vars: map[string]string{
+				"name":      "foo/bar",
+				"reference": "sha256:abcdef01234567890",
 			},
 		},
 		{
@@ -112,8 +120,8 @@ func TestRouter(t *testing.T) {
 			RouteName:  RouteNameManifest,
 			RequestURI: "/v2/foo/bar/manifests/manifests/tags",
 			Vars: map[string]string{
-				"name": "foo/bar/manifests",
-				"tag":  "tags",
+				"name":      "foo/bar/manifests",
+				"reference": "tags",
 			},
 		},
 		{

--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -107,11 +107,12 @@ func (ub *URLBuilder) BuildTagsURL(name string) (string, error) {
 	return tagsURL.String(), nil
 }
 
-// BuildManifestURL constructs a url for the manifest identified by name and tag.
-func (ub *URLBuilder) BuildManifestURL(name, tag string) (string, error) {
+// BuildManifestURL constructs a url for the manifest identified by name and
+// reference. The argument reference may be either a tag or digest.
+func (ub *URLBuilder) BuildManifestURL(name, reference string) (string, error) {
 	route := ub.cloneRoute(RouteNameManifest)
 
-	manifestURL, err := route.URL("name", name, "tag", tag)
+	manifestURL, err := route.URL("name", name, "reference", reference)
 	if err != nil {
 		return "", err
 	}

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -277,9 +277,8 @@ func (app *App) context(w http.ResponseWriter, r *http.Request) *Context {
 	ctx = ctxu.WithLogger(ctx, ctxu.GetRequestLogger(ctx))
 	ctx = ctxu.WithLogger(ctx, ctxu.GetLogger(ctx,
 		"vars.name",
-		"vars.tag",
+		"vars.reference",
 		"vars.digest",
-		"vars.tag",
 		"vars.uuid"))
 
 	context := &Context{

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -84,7 +84,7 @@ func TestAppDispatcher(t *testing.T) {
 			endpoint: v2.RouteNameManifest,
 			vars: []string{
 				"name", "foo/bar",
-				"tag", "sometag",
+				"reference", "sometag",
 			},
 		},
 		{

--- a/registry/handlers/context.go
+++ b/registry/handlers/context.go
@@ -45,8 +45,8 @@ func getName(ctx context.Context) (name string) {
 	return ctxu.GetStringValue(ctx, "vars.name")
 }
 
-func getTag(ctx context.Context) (tag string) {
-	return ctxu.GetStringValue(ctx, "vars.tag")
+func getReference(ctx context.Context) (reference string) {
+	return ctxu.GetStringValue(ctx, "vars.reference")
 }
 
 var errDigestNotAvailable = fmt.Errorf("digest not available in context")

--- a/registry/handlers/layer.go
+++ b/registry/handlers/layer.go
@@ -64,6 +64,8 @@ func (lh *layerHandler) GetLayer(w http.ResponseWriter, r *http.Request) {
 	}
 	defer layer.Close()
 
+	w.Header().Set("Docker-Content-Digest", lh.Digest.String())
+
 	if lh.layerHandler != nil {
 		handler, _ := lh.layerHandler.Resolve(layer)
 		if handler != nil {

--- a/registry/handlers/layerupload.go
+++ b/registry/handlers/layerupload.go
@@ -193,6 +193,10 @@ func (luh *layerUploadHandler) PutLayerUploadComplete(w http.ResponseWriter, r *
 	// TODO(stevvooe): Check the incoming range header here, per the
 	// specification. LayerUpload should be seeked (sought?) to that position.
 
+	// TODO(stevvooe): Consider checking the error on this copy.
+	// Theoretically, problems should be detected during verification but we
+	// may miss a root cause.
+
 	// Read in the final chunk, if any.
 	io.Copy(luh.Upload, r.Body)
 
@@ -227,6 +231,7 @@ func (luh *layerUploadHandler) PutLayerUploadComplete(w http.ResponseWriter, r *
 
 	w.Header().Set("Location", layerURL)
 	w.Header().Set("Content-Length", "0")
+	w.Header().Set("Docker-Content-Digest", layer.Digest().String())
 	w.WriteHeader(http.StatusCreated)
 }
 

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -72,11 +72,12 @@ const storagePathVersion = "v2"
 //
 //	Tags:
 //
-// 	manifestTagsPathSpec:          <root>/v2/repositories/<name>/_manifests/tags/
-// 	manifestTagPathSpec:           <root>/v2/repositories/<name>/_manifests/tags/<tag>/
-// 	manifestTagCurrentPathSpec:    <root>/v2/repositories/<name>/_manifests/tags/<tag>/current/link
-// 	manifestTagIndexPathSpec:      <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/
-// 	manifestTagIndexEntryPathSpec: <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/link
+// 	manifestTagsPathSpec:                  <root>/v2/repositories/<name>/_manifests/tags/
+// 	manifestTagPathSpec:                   <root>/v2/repositories/<name>/_manifests/tags/<tag>/
+// 	manifestTagCurrentPathSpec:            <root>/v2/repositories/<name>/_manifests/tags/<tag>/current/link
+// 	manifestTagIndexPathSpec:              <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/
+// 	manifestTagIndexEntryPathSpec:         <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/
+// 	manifestTagIndexEntryLinkPathSpec:     <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/link
 //
 // 	Layers:
 //
@@ -199,6 +200,17 @@ func (pm *pathMapper) path(spec pathSpec) (string, error) {
 		}
 
 		return path.Join(root, "index"), nil
+	case manifestTagIndexEntryLinkPathSpec:
+		root, err := pm.path(manifestTagIndexEntryPathSpec{
+			name:     v.name,
+			tag:      v.tag,
+			revision: v.revision,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(root, "link"), nil
 	case manifestTagIndexEntryPathSpec:
 		root, err := pm.path(manifestTagIndexPathSpec{
 			name: v.name,
@@ -213,7 +225,7 @@ func (pm *pathMapper) path(spec pathSpec) (string, error) {
 			return "", err
 		}
 
-		return path.Join(root, path.Join(append(components, "link")...)), nil
+		return path.Join(root, path.Join(components...)), nil
 	case layerLinkPathSpec:
 		components, err := digestPathComponents(v.digest, false)
 		if err != nil {
@@ -332,8 +344,7 @@ type manifestTagIndexPathSpec struct {
 
 func (manifestTagIndexPathSpec) pathSpec() {}
 
-// manifestTagIndexEntryPathSpec describes the link to a revisions of a
-// manifest with given tag within the index.
+// manifestTagIndexEntryPathSpec contains the entries of the index by revision.
 type manifestTagIndexEntryPathSpec struct {
 	name     string
 	tag      string
@@ -341,6 +352,16 @@ type manifestTagIndexEntryPathSpec struct {
 }
 
 func (manifestTagIndexEntryPathSpec) pathSpec() {}
+
+// manifestTagIndexEntryLinkPathSpec describes the link to a revisions of a
+// manifest with given tag within the index.
+type manifestTagIndexEntryLinkPathSpec struct {
+	name     string
+	tag      string
+	revision digest.Digest
+}
+
+func (manifestTagIndexEntryLinkPathSpec) pathSpec() {}
 
 // layerLink specifies a path for a layer link, which is a file with a blob
 // id. The layer link will contain a content addressable blob id reference

--- a/registry/storage/paths_test.go
+++ b/registry/storage/paths_test.go
@@ -78,6 +78,14 @@ func TestPathMapper(t *testing.T) {
 				tag:      "thetag",
 				revision: "sha256:abcdef0123456789",
 			},
+			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789",
+		},
+		{
+			spec: manifestTagIndexEntryLinkPathSpec{
+				name:     "foo/bar",
+				tag:      "thetag",
+				revision: "sha256:abcdef0123456789",
+			},
 			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789/link",
 		},
 		{

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -63,7 +63,7 @@ func (ts *tagStore) exists(tag string) (bool, error) {
 // tag tags the digest with the given tag, updating the the store to point at
 // the current tag. The digest must point to a manifest.
 func (ts *tagStore) tag(tag string, revision digest.Digest) error {
-	indexEntryPath, err := ts.pm.path(manifestTagIndexEntryPathSpec{
+	indexEntryPath, err := ts.pm.path(manifestTagIndexEntryLinkPathSpec{
 		name:     ts.Name(),
 		tag:      tag,
 		revision: revision,


### PR DESCRIPTION
Manifests are now fetched by a field called "reference", which may be a tag or a digest. When using digests to reference a manifest, the data is immutable. The routes and specification have been updated to allow this. There are a few caveats to this approach:

1. It may be problematic to rely on data format to differentiate between a tag and a digest. Currently, they are disjoint but there may modifications on either side that break this guarantee.
2. The caching characteristics of returned content are very different for digest versus tag-based references. Digest urls can be cached forever while tag urls cannot.

Both of these are minimal caveats that we can live with in the future.

Most of the changes follow from modifications to ManifestService. Once updates were made across the repo to implement these changes, the http handlers were change accordingly. The new methods on ManifestService will be broken out into tagging service in a later PR.

Unfortunately, due to complexities around managing the manifest tag index in an eventually consistent manner, direct deletes of manifests have been disabled.

Closes #46. Implements the registry portion of docker/docker#10740.