### PR TITLE
Expose Signatures() on Repository

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -27,6 +27,9 @@ type Repository interface {
 
 	// Layers returns a reference to this repository's layers service.
 	Layers() LayerService
+
+	// Signatures returns a reference to this repository's signatures service.
+	Signatures() SignatureService
 }
 
 // ManifestService provides operations on image manifests.
@@ -121,4 +124,13 @@ type LayerUpload interface {
 
 	// Cancel the layer upload process.
 	Cancel() error
+}
+
+// SignatureService provides operations on signatures.
+type SignatureService interface {
+	// Get retrieves all of the signature blobs for the specified digest.
+	Get(dgst digest.Digest) ([][]byte, error)
+
+	// Put stores the signature for the provided digest.
+	Put(dgst digest.Digest, signatures ...[]byte) error
 }

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -87,3 +87,9 @@ func (repo *repository) Layers() distribution.LayerService {
 		repository: repo,
 	}
 }
+
+func (repo *repository) Signatures() distribution.SignatureService {
+	return &signatureStore{
+		repository: repo,
+	}
+}

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"path"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/digest"
+)
+
+type signatureStore struct {
+	*repository
+}
+
+var _ distribution.SignatureService = &signatureStore{}
+
+func (s *signatureStore) Get(dgst digest.Digest) ([][]byte, error) {
+	signaturesPath, err := s.pm.path(manifestSignaturesPathSpec{
+		name:     s.Name(),
+		revision: dgst,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Need to append signature digest algorithm to path to get all items.
+	// Perhaps, this should be in the pathMapper but it feels awkward. This
+	// can be eliminated by implementing listAll on drivers.
+	signaturesPath = path.Join(signaturesPath, "sha256")
+
+	signaturePaths, err := s.driver.List(signaturesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var signatures [][]byte
+	for _, sigPath := range signaturePaths {
+		// Append the link portion
+		sigPath = path.Join(sigPath, "link")
+
+		// TODO(stevvooe): These fetches should be parallelized for performance.
+		p, err := s.blobStore.linked(sigPath)
+		if err != nil {
+			return nil, err
+		}
+
+		signatures = append(signatures, p)
+	}
+
+	return signatures, nil
+}
+
+func (s *signatureStore) Put(dgst digest.Digest, signatures ...[]byte) error {
+	for _, signature := range signatures {
+		signatureDigest, err := s.blobStore.put(signature)
+		if err != nil {
+			return err
+		}
+
+		signaturePath, err := s.pm.path(manifestSignatureLinkPathSpec{
+			name:      s.Name(),
+			revision:  dgst,
+			signature: signatureDigest,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if err := s.blobStore.link(signaturePath, signatureDigest); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add a SignatureService and expose it via Signatures() on Repository so
external integrations wrapping the registry can access signatures.

Signed-off-by: Andy Goldstein <agoldste@redhat.com>