### PR TITLE
context: correctly reference context object

### DIFF
--- a/context/logger.go
+++ b/context/logger.go
@@ -47,14 +47,14 @@ func WithLogger(ctx Context, logger Logger) Context {
 // GetLoggerWithField returns a logger instance with the specified field key
 // and value without affecting the context. Extra specified keys will be
 // resolved from the context.
-func GetLoggerWithField(ctx context.Context, key, value interface{}, keys ...interface{}) Logger {
+func GetLoggerWithField(ctx Context, key, value interface{}, keys ...interface{}) Logger {
 	return getLogrusLogger(ctx, keys...).WithField(fmt.Sprint(key), value)
 }
 
 // GetLoggerWithFields returns a logger instance with the specified fields
 // without affecting the context. Extra specified keys will be resolved from
 // the context.
-func GetLoggerWithFields(ctx context.Context, fields map[string]interface{}, keys ...interface{}) Logger {
+func GetLoggerWithFields(ctx Context, fields map[string]interface{}, keys ...interface{}) Logger {
 	return getLogrusLogger(ctx, keys...).WithFields(logrus.Fields(fields))
 }
 


### PR DESCRIPTION
This fixes the build after a bad merge.

Signed-off-by: Stephen J Day <stephen.day@docker.com>