### PR TITLE
Insert request method option storage driver URLFor

### DIFF
--- a/registry/storage/layerreader.go
+++ b/registry/storage/layerreader.go
@@ -38,7 +38,7 @@ func (lr *layerReader) Close() error {
 func (lr *layerReader) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Docker-Content-Digest", lr.digest.String())
 
-	if url, err := lr.fileReader.driver.URLFor(lr.path, map[string]interface{}{}); err == nil {
+	if url, err := lr.fileReader.driver.URLFor(lr.path, map[string]interface{}{"method": r.Method}); err == nil {
 		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 	}
 	http.ServeContent(w, r, lr.digest.String(), lr.CreatedAt(), lr)


### PR DESCRIPTION
Otherwise `HEAD` requests using s3 result in a redirect to a 403.