### PR TITLE
registry/storage/driver: defer case-sensitive support to storage backend

### DIFF
--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -83,7 +83,7 @@ type StorageDriver interface {
 // number of path components separated by slashes, where each component is
 // restricted to lowercase alphanumeric characters or a period, underscore, or
 // hyphen.
-var PathRegexp = regexp.MustCompile(`^(/[a-z0-9._-]+)+$`)
+var PathRegexp = regexp.MustCompile(`^(/[A-Za-z0-9._-]+)+$`)
 
 // ErrUnsupportedMethod may be returned in the case where a StorageDriver implementation does not support an optional method.
 var ErrUnsupportedMethod = errors.New("unsupported method")

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -136,7 +136,9 @@ func (suite *DriverSuite) TestValidPaths(c *check.C) {
 		"/.abc",
 		"/a--b",
 		"/a-.b",
-		"/_.abc"}
+		"/_.abc",
+		"/Docker/docker-registry",
+		"/Abc/Cba"}
 
 	for _, filename := range validFiles {
 		err := suite.StorageDriver.PutContent(filename, contents)
@@ -159,8 +161,7 @@ func (suite *DriverSuite) TestInvalidPaths(c *check.C) {
 		"abc",
 		"123.abc",
 		"//bcd",
-		"/abc_123/",
-		"/Docker/docker-registry"}
+		"/abc_123/"}
 
 	for _, filename := range invalidFiles {
 		err := suite.StorageDriver.PutContent(filename, contents)


### PR DESCRIPTION
Rather than enforce lowercase paths for all drivers, support for
case-sensitivity has been deferred to the driver. There are a few caveats to
this approach:

1. There are possible security implications for tags that only differ in their
    case. For instance, a tag "A" may be equivalent to tag "a" on certain file
    system backends.
2. All system paths should not use case-sensitive identifiers where possible.
    This might be problematic in a blob store that uses case-sensitive ids. For
    now, since digest hex ids are all case-insensitive, this will not be an issue.

The recommend workaround is to not run the registry on a case-insensitive
filesystem driver in security sensitive applications.

Signed-off-by: Stephen J Day <stephen.day@docker.com>