### PR TITLE
cmd/registry: Import Azure driver for factory registration

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/docker/distribution/registry/auth/silly"
 	_ "github.com/docker/distribution/registry/auth/token"
 	"github.com/docker/distribution/registry/handlers"
+	_ "github.com/docker/distribution/registry/storage/driver/azure"
 	_ "github.com/docker/distribution/registry/storage/driver/filesystem"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 	_ "github.com/docker/distribution/registry/storage/driver/s3"


### PR DESCRIPTION
Importing Azure storage driver to make it register itself as
a storage driver.

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>

:exclamation: cc: @dmp42 @stevvooe can you guys add it to the 2.0 milestone or merge as soon as possible? 