### PR TITLE
digest: func Validate in digest doesn't filter no-hex data

### DIFF
--- a/digest/digest.go
+++ b/digest/digest.go
@@ -112,6 +112,10 @@ func (d Digest) Validate() error {
 
 	// Continue on for general parser
 
+	if !DigestRegexp.MatchString(s) {
+		return ErrDigestInvalidFormat
+	}
+
 	i := strings.Index(s, ":")
 	if i < 0 {
 		return ErrDigestInvalidFormat
@@ -128,8 +132,6 @@ func (d Digest) Validate() error {
 	default:
 		return ErrDigestUnsupported
 	}
-
-	// TODO(stevvooe): Use DigestRegexp to validate digest here.
 
 	return nil
 }


### PR DESCRIPTION
old func Validate in digest seems not to validate when digest data isn't HEX format.
As it accepts the data string which is out of range of a-f0-9.
@stevvooe @dmp42 ,
Please help take a view. Thanks a lot!