### PR TITLE
registry/storage: buffered wrapper for fileWriter

### DIFF
--- a/registry/storage/layerstore.go
+++ b/registry/storage/layerstore.go
@@ -139,10 +139,10 @@ func (ls *layerStore) newLayerUpload(uuid, path string, startedAt time.Time) (di
 	}
 
 	return &layerUploadController{
-		layerStore: ls,
-		uuid:       uuid,
-		startedAt:  startedAt,
-		fileWriter: *fw,
+		layerStore:         ls,
+		uuid:               uuid,
+		startedAt:          startedAt,
+		bufferedFileWriter: *fw,
 	}, nil
 }
 


### PR DESCRIPTION
Resolves https://github.com/docker/distribution/issues/148

Tests included to confirm buffer is working. Cover all new code except the inside of some err conditionals.

I believe the only place bfw.Close needed to be added was in LayerUpload.Finish