### PR TITLE
Attempt to identify remote IP addresses for requests which come through proxies.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,8 @@ Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
 Josh Hawn <josh.hawn@docker.com>
 Nghia Tran <tcnghia@gmail.com>
 Olivier Gambier <olivier@docker.com>
+Richard <richard.scothern@gmail.com>
+Shreyas Karnik <karnik.shreyas@gmail.com>
 Stephen J Day <stephen.day@docker.com>
 Tianon Gravi <admwiggin@gmail.com>
 xiekeyang <xiekeyang@huawei.com>

--- a/context/http.go
+++ b/context/http.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"code.google.com/p/go-uuid/uuid"
+	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"golang.org/x/net/context"
 )
@@ -18,6 +19,14 @@ var (
 	ErrNoRequestContext = errors.New("no http request in context")
 )
 
+func parseIP(ipStr string) net.IP {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		log.Warnf("invalid remote IP address: %q", ipStr)
+	}
+	return ip
+}
+
 // RemoteAddr extracts the remote address of the request, taking into
 // account proxy headers.
 func RemoteAddr(r *http.Request) string {
@@ -25,7 +34,7 @@ func RemoteAddr(r *http.Request) string {
 		proxies := strings.Split(prior, ",")
 		if len(proxies) > 0 {
 			remoteAddr := strings.Trim(proxies[0], " ")
-			if net.ParseIP(remoteAddr) != nil {
+			if parseIP(remoteAddr) != nil {
 				return remoteAddr
 			}
 		}
@@ -33,7 +42,7 @@ func RemoteAddr(r *http.Request) string {
 	// X-Real-Ip is less supported, but worth checking in the
 	// absence of X-Forwarded-For
 	if realIP := r.Header.Get("X-Real-Ip"); realIP != "" {
-		if net.ParseIP(realIP) != nil {
+		if parseIP(realIP) != nil {
 			return realIP
 		}
 	}

--- a/context/http_test.go
+++ b/context/http_test.go
@@ -2,6 +2,9 @@ package context
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -204,4 +207,48 @@ func TestWithVars(t *testing.T) {
 			t.Fatalf("%q: %v != %v", testcase.key, v, testcase.expected)
 		}
 	}
+}
+
+// SingleHostReverseProxy will insert an X-Forwarded-For header, and can be used to test
+// RemoteAddr().  A fake RemoteAddr cannot be set on the HTTP request - it is overwritten
+// at the transport layer to 127.0.0.1:<port> .  However, as the X-Forwarded-For header
+// just contains the IP address, it is different enough for testing.
+func TestRemoteAddr(t *testing.T) {
+	expectedRemote := "127.0.0.1"
+	var actualRemote string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		if r.RemoteAddr == expectedRemote {
+			t.Errorf("Unexpected matching remote addresses")
+		}
+		actualRemote = RemoteAddr(r)
+
+		if expectedRemote != actualRemote {
+			t.Errorf("Mismatching remote hosts: %v != %v", expectedRemote, actualRemote)
+		}
+
+		w.WriteHeader(200)
+	}))
+
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(backendURL)
+	frontend := httptest.NewServer(proxy)
+	defer frontend.Close()
+
+	getReq, err := http.NewRequest("GET", frontend.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 }

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -6,6 +6,7 @@ import (
 
 	"code.google.com/p/go-uuid/uuid"
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 )
@@ -42,10 +43,11 @@ func NewBridge(ub URLBuilder, source SourceRecord, actor ActorRecord, request Re
 
 // NewRequestRecord builds a RequestRecord for use in NewBridge from an
 // http.Request, associating it with a request id.
+
 func NewRequestRecord(id string, r *http.Request) RequestRecord {
 	return RequestRecord{
 		ID:        id,
-		Addr:      r.RemoteAddr,
+		Addr:      context.RemoteAddr(r),
 		Host:      r.Host,
 		Method:    r.Method,
 		UserAgent: r.UserAgent(),

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -43,7 +43,6 @@ func NewBridge(ub URLBuilder, source SourceRecord, actor ActorRecord, request Re
 
 // NewRequestRecord builds a RequestRecord for use in NewBridge from an
 // http.Request, associating it with a request id.
-
 func NewRequestRecord(id string, r *http.Request) RequestRecord {
 	return RequestRecord{
 		ID:        id,


### PR DESCRIPTION
Add a function to examine X-Forward-For and X-Real-Ip headers for
originating IP addresses.  Use RemoteAddr for notification request
record and HTTP request context.

Closes #298.