### PR TITLE
registry/handlers, configuration: add registry and repository handlers

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -26,6 +26,12 @@ type Configuration struct {
 	// used to gate requests.
 	Auth Auth `yaml:"auth,omitempty"`
 
+	// RegistryHandler allows for custom behavior against a Registry.
+	RegistryHandler RegistryHandler `yaml:"registryhandler,omitempty"`
+
+	// RepositoryHandler allows for custom behavior against a Repository.
+	RepositoryHandler RepositoryHandler `yaml:"repositoryhandler,omitempty"`
+
 	// LayerHandler specifies a middleware for serving image layers.
 	LayerHandler LayerHandler `yaml:"layerhandler,omitempty"`
 
@@ -349,6 +355,118 @@ func (layerHandler LayerHandler) MarshalYAML() (interface{}, error) {
 		return t, nil
 	}
 	return map[string]Parameters(layerHandler), nil
+}
+
+// RegistryHandler defines the configuration for wrapping a Registry
+type RegistryHandler map[string]Parameters
+
+// Type returns the registryHandler type
+func (registryHandler RegistryHandler) Type() string {
+	// Return only key in this map
+	for k := range registryHandler {
+		return k
+	}
+	return ""
+}
+
+// Parameters returns the Parameters map for a RegistryHandler configuration
+func (registryHandler RegistryHandler) Parameters() Parameters {
+	return registryHandler[registryHandler.Type()]
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+// Unmarshals a single item map into a RegistryHandler or a string into a RegistryHandler type with no parameters
+func (registryHandler *RegistryHandler) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var params map[string]Parameters
+	err := unmarshal(&params)
+	if err == nil {
+		if len(params) > 1 {
+			types := make([]string, 0, len(params))
+			for k := range params {
+				types = append(types, k)
+			}
+			return fmt.Errorf("Must provide exactly one registryHandler type. Provided: %v", types)
+		}
+		*registryHandler = params
+		return nil
+	}
+
+	var registryHandlerType string
+	err = unmarshal(&registryHandlerType)
+	if err == nil {
+		*registryHandler = RegistryHandler{registryHandlerType: Parameters{}}
+		return nil
+	}
+
+	return err
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (registryHandler RegistryHandler) MarshalYAML() (interface{}, error) {
+	if registryHandler.Parameters() == nil {
+		t := registryHandler.Type()
+		if t == "" {
+			return nil, nil
+		}
+		return t, nil
+	}
+	return map[string]Parameters(registryHandler), nil
+}
+
+// RepositoryHandler defines the configuration for wrapping a Repository
+type RepositoryHandler map[string]Parameters
+
+// Type returns the repositoryHandler type
+func (repositoryHandler RepositoryHandler) Type() string {
+	// Return only key in this map
+	for k := range repositoryHandler {
+		return k
+	}
+	return ""
+}
+
+// Parameters returns the Parameters map for a RepositoryHandler configuration
+func (repositoryHandler RepositoryHandler) Parameters() Parameters {
+	return repositoryHandler[repositoryHandler.Type()]
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface
+// Unmarshals a single item map into a RepositoryHandler or a string into a RepositoryHandler type with no parameters
+func (repositoryHandler *RepositoryHandler) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var params map[string]Parameters
+	err := unmarshal(&params)
+	if err == nil {
+		if len(params) > 1 {
+			types := make([]string, 0, len(params))
+			for k := range params {
+				types = append(types, k)
+			}
+			return fmt.Errorf("Must provide exactly one repositoryHandler type. Provided: %v", types)
+		}
+		*repositoryHandler = params
+		return nil
+	}
+
+	var repositoryHandlerType string
+	err = unmarshal(&repositoryHandlerType)
+	if err == nil {
+		*repositoryHandler = RepositoryHandler{repositoryHandlerType: Parameters{}}
+		return nil
+	}
+
+	return err
+}
+
+// MarshalYAML implements the yaml.Marshaler interface
+func (repositoryHandler RepositoryHandler) MarshalYAML() (interface{}, error) {
+	if repositoryHandler.Parameters() == nil {
+		t := repositoryHandler.Type()
+		if t == "" {
+			return nil, nil
+		}
+		return t, nil
+	}
+	return map[string]Parameters(repositoryHandler), nil
 }
 
 // Parse parses an input configuration yaml document into a Configuration struct

--- a/registry/handlers/registryhandler.go
+++ b/registry/handlers/registryhandler.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution"
+)
+
+// RegistryHandlerInitFunc is the type of a RegistryHandler factory function.
+type RegistryHandlerInitFunc func(registry distribution.Registry, options map[string]interface{}) (distribution.Registry, error)
+
+var registryHandlers map[string]RegistryHandlerInitFunc
+
+// RegisterRegistryHandler registers a RegistryHandlerInitFunc for a RegistryHandler
+// with the given name.
+func RegisterRegistryHandler(name string, initFunc RegistryHandlerInitFunc) error {
+	if registryHandlers == nil {
+		registryHandlers = make(map[string]RegistryHandlerInitFunc)
+	}
+	if _, exists := registryHandlers[name]; exists {
+		return fmt.Errorf("name already registered: %s", name)
+	}
+
+	registryHandlers[name] = initFunc
+
+	return nil
+}
+
+// GetRegistryHandler constructs a RegistryHandler with the given options using the named handler.
+func GetRegistryHandler(name string, registry distribution.Registry, options map[string]interface{}) (distribution.Registry, error) {
+	if registryHandlers != nil {
+		if initFunc, exists := registryHandlers[name]; exists {
+			return initFunc(registry, options)
+		}
+	}
+
+	return nil, fmt.Errorf("no registry handler registered with name: %s", name)
+}

--- a/registry/handlers/registryhandler_test.go
+++ b/registry/handlers/registryhandler_test.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/docker/distribution"
+	"golang.org/x/net/context"
+)
+
+type fakeRegistry struct{}
+
+func (f *fakeRegistry) Repository(ctx context.Context, name string) (distribution.Repository, error) {
+	return nil, nil
+}
+
+type testRegistryHandler struct {
+	registry distribution.Registry
+	options  map[string]interface{}
+	ctx      context.Context
+	name     string
+}
+
+func (h *testRegistryHandler) Repository(ctx context.Context, name string) (distribution.Repository, error) {
+	h.ctx = ctx
+	h.name = name
+	return nil, nil
+}
+
+func newTestHandler(registry distribution.Registry, options map[string]interface{}) (distribution.Registry, error) {
+	return &testRegistryHandler{
+		registry: registry,
+		options:  options,
+	}, nil
+}
+
+func TestRegistryHandler(t *testing.T) {
+	RegisterRegistryHandler("testRegistryHandler", newTestHandler)
+
+	options := map[string]interface{}{"option1": "value1"}
+	existingRegistry := &fakeRegistry{}
+
+	handler, err := GetRegistryHandler("testRegistryHandler", existingRegistry, options)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if e, a := handler.(*testRegistryHandler).registry, existingRegistry; e != a {
+		t.Fatalf("init func registry: expected %#v, got %#v", e, a)
+	}
+	if e, a := handler.(*testRegistryHandler).options, options; !reflect.DeepEqual(e, a) {
+		t.Fatalf("init func options: expected %#v, got %#v", e, a)
+	}
+
+	ctx := context.Background()
+	name := "repo"
+	_, err = handler.Repository(ctx, name)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if e, a := ctx, handler.(*testRegistryHandler).ctx; e != a {
+		t.Fatalf("ctx: expected %#v, got %#v", e, a)
+	}
+	if e, a := name, handler.(*testRegistryHandler).name; e != a {
+		t.Fatalf("name: expected %s, got %s", e, a)
+	}
+}

--- a/registry/handlers/repositoryhandler.go
+++ b/registry/handlers/repositoryhandler.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution"
+)
+
+// RepositoryHandlerInitFunc is the type of a RepositoryHandler factory function.
+type RepositoryHandlerInitFunc func(repository distribution.Repository, options map[string]interface{}) (distribution.Repository, error)
+
+var repositoryHandlers map[string]RepositoryHandlerInitFunc
+
+// RegisterRepositoryHandler registers a RepositoryHandlerInitFunc for a RepositoryHandler
+// with the given name.
+func RegisterRepositoryHandler(name string, initFunc RepositoryHandlerInitFunc) error {
+	if repositoryHandlers == nil {
+		repositoryHandlers = make(map[string]RepositoryHandlerInitFunc)
+	}
+	if _, exists := repositoryHandlers[name]; exists {
+		return fmt.Errorf("name already registered: %s", name)
+	}
+
+	repositoryHandlers[name] = initFunc
+
+	return nil
+}
+
+// GetRepositoryHandler constructs a RepositoryHandler with the given options using the named handler.
+func GetRepositoryHandler(name string, repository distribution.Repository, options map[string]interface{}) (distribution.Repository, error) {
+	if repositoryHandlers != nil {
+		if initFunc, exists := repositoryHandlers[name]; exists {
+			return initFunc(repository, options)
+		}
+	}
+
+	return nil, fmt.Errorf("no repository handler registered with name: %s", name)
+}

--- a/registry/handlers/repositoryhandler_test.go
+++ b/registry/handlers/repositoryhandler_test.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/docker/distribution"
+)
+
+type fakeRepository struct{}
+
+func (f *fakeRepository) Name() string {
+	return ""
+}
+
+func (f *fakeRepository) Manifests() distribution.ManifestService {
+	return nil
+}
+
+func (f *fakeRepository) Layers() distribution.LayerService {
+	return nil
+}
+
+func (f *fakeRepository) Signatures() distribution.SignatureService {
+	return nil
+}
+
+type testRepositoryHandler struct {
+	repository       distribution.Repository
+	options          map[string]interface{}
+	manifestsCalled  bool
+	layersCalled     bool
+	signaturesCalled bool
+}
+
+func (h *testRepositoryHandler) Name() string {
+	return "testRepo"
+}
+
+func (h *testRepositoryHandler) Manifests() distribution.ManifestService {
+	h.manifestsCalled = true
+	return nil
+}
+
+func (h *testRepositoryHandler) Layers() distribution.LayerService {
+	h.layersCalled = true
+	return nil
+}
+
+func (h *testRepositoryHandler) Signatures() distribution.SignatureService {
+	h.signaturesCalled = true
+	return nil
+}
+
+func newTestRepositoryHandler(repository distribution.Repository, options map[string]interface{}) (distribution.Repository, error) {
+	return &testRepositoryHandler{
+		repository: repository,
+		options:    options,
+	}, nil
+}
+
+func TestRepositoryHandler(t *testing.T) {
+	RegisterRepositoryHandler("testRepositoryHandler", newTestRepositoryHandler)
+
+	options := map[string]interface{}{"option1": "value1"}
+	existingRepository := &fakeRepository{}
+
+	handler, err := GetRepositoryHandler("testRepositoryHandler", existingRepository, options)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if e, a := handler.(*testRepositoryHandler).repository, existingRepository; e != a {
+		t.Fatalf("init func repository: expected %#v, got %#v", e, a)
+	}
+	if e, a := handler.(*testRepositoryHandler).options, options; !reflect.DeepEqual(e, a) {
+		t.Fatalf("init func options: expected %#v, got %#v", e, a)
+	}
+
+	if e, a := "testRepo", handler.Name(); e != a {
+		t.Fatalf("name: expected %q, got %q", e, a)
+	}
+
+	handler.Manifests()
+	if !handler.(*testRepositoryHandler).manifestsCalled {
+		t.Fatal("expected handler's Manifests() to have been called")
+	}
+
+	handler.Layers()
+	if !handler.(*testRepositoryHandler).layersCalled {
+		t.Fatal("expected handler's Layers() to have been called")
+	}
+
+	handler.Signatures()
+	if !handler.(*testRepositoryHandler).signaturesCalled {
+		t.Fatal("expected handler's Signatures() to have been called")
+	}
+}


### PR DESCRIPTION
Add registry and repository handlers that allow external integrators to
wrap the registry and repository instances in order to customize
registry and repository behavior.