### PR TITLE
Use entrypoint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM golang:1.4
 
-ENV CONFIG_PATH /etc/docker/registry/config.yml
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
 ENV GOPATH $DISTRIBUTION_DIR/Godeps/_workspace:$GOPATH
 
 WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
 RUN make PREFIX=/go clean binaries
-RUN mkdir -pv "$(dirname $CONFIG_PATH)"
-RUN cp -lv ./cmd/registry/config.yml $CONFIG_PATH
 
 EXPOSE 5000
-CMD registry $CONFIG_PATH
+ENTRYPOINT ["registry"]
+CMD ["cmd/registry/config.yml"]


### PR DESCRIPTION
Fixes #319.

Environment variables don't work in the command when an entrypoint is used because it isn't executed by a shell so I've removed `CONFIG_PATH`. Any suggestions on how to bring it back are welcome...