### PR TITLE
registry/storage/driver/inmemory: avoid crash on invalid Move arguments

### DIFF
--- a/registry/storage/driver/inmemory/mfs.go
+++ b/registry/storage/driver/inmemory/mfs.go
@@ -212,12 +212,17 @@ func (d *dir) move(src, dst string) error {
 		return errNotExists
 	}
 
-	s, ok := sp.(*dir).children[srcFilename]
+	spd, ok := sp.(*dir)
+	if !ok {
+		return errIsNotDir // paranoid.
+	}
+
+	s, ok := spd.children[srcFilename]
 	if !ok {
 		return errNotExists
 	}
 
-	delete(sp.(*dir).children, srcFilename)
+	delete(spd.children, srcFilename)
 
 	switch n := s.(type) {
 	case *dir:

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
-
 	"gopkg.in/check.v1"
 )
 
@@ -589,6 +588,20 @@ func (suite *DriverSuite) TestMoveNonexistent(c *check.C) {
 	received, err := suite.StorageDriver.GetContent(destPath)
 	c.Assert(err, check.IsNil)
 	c.Assert(received, check.DeepEquals, contents)
+}
+
+// TestMoveInvalid provides various checks for invalid moves.
+func (suite *DriverSuite) TestMoveInvalid(c *check.C) {
+	contents := randomContents(32)
+
+	// Create a regular file.
+	err := suite.StorageDriver.PutContent("/notadir", contents)
+	c.Assert(err, check.IsNil)
+	defer suite.StorageDriver.Delete("/notadir")
+
+	// Now try to move a non-existent file under it.
+	err = suite.StorageDriver.Move("/notadir/foo", "/notadir/bar")
+	c.Assert(err, check.NotNil) // non-nil error
 }
 
 // TestDelete checks that the delete operation removes data from the storage


### PR DESCRIPTION
This chnage prevents a crash when moving from a non-existent directory that has
a file as a parent. To prevent this, we simply check that the node is a
directory and throws an error if it is not.

Signed-off-by: Stephen J Day <stephen.day@docker.com>