### PR TITLE
digest, registry/storage, registry/handlers: switch to SHA256 as canonical digest

### DIFF
--- a/digest/digest.go
+++ b/digest/digest.go
@@ -16,6 +16,8 @@ import (
 const (
 	// DigestTarSumV1EmptyTar is the digest for the empty tar file.
 	DigestTarSumV1EmptyTar = "tarsum.v1+sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	// DigestSha256EmptyTar is the canonical sha256 digest of empty data
+	DigestSha256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 )
 
 // Digest allows simple protection of hex formatted digest strings, prefixed

--- a/digest/digester.go
+++ b/digest/digester.go
@@ -1,0 +1,44 @@
+package digest
+
+import (
+	"crypto/sha256"
+	"hash"
+)
+
+// Digester calculates the digest of written data. It is functionally
+// equivalent to hash.Hash but provides methods for returning the Digest type
+// rather than raw bytes.
+type Digester struct {
+	alg  string
+	hash hash.Hash
+}
+
+// NewDigester create a new Digester with the given hashing algorithm and instance
+// of that algo's hasher.
+func NewDigester(alg string, h hash.Hash) Digester {
+	return Digester{
+		alg:  alg,
+		hash: h,
+	}
+}
+
+// NewCanonicalDigester is a convenience function to create a new Digester with
+// out default settings.
+func NewCanonicalDigester() Digester {
+	return NewDigester("sha256", sha256.New())
+}
+
+// Write data to the digester. These writes cannot fail.
+func (d *Digester) Write(p []byte) (n int, err error) {
+	return d.hash.Write(p)
+}
+
+// Digest returns the current digest for this digester.
+func (d *Digester) Digest() Digest {
+	return NewDigest(d.alg, d.hash)
+}
+
+// Reset the state of the digester.
+func (d *Digester) Reset() {
+	d.hash.Reset()
+}

--- a/registry/storage/layer_test.go
+++ b/registry/storage/layer_test.go
@@ -266,12 +266,12 @@ func TestLayerUploadZeroLength(t *testing.T) {
 
 	io.Copy(upload, bytes.NewReader([]byte{}))
 
-	dgst, err := digest.FromTarArchive(bytes.NewReader([]byte{}))
+	dgst, err := digest.FromReader(bytes.NewReader([]byte{}))
 	if err != nil {
 		t.Fatalf("error getting zero digest: %v", err)
 	}
 
-	if dgst != digest.DigestTarSumV1EmptyTar {
+	if dgst != digest.DigestSha256EmptyTar {
 		// sanity check on zero digest
 		t.Fatalf("digest not as expected: %v != %v", dgst, digest.DigestTarSumV1EmptyTar)
 	}

--- a/registry/storage/layerupload.go
+++ b/registry/storage/layerupload.go
@@ -159,7 +159,7 @@ func (luc *layerUploadController) moveLayer(dgst digest.Digest) error {
 			// a zero-length blob into a nonzero-length blob location. To
 			// prevent this horrid thing, we employ the hack of only allowing
 			// to this happen for the zero tarsum.
-			if dgst == digest.DigestTarSumV1EmptyTar {
+			if dgst == digest.DigestSha256EmptyTar {
 				return luc.driver.PutContent(blobPath, []byte{})
 			}
 

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -232,12 +232,6 @@ func (pm *pathMapper) path(spec pathSpec) (string, error) {
 			return "", err
 		}
 
-		// For now, only map tarsum paths.
-		if components[0] != "tarsum" {
-			// Only tarsum is supported, for now
-			return "", fmt.Errorf("unsupported content digest: %v", v.digest)
-		}
-
 		layerLinkPathComponents := append(repoPrefix, v.name, "_layers")
 
 		return path.Join(path.Join(append(layerLinkPathComponents, components...)...), "link"), nil


### PR DESCRIPTION
Supersedes https://github.com/docker/distribution/pull/237

@jlhawn @stevvooe  