### PR TITLE
Add docker compose configuration for v1 and v2

### DIFF
--- a/contrib/compose/README.md
+++ b/contrib/compose/README.md
@@ -1,0 +1,23 @@
+# Docker Compose V1 + V2 registry
+
+This compose configuration will setup a v1 and v2 registry behind an nginx
+proxy. By default the combined registry may be accessed at localhost:5000.
+This registry does not support pushing images to v2 and pull from v1. Clients
+from before 1.6 will be configured to use the v1 registry, and newer clients
+will use the v2 registry.
+
+## Prerequisites
+Install [docker-compose](https://github.com/docker/compose)
+
+## How to run
+```
+$ docker-compose up
+```
+
+## How to push images
+From a local project directory with Dockerfile
+```
+$ docker build -t localhost:5000/myimage .
+$ docker push localhost:5000/myimage
+```
+

--- a/contrib/compose/docker-compose.yml
+++ b/contrib/compose/docker-compose.yml
@@ -1,0 +1,15 @@
+nginx:
+  build: "nginx"
+  ports:
+    - "5000:5000"
+  links:
+    - registryv1:registryv1
+    - registryv2:registryv2
+registryv1:
+  image: registry
+  ports:
+    - "5000"
+registryv2:
+  build: "../../"
+  ports:
+    - "5000"

--- a/contrib/compose/nginx/Dockerfile
+++ b/contrib/compose/nginx/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.7
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY registry.conf /etc/nginx/conf.d/registry.conf
+COPY docker-registry.conf /etc/nginx/docker-registry.conf
+COPY docker-registry-v2.conf /etc/nginx/docker-registry-v2.conf

--- a/contrib/compose/nginx/docker-registry-v2.conf
+++ b/contrib/compose/nginx/docker-registry-v2.conf
@@ -1,0 +1,4 @@
+proxy_pass                       http://docker-registry-v2;
+proxy_set_header  Host           $http_host;   # required for docker client's sake
+proxy_set_header  X-Real-IP      $remote_addr; # pass on real client's IP
+proxy_read_timeout               900;

--- a/contrib/compose/nginx/docker-registry.conf
+++ b/contrib/compose/nginx/docker-registry.conf
@@ -1,0 +1,5 @@
+proxy_pass                       http://docker-registry;
+proxy_set_header  Host           $http_host;   # required for docker client's sake
+proxy_set_header  X-Real-IP      $remote_addr; # pass on real client's IP
+proxy_set_header  Authorization  ""; # see https://github.com/docker/docker-registry/issues/170
+proxy_read_timeout               900;

--- a/contrib/compose/nginx/nginx.conf
+++ b/contrib/compose/nginx/nginx.conf
@@ -1,0 +1,27 @@
+user  nginx;
+worker_processes  1;
+
+error_log /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+

--- a/contrib/compose/nginx/registry.conf
+++ b/contrib/compose/nginx/registry.conf
@@ -1,0 +1,36 @@
+# Docker registry proxy for api versions 1 and 2
+
+upstream docker-registry {
+  server registryv1:5000;
+}
+
+upstream docker-registry-v2 {
+  server registryv2:5000;
+}
+
+# No client auth or TLS
+server {
+  listen 5000;
+  server_name localhost;
+
+  # disable any limits to avoid HTTP 413 for large image uploads
+  client_max_body_size 0;
+
+  # required to avoid HTTP 411: see Issue #1486 (https://github.com/docker/docker/issues/1486)
+  chunked_transfer_encoding on;
+
+  location /v2/ {
+    # Do not allow connections from docker 1.5 and earlier
+    # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
+    if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*$" ) {
+      return 404;
+    }
+
+    include               docker-registry-v2.conf;
+  }
+
+  location / {
+    include               docker-registry.conf;
+  }
+}
+


### PR DESCRIPTION
Add nginx configuration to proxy to both a v1 and v2 registry. Nginx is configured to force 1.5 clients to use the v1 registry.

Currently does not use official v2 image