### PR TITLE
digest: remove unnecessary error pointer formats in test

### DIFF
--- a/digest/verifiers_test.go
+++ b/digest/verifiers_test.go
@@ -80,7 +80,7 @@ func TestVerifierUnsupportedDigest(t *testing.T) {
 	}
 
 	if err != ErrDigestUnsupported {
-		t.Fatalf("incorrect error for unsupported digest: %v %p %p", err, ErrDigestUnsupported, err)
+		t.Fatalf("incorrect error for unsupported digest: %v", err)
 	}
 }
 


### PR DESCRIPTION
The linter was complaining about these and they are quite unnecessary.