### PR TITLE
handler/dispatcher refactor

### DIFF
--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -20,6 +20,31 @@ func serveJSON(w http.ResponseWriter, v interface{}) error {
 	return nil
 }
 
+func serveJSONStatus(w http.ResponseWriter, v interface{}, status int) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if status > 0 {
+		w.WriteHeader(status)
+	}
+	enc := json.NewEncoder(w)
+
+	if err := enc.Encode(v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func serveError(err error, w http.ResponseWriter) error {
+	switch err := err.(type) {
+	case httpError:
+		err.ServeError(w)
+		return nil
+	default:
+		return serveJSON(w, err)
+
+	}
+}
+
 // closeResources closes all the provided resources after running the target
 // handler.
 func closeResources(handler http.Handler, closers ...io.Closer) http.Handler {

--- a/registry/handlers/httperror.go
+++ b/registry/handlers/httperror.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"github.com/docker/distribution/registry/api/v2"
+	"net/http"
+)
+
+// httpError is a wrapper for v2.Errors that adds a Status int to hold
+// an HTTP Status code which will be used to set the status code on
+// the response.
+type httpError struct {
+	v2.Errors
+	Status int
+}
+
+// NewHTTPError create a new httpError using the given ErrorCode, detail and http status.
+// detail must be json serializable.
+func NewHTTPError(errCode v2.ErrorCode, detail interface{}, status int) error {
+	errs := v2.Errors{}
+	if errCode > 0 {
+		errs.Push(errCode, detail)
+	}
+	newErr := httpError{
+		errs,
+		status,
+	}
+	return newErr
+}
+
+// ServeError is currently just a pass through to serveJSONStatus but its use will
+// allow us to easily make changes to how errors are served in the future.
+func (err *httpError) ServeError(w http.ResponseWriter) {
+	serveJSONStatus(w, err.Errors, err.Status)
+}
+
+func (err httpError) Error() string {
+	return err.Errors.Error()
+}

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -11,178 +11,159 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/registry/api/v2"
-	"github.com/gorilla/handlers"
 	"golang.org/x/net/context"
 )
 
 // imageManifestDispatcher takes the request context and builds the
 // appropriate handler for handling image manifest requests.
-func imageManifestDispatcher(ctx *Context, r *http.Request) http.Handler {
-	imageManifestHandler := &imageManifestHandler{
-		Context: ctx,
+func imageManifestHandler(ctx *Context, w http.ResponseWriter, r *http.Request) (httpErr error) {
+	switch r.Method {
+	case "GET":
+		httpErr = GetImageManifest(ctx, w, r)
+	case "PUT":
+		httpErr = PutImageManifest(ctx, w, r)
+	case "DELETE":
+		httpErr = DeleteImageManifest(ctx, w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
-	reference := getReference(ctx)
-	dgst, err := digest.ParseDigest(reference)
-	if err != nil {
-		// We just have a tag
-		imageManifestHandler.Tag = reference
-	} else {
-		imageManifestHandler.Digest = dgst
-	}
-
-	return handlers.MethodHandler{
-		"GET":    http.HandlerFunc(imageManifestHandler.GetImageManifest),
-		"PUT":    http.HandlerFunc(imageManifestHandler.PutImageManifest),
-		"DELETE": http.HandlerFunc(imageManifestHandler.DeleteImageManifest),
-	}
+	return httpErr
 }
 
-// imageManifestHandler handles http operations on image manifests.
-type imageManifestHandler struct {
-	*Context
-
-	// One of tag or digest gets set, depending on what is present in context.
-	Tag    string
-	Digest digest.Digest
+func parseTagDigest(ctx *Context, r *http.Request) (string, digest.Digest) {
+	tag := getReference(ctx)
+	dgst, err := digest.ParseDigest(tag)
+	if err != nil {
+		return tag, ""
+	}
+	return "", dgst
 }
 
 // GetImageManifest fetches the image manifest from the storage backend, if it exists.
-func (imh *imageManifestHandler) GetImageManifest(w http.ResponseWriter, r *http.Request) {
-	ctxu.GetLogger(imh).Debug("GetImageManifest")
-	manifests := imh.Repository.Manifests()
+func GetImageManifest(ctx *Context, w http.ResponseWriter, r *http.Request) error {
+	ctxu.GetLogger(ctx).Debug("GetImageManifest")
+	tag, dgst := parseTagDigest(ctx, r)
+	manifests := ctx.Repository.Manifests()
 
 	var (
 		sm  *manifest.SignedManifest
 		err error
 	)
 
-	if imh.Tag != "" {
-		sm, err = manifests.GetByTag(imh.Tag)
+	if tag != "" {
+		sm, err = manifests.GetByTag(tag)
 	} else {
-		sm, err = manifests.Get(imh.Digest)
+		sm, err = manifests.Get(dgst)
 	}
 
 	if err != nil {
-		imh.Errors.Push(v2.ErrorCodeManifestUnknown, err)
-		w.WriteHeader(http.StatusNotFound)
-		return
+		return NewHTTPError(v2.ErrorCodeManifestUnknown, err, http.StatusNotFound)
 	}
 
 	// Get the digest, if we don't already have it.
-	if imh.Digest == "" {
-		dgst, err := digestManifest(imh, sm)
+	if dgst == "" {
+		dgst, err = digestManifest(ctx, sm)
 		if err != nil {
-			imh.Errors.Push(v2.ErrorCodeDigestInvalid, err)
-			w.WriteHeader(http.StatusBadRequest)
-			return
+			return NewHTTPError(v2.ErrorCodeDigestInvalid, err, http.StatusBadRequest)
 		}
 
-		imh.Digest = dgst
 	}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Content-Length", fmt.Sprint(len(sm.Raw)))
-	w.Header().Set("Docker-Content-Digest", imh.Digest.String())
+	w.Header().Set("Docker-Content-Digest", dgst.String())
 	w.Write(sm.Raw)
+	return nil
 }
 
 // PutImageManifest validates and stores and image in the registry.
-func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http.Request) {
-	ctxu.GetLogger(imh).Debug("PutImageManifest")
-	manifests := imh.Repository.Manifests()
+func PutImageManifest(ctx *Context, w http.ResponseWriter, r *http.Request) error {
+	ctxu.GetLogger(ctx).Debug("PutImageManifest")
+	tag, sentDgst := parseTagDigest(ctx, r)
+	manifests := ctx.Repository.Manifests()
 	dec := json.NewDecoder(r.Body)
 
 	var manifest manifest.SignedManifest
 	if err := dec.Decode(&manifest); err != nil {
-		imh.Errors.Push(v2.ErrorCodeManifestInvalid, err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
+		return NewHTTPError(v2.ErrorCodeManifestInvalid, err, http.StatusBadRequest)
 	}
 
-	dgst, err := digestManifest(imh, &manifest)
+	dgst, err := digestManifest(ctx, &manifest)
 	if err != nil {
-		imh.Errors.Push(v2.ErrorCodeDigestInvalid, err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
+		return NewHTTPError(v2.ErrorCodeDigestInvalid, err, http.StatusBadRequest)
 	}
 
 	// Validate manifest tag or digest matches payload
-	if imh.Tag != "" {
-		if manifest.Tag != imh.Tag {
-			ctxu.GetLogger(imh).Errorf("invalid tag on manifest payload: %q != %q", manifest.Tag, imh.Tag)
-			imh.Errors.Push(v2.ErrorCodeTagInvalid)
-			w.WriteHeader(http.StatusBadRequest)
-			return
+	if tag != "" {
+		if manifest.Tag != tag {
+			ctxu.GetLogger(ctx).Errorf("invalid tag on manifest payload: %q != %q", manifest.Tag, tag)
+			return NewHTTPError(v2.ErrorCodeTagInvalid, nil, http.StatusBadRequest)
 		}
 
-		imh.Digest = dgst
-	} else if imh.Digest != "" {
-		if dgst != imh.Digest {
-			ctxu.GetLogger(imh).Errorf("payload digest does match: %q != %q", dgst, imh.Digest)
-			imh.Errors.Push(v2.ErrorCodeDigestInvalid)
-			w.WriteHeader(http.StatusBadRequest)
-			return
+	} else if sentDgst != "" {
+		if dgst.String() != sentDgst.String() {
+			ctxu.GetLogger(ctx).Errorf("payload digest does match: %q != %q", dgst, dgst)
+			return NewHTTPError(v2.ErrorCodeDigestInvalid, nil, http.StatusBadRequest)
 		}
 	} else {
-		imh.Errors.Push(v2.ErrorCodeTagInvalid, "no tag or digest specified")
-		w.WriteHeader(http.StatusBadRequest)
-		return
+		return NewHTTPError(v2.ErrorCodeTagInvalid, "no tag or digest specified", http.StatusBadRequest)
 	}
 
 	if err := manifests.Put(&manifest); err != nil {
 		// TODO(stevvooe): These error handling switches really need to be
 		// handled by an app global mapper.
+		newErr := NewHTTPError(0, nil, http.StatusBadRequest)
+		httpErr := newErr.(httpError)
 		switch err := err.(type) {
 		case distribution.ErrManifestVerification:
 			for _, verificationError := range err {
 				switch verificationError := verificationError.(type) {
 				case distribution.ErrUnknownLayer:
-					imh.Errors.Push(v2.ErrorCodeBlobUnknown, verificationError.FSLayer)
+					httpErr.Push(v2.ErrorCodeBlobUnknown, verificationError.FSLayer)
 				case distribution.ErrManifestUnverified:
-					imh.Errors.Push(v2.ErrorCodeManifestUnverified)
+					httpErr.Push(v2.ErrorCodeManifestUnverified)
 				default:
 					if verificationError == digest.ErrDigestInvalidFormat {
 						// TODO(stevvooe): We need to really need to move all
 						// errors to types. Its much more straightforward.
-						imh.Errors.Push(v2.ErrorCodeDigestInvalid)
+						httpErr.Push(v2.ErrorCodeDigestInvalid)
 					} else {
-						imh.Errors.PushErr(verificationError)
+						httpErr.PushErr(verificationError)
 					}
 				}
 			}
 		default:
-			imh.Errors.PushErr(err)
+			httpErr.PushErr(err)
 		}
 
-		w.WriteHeader(http.StatusBadRequest)
-		return
+		return httpErr
 	}
 
 	// Construct a canonical url for the uploaded manifest.
-	location, err := imh.urlBuilder.BuildManifestURL(imh.Repository.Name(), imh.Digest.String())
+	location, err := ctx.urlBuilder.BuildManifestURL(ctx.Repository.Name(), dgst.String())
 	if err != nil {
 		// NOTE(stevvooe): Given the behavior above, this absurdly unlikely to
 		// happen. We'll log the error here but proceed as if it worked. Worst
 		// case, we set an empty location header.
-		ctxu.GetLogger(imh).Errorf("error building manifest url from digest: %v", err)
+		ctxu.GetLogger(ctx).Errorf("error building manifest url from digest: %v", err)
 	}
 
 	w.Header().Set("Location", location)
-	w.Header().Set("Docker-Content-Digest", imh.Digest.String())
+	w.Header().Set("Docker-Content-Digest", dgst.String())
 	w.WriteHeader(http.StatusAccepted)
+	return nil
 }
 
 // DeleteImageManifest removes the image with the given tag from the registry.
-func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *http.Request) {
-	ctxu.GetLogger(imh).Debug("DeleteImageManifest")
+func DeleteImageManifest(ctx *Context, w http.ResponseWriter, r *http.Request) error {
+	ctxu.GetLogger(ctx).Debug("DeleteImageManifest")
 
 	// TODO(stevvooe): Unfortunately, at this point, manifest deletes are
 	// unsupported. There are issues with schema version 1 that make removing
 	// tag index entries a serious problem in eventually consistent storage.
 	// Once we work out schema version 2, the full deletion system will be
 	// worked out and we can add support back.
-	imh.Errors.Push(v2.ErrorCodeUnsupported)
-	w.WriteHeader(http.StatusBadRequest)
+	return NewHTTPError(v2.ErrorCodeUnsupported, nil, http.StatusBadRequest)
 }
 
 // digestManifest takes a digest of the given manifest. This belongs somewhere

--- a/registry/handlers/layerupload.go
+++ b/registry/handlers/layerupload.go
@@ -11,154 +11,123 @@ import (
 	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/api/v2"
-	"github.com/gorilla/handlers"
 )
 
 // layerUploadDispatcher constructs and returns the layer upload handler for
 // the given request context.
-func layerUploadDispatcher(ctx *Context, r *http.Request) http.Handler {
-	luh := &layerUploadHandler{
-		Context: ctx,
-		UUID:    getUploadUUID(ctx),
+func layerUploadHandler(ctx *Context, w http.ResponseWriter, r *http.Request) (err error) {
+	switch r.Method {
+	case "POST":
+		err = StartLayerUpload(ctx, w, r)
+	case "GET", "HEAD":
+		err = GetUploadStatus(ctx, w, r)
+	case "PUT":
+		err = PutLayerUploadComplete(ctx, w, r)
+	case "DELETE":
+		err = CancelLayerUpload(ctx, w, r)
+	// TODO(stevvooe): Must implement patch support.
+	// case "PATCH":
+	//	PutLayerChunk(ctx, w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
+	return err
+}
 
-	handler := http.Handler(handlers.MethodHandler{
-		"POST": http.HandlerFunc(luh.StartLayerUpload),
-		"GET":  http.HandlerFunc(luh.GetUploadStatus),
-		"HEAD": http.HandlerFunc(luh.GetUploadStatus),
-		// TODO(stevvooe): Must implement patch support.
-		// "PATCH":    http.HandlerFunc(luh.PutLayerChunk),
-		"PUT":    http.HandlerFunc(luh.PutLayerUploadComplete),
-		"DELETE": http.HandlerFunc(luh.CancelLayerUpload),
-	})
-
-	if luh.UUID != "" {
-		state, err := hmacKey(ctx.Config.HTTP.Secret).unpackUploadState(r.FormValue("_state"))
+func layerUploadInfo(ctx *Context, r *http.Request) (uuid string, upload distribution.LayerUpload, httpErr error) {
+	uuid = getUploadUUID(ctx)
+	if uuid != "" {
+		state, err := hmacKey(ctx.Secret).unpackUploadState(r.FormValue("_state"))
 		if err != nil {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				ctxu.GetLogger(ctx).Infof("error resolving upload: %v", err)
-				w.WriteHeader(http.StatusBadRequest)
-				luh.Errors.Push(v2.ErrorCodeBlobUploadInvalid, err)
-			})
+			ctxu.GetLogger(ctx).Infof("error resolving upload: %v", err)
+			httpErr = NewHTTPError(v2.ErrorCodeBlobUploadInvalid, err, http.StatusBadRequest)
+			return
 		}
-		luh.State = state
 
 		if state.Name != ctx.Repository.Name() {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				ctxu.GetLogger(ctx).Infof("mismatched repository name in upload state: %q != %q", state.Name, luh.Repository.Name())
-				w.WriteHeader(http.StatusBadRequest)
-				luh.Errors.Push(v2.ErrorCodeBlobUploadInvalid, err)
-			})
+			ctxu.GetLogger(ctx).Infof("mismatched repository name in upload state: %q != %q", state.Name, ctx.Repository.Name())
+			httpErr = NewHTTPError(v2.ErrorCodeBlobUploadInvalid, err, http.StatusBadRequest)
+			return
 		}
 
-		if state.UUID != luh.UUID {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				ctxu.GetLogger(ctx).Infof("mismatched uuid in upload state: %q != %q", state.UUID, luh.UUID)
-				w.WriteHeader(http.StatusBadRequest)
-				luh.Errors.Push(v2.ErrorCodeBlobUploadInvalid, err)
-			})
+		if state.UUID != uuid {
+			ctxu.GetLogger(ctx).Infof("mismatched uuid in upload state: %q != %q", state.UUID, uuid)
+			httpErr = NewHTTPError(v2.ErrorCodeBlobUploadInvalid, err, http.StatusBadRequest)
+			return
 		}
 
 		layers := ctx.Repository.Layers()
-		upload, err := layers.Resume(luh.UUID)
+		upload, err = layers.Resume(uuid)
 		if err != nil {
 			ctxu.GetLogger(ctx).Errorf("error resolving upload: %v", err)
 			if err == distribution.ErrLayerUploadUnknown {
-				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusNotFound)
-					luh.Errors.Push(v2.ErrorCodeBlobUploadUnknown, err)
-				})
+				httpErr = NewHTTPError(v2.ErrorCodeBlobUploadUnknown, err, http.StatusNotFound)
+				return
 			}
 
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusInternalServerError)
-				luh.Errors.Push(v2.ErrorCodeUnknown, err)
-			})
+			httpErr = NewHTTPError(v2.ErrorCodeUnknown, err, http.StatusInternalServerError)
+			return
 		}
-		luh.Upload = upload
 
 		if state.Offset > 0 {
 			// Seek the layer upload to the correct spot if it's non-zero.
 			// These error conditions should be rare and demonstrate really
 			// problems. We basically cancel the upload and tell the client to
 			// start over.
-			if nn, err := upload.Seek(luh.State.Offset, os.SEEK_SET); err != nil {
-				defer upload.Close()
+			if nn, err := upload.Seek(state.Offset, os.SEEK_SET); err != nil {
+				defer upload.Cancel() // Cancel calls Close
 				ctxu.GetLogger(ctx).Infof("error seeking layer upload: %v", err)
-				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusBadRequest)
-					luh.Errors.Push(v2.ErrorCodeBlobUploadInvalid, err)
-					upload.Cancel()
-				})
-			} else if nn != luh.State.Offset {
-				defer upload.Close()
-				ctxu.GetLogger(ctx).Infof("seek to wrong offest: %d != %d", nn, luh.State.Offset)
-				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusBadRequest)
-					luh.Errors.Push(v2.ErrorCodeBlobUploadInvalid, err)
-					upload.Cancel()
-				})
+				httpErr = NewHTTPError(v2.ErrorCodeBlobUploadInvalid, err, http.StatusBadRequest)
+				return
+			} else if nn != state.Offset {
+				defer upload.Cancel()
+				ctxu.GetLogger(ctx).Infof("seek to wrong offest: %d != %d", nn, state.Offset)
+				httpErr = NewHTTPError(v2.ErrorCodeBlobUploadInvalid, err, http.StatusBadRequest)
+				return
 			}
 		}
-
-		handler = closeResources(handler, luh.Upload)
 	}
-
-	return handler
-}
-
-// layerUploadHandler handles the http layer upload process.
-type layerUploadHandler struct {
-	*Context
-
-	// UUID identifies the upload instance for the current request.
-	UUID string
-
-	Upload distribution.LayerUpload
-
-	State layerUploadState
+	return uuid, upload, nil
 }
 
 // StartLayerUpload begins the layer upload process and allocates a server-
 // side upload session.
-func (luh *layerUploadHandler) StartLayerUpload(w http.ResponseWriter, r *http.Request) {
-	layers := luh.Repository.Layers()
+func StartLayerUpload(ctx *Context, w http.ResponseWriter, r *http.Request) error {
+	layers := ctx.Repository.Layers()
 	upload, err := layers.Upload()
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError) // Error conditions here?
-		luh.Errors.Push(v2.ErrorCodeUnknown, err)
-		return
+		return NewHTTPError(v2.ErrorCodeUnknown, err, http.StatusInternalServerError)
 	}
 
-	luh.Upload = upload
-	defer luh.Upload.Close()
+	defer upload.Close()
 
-	if err := luh.layerUploadResponse(w, r); err != nil {
-		w.WriteHeader(http.StatusInternalServerError) // Error conditions here?
-		luh.Errors.Push(v2.ErrorCodeUnknown, err)
-		return
+	if err := layerUploadResponse(ctx, upload, w); err != nil {
+		return NewHTTPError(v2.ErrorCodeUnknown, err, http.StatusInternalServerError)
 	}
 
-	w.Header().Set("Docker-Upload-UUID", luh.Upload.UUID())
+	w.Header().Set("Docker-Upload-UUID", upload.UUID())
 	w.WriteHeader(http.StatusAccepted)
+	return nil
 }
 
 // GetUploadStatus returns the status of a given upload, identified by uuid.
-func (luh *layerUploadHandler) GetUploadStatus(w http.ResponseWriter, r *http.Request) {
-	if luh.Upload == nil {
-		w.WriteHeader(http.StatusNotFound)
-		luh.Errors.Push(v2.ErrorCodeBlobUploadUnknown)
-		return
+func GetUploadStatus(ctx *Context, w http.ResponseWriter, r *http.Request) error {
+	uuid, upload, httpErr := layerUploadInfo(ctx, r)
+	if httpErr != nil {
+		return httpErr
 	}
 
-	if err := luh.layerUploadResponse(w, r); err != nil {
-		w.WriteHeader(http.StatusInternalServerError) // Error conditions here?
-		luh.Errors.Push(v2.ErrorCodeUnknown, err)
-		return
+	if upload == nil {
+		return NewHTTPError(v2.ErrorCodeBlobUploadUnknown, nil, http.StatusNotFound)
 	}
 
-	w.Header().Set("Docker-Upload-UUID", luh.UUID)
+	if err := layerUploadResponse(ctx, upload, w); err != nil {
+		return NewHTTPError(v2.ErrorCodeUnknown, err, http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Docker-Upload-UUID", uuid)
 	w.WriteHeader(http.StatusNoContent)
+	return nil
 }
 
 // PutLayerUploadComplete takes the final request of a layer upload. The final
@@ -166,28 +135,27 @@ func (luh *layerUploadHandler) GetUploadStatus(w http.ResponseWriter, r *http.Re
 // layer data. Any data provided is received and verified. If successful, the
 // layer is linked into the blob store and 201 Created is returned with the
 // canonical url of the layer.
-func (luh *layerUploadHandler) PutLayerUploadComplete(w http.ResponseWriter, r *http.Request) {
-	if luh.Upload == nil {
-		w.WriteHeader(http.StatusNotFound)
-		luh.Errors.Push(v2.ErrorCodeBlobUploadUnknown)
-		return
+func PutLayerUploadComplete(ctx *Context, w http.ResponseWriter, r *http.Request) error {
+	_, upload, httpErr := layerUploadInfo(ctx, r)
+	if httpErr != nil {
+		return httpErr
+	}
+
+	if upload == nil {
+		return NewHTTPError(v2.ErrorCodeBlobUploadUnknown, nil, http.StatusNotFound)
 	}
 
 	dgstStr := r.FormValue("digest") // TODO(stevvooe): Support multiple digest parameters!
 
 	if dgstStr == "" {
 		// no digest? return error, but allow retry.
-		w.WriteHeader(http.StatusBadRequest)
-		luh.Errors.Push(v2.ErrorCodeDigestInvalid, "digest missing")
-		return
+		return NewHTTPError(v2.ErrorCodeDigestInvalid, "digest missing", http.StatusBadRequest)
 	}
 
 	dgst, err := digest.ParseDigest(dgstStr)
 	if err != nil {
 		// no digest? return error, but allow retry.
-		w.WriteHeader(http.StatusNotFound)
-		luh.Errors.Push(v2.ErrorCodeDigestInvalid, "digest parsing failed")
-		return
+		return NewHTTPError(v2.ErrorCodeDigestInvalid, "digest parsing failed", http.StatusNotFound)
 	}
 
 	// TODO(stevvooe): Check the incoming range header here, per the
@@ -198,98 +166,101 @@ func (luh *layerUploadHandler) PutLayerUploadComplete(w http.ResponseWriter, r *
 	// may miss a root cause.
 
 	// Read in the final chunk, if any.
-	io.Copy(luh.Upload, r.Body)
+	io.Copy(upload, r.Body)
 
-	layer, err := luh.Upload.Finish(dgst)
+	layer, err := upload.Finish(dgst)
 	if err != nil {
+		var httpErr error
+
 		switch err := err.(type) {
 		case distribution.ErrLayerInvalidDigest:
-			w.WriteHeader(http.StatusBadRequest)
-			luh.Errors.Push(v2.ErrorCodeDigestInvalid, err)
+			httpErr = NewHTTPError(v2.ErrorCodeDigestInvalid, err, http.StatusBadRequest)
 		default:
-			ctxu.GetLogger(luh).Errorf("unknown error completing upload: %#v", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			luh.Errors.Push(v2.ErrorCodeUnknown, err)
+			ctxu.GetLogger(ctx).Errorf("unknown error completing upload: %#v", err)
+			httpErr = NewHTTPError(v2.ErrorCodeUnknown, err, http.StatusInternalServerError)
 		}
 
 		// Clean up the backend layer data if there was an error.
-		if err := luh.Upload.Cancel(); err != nil {
+		if err := upload.Cancel(); err != nil {
 			// If the cleanup fails, all we can do is observe and report.
-			ctxu.GetLogger(luh).Errorf("error canceling upload after error: %v", err)
+			ctxu.GetLogger(ctx).Errorf("error canceling upload after error: %v", err)
 		}
 
-		return
+		return httpErr
 	}
 
 	// Build our canonical layer url
-	layerURL, err := luh.urlBuilder.BuildBlobURL(luh.Repository.Name(), layer.Digest())
+	layerURL, err := ctx.urlBuilder.BuildBlobURL(ctx.Repository.Name(), layer.Digest())
 	if err != nil {
-		luh.Errors.Push(v2.ErrorCodeUnknown, err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
+		return NewHTTPError(v2.ErrorCodeUnknown, err, http.StatusInternalServerError)
 	}
 
 	w.Header().Set("Location", layerURL)
 	w.Header().Set("Content-Length", "0")
 	w.Header().Set("Docker-Content-Digest", layer.Digest().String())
 	w.WriteHeader(http.StatusCreated)
+	return nil
 }
 
 // CancelLayerUpload cancels an in-progress upload of a layer.
-func (luh *layerUploadHandler) CancelLayerUpload(w http.ResponseWriter, r *http.Request) {
-	if luh.Upload == nil {
-		w.WriteHeader(http.StatusNotFound)
-		luh.Errors.Push(v2.ErrorCodeBlobUploadUnknown)
-		return
+func CancelLayerUpload(ctx *Context, w http.ResponseWriter, r *http.Request) error {
+	uuid, upload, httpErr := layerUploadInfo(ctx, r)
+	if httpErr != nil {
+		return httpErr
 	}
 
-	w.Header().Set("Docker-Upload-UUID", luh.UUID)
-	if err := luh.Upload.Cancel(); err != nil {
-		ctxu.GetLogger(luh).Errorf("error encountered canceling upload: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		luh.Errors.PushErr(err)
+	if upload == nil {
+		return NewHTTPError(v2.ErrorCodeBlobUploadUnknown, nil, http.StatusNotFound)
+	}
+
+	w.Header().Set("Docker-Upload-UUID", uuid)
+	if err := upload.Cancel(); err != nil {
+		ctxu.GetLogger(ctx).Errorf("error encountered canceling upload: %v", err)
+		return NewHTTPError(v2.ErrorCodeUnknown, err, http.StatusInternalServerError)
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+	return nil
 }
 
 // layerUploadResponse provides a standard request for uploading layers and
 // chunk responses. This sets the correct headers but the response status is
 // left to the caller.
-func (luh *layerUploadHandler) layerUploadResponse(w http.ResponseWriter, r *http.Request) error {
+func layerUploadResponse(ctx *Context, upload distribution.LayerUpload, w http.ResponseWriter) error {
 
-	offset, err := luh.Upload.Seek(0, os.SEEK_CUR)
+	offset, err := upload.Seek(0, os.SEEK_CUR)
 	if err != nil {
-		ctxu.GetLogger(luh).Errorf("unable get current offset of layer upload: %v", err)
+		ctxu.GetLogger(ctx).Errorf("unable get current offset of layer upload: %v", err)
 		return err
 	}
 
-	// TODO(stevvooe): Need a better way to manage the upload state automatically.
-	luh.State.Name = luh.Repository.Name()
-	luh.State.UUID = luh.Upload.UUID()
-	luh.State.Offset = offset
-	luh.State.StartedAt = luh.Upload.StartedAt()
+	state := layerUploadState{
+		Name:      ctx.Repository.Name(),
+		UUID:      upload.UUID(),
+		Offset:    offset,
+		StartedAt: upload.StartedAt(),
+	}
 
-	token, err := hmacKey(luh.Config.HTTP.Secret).packUploadState(luh.State)
+	token, err := hmacKey(ctx.Secret).packUploadState(state)
 	if err != nil {
-		ctxu.GetLogger(luh).Infof("error building upload state token: %s", err)
+		ctxu.GetLogger(ctx).Infof("error building upload state token: %s", err)
 		return err
 	}
 
-	uploadURL, err := luh.urlBuilder.BuildBlobUploadChunkURL(
-		luh.Repository.Name(), luh.Upload.UUID(),
+	uploadURL, err := ctx.urlBuilder.BuildBlobUploadChunkURL(
+		ctx.Repository.Name(), upload.UUID(),
 		url.Values{
 			"_state": []string{token},
 		})
 	if err != nil {
-		ctxu.GetLogger(luh).Infof("error building upload url: %s", err)
+		ctxu.GetLogger(ctx).Infof("error building upload url: %s", err)
 		return err
 	}
 
-	w.Header().Set("Docker-Upload-UUID", luh.UUID)
+	w.Header().Set("Docker-Upload-UUID", upload.UUID())
 	w.Header().Set("Location", uploadURL)
 	w.Header().Set("Content-Length", "0")
-	w.Header().Set("Range", fmt.Sprintf("0-%d", luh.State.Offset))
+	w.Header().Set("Range", fmt.Sprintf("0-%d", state.Offset))
 
 	return nil
 }


### PR DESCRIPTION
Major points:

* Dispatchers no longer exist.
* Simpler call path for handlers.
* gorilla's MethodHandler no longer in use.
* Errors more generically handled in a uniform way via HTTPError
* A request Context no longer needs to embed App
* The various handler structs are gone.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)