### PR TITLE
supplement of digest refactoring

### DIFF
--- a/digest/digest.go
+++ b/digest/digest.go
@@ -51,6 +51,9 @@ func NewDigestFromHex(alg, hex string) Digest {
 // DigestRegexp matches valid digest types.
 var DigestRegexp = regexp.MustCompile(`[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+`)
 
+// DigestRegexpAnchored matches valid digest types, anchored to the start and end of the match.
+var DigestRegexpAnchored = regexp.MustCompile(`^` + DigestRegexp.String() + `$`)
+
 var (
 	// ErrDigestInvalidFormat returned when digest format invalid.
 	ErrDigestInvalidFormat = fmt.Errorf("invalid checksum digest format")
@@ -114,7 +117,7 @@ func (d Digest) Validate() error {
 
 	// Continue on for general parser
 
-	if !DigestRegexp.MatchString(s) {
+	if !DigestRegexpAnchored.MatchString(s) {
 		return ErrDigestInvalidFormat
 	}
 

--- a/digest/digest_test.go
+++ b/digest/digest_test.go
@@ -49,6 +49,11 @@ func TestParseDigest(t *testing.T) {
 			err:   ErrDigestInvalidFormat,
 		},
 		{
+			// not hex
+			input: "sha256:d41d8cd98f00b204e9800m98ecf8427e",
+			err:   ErrDigestInvalidFormat,
+		},
+		{
 			input: "foo:d41d8cd98f00b204e9800998ecf8427e",
 			err:   ErrDigestUnsupported,
 		},


### PR DESCRIPTION
@stevvooe 
The invalid character in the middle of HEX digest should be well-marked.
Hence, add 'full string verification' rule in DigestRegexp.

By the way, the relevant point in docker/docker should be modified to accordant, right?