### PR TITLE
azure: Allow non-default Azure realms

### DIFF
--- a/doc/storagedriver/azure.md
+++ b/doc/storagedriver/azure.md
@@ -10,6 +10,7 @@ The following parameters must be used to authenticate and configure the storage 
 * `accountname`: Name of the Azure Storage Account.
 * `accountkey`: Primary or Secondary Key for the Storage Account.
 * `container`: Name of the root storage container in which all registry data will be stored. Must comply the storage container name [requirements][create-container-api].
+* `realm`: (optional) Domain name suffix for the Storage Service API endpoint. Defaults to `core.windows.net`. For example realm for "Azure in China" would be `core.chinacloudapi.cn` and realm for "Azure Government" would be `core.usgovcloudapi.net`.
 
 
 [azure-blob-storage]: http://azure.microsoft.com/en-us/services/storage/

--- a/registry/storage/driver/azure/azure_test.go
+++ b/registry/storage/driver/azure/azure_test.go
@@ -15,6 +15,7 @@ const (
 	envAccountName = "AZURE_STORAGE_ACCOUNT_NAME"
 	envAccountKey  = "AZURE_STORAGE_ACCOUNT_KEY"
 	envContainer   = "AZURE_STORAGE_CONTAINER"
+	envRealm       = "AZURE_STORAGE_REALM"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -25,6 +26,7 @@ func init() {
 		accountName string
 		accountKey  string
 		container   string
+		realm       string
 	)
 
 	config := []struct {
@@ -34,6 +36,7 @@ func init() {
 		{envAccountName, &accountName},
 		{envAccountKey, &accountKey},
 		{envContainer, &container},
+		{envRealm, &realm},
 	}
 
 	missing := []string{}
@@ -45,7 +48,7 @@ func init() {
 	}
 
 	azureDriverConstructor := func() (storagedriver.StorageDriver, error) {
-		return New(accountName, accountKey, container)
+		return New(accountName, accountKey, container, realm)
 	}
 
 	// Skip Azure storage driver tests if environment variable parameters are not provided
@@ -61,5 +64,6 @@ func init() {
 	// 	paramAccountName: accountName,
 	// 	paramAccountKey:  accountKey,
 	// 	paramContainer:   container,
+	// 	paramRealm:       realm,
 	// }, skipCheck)
 }


### PR DESCRIPTION
This enables Azure storage driver to be used with non-default
cloud storage endpoints like Azure China or Azure Government which
do not use the `.blob.core.windows.net` FQDN suffix.

Change introduces an optional `domain:` key in the `config.yml`.

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>