### PR TITLE
Adds omitempty to several configuration fields

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -24,16 +24,16 @@ type Configuration struct {
 
 		// Formatter overrides the default formatter with another. Options
 		// include "text", "json" and "logstash".
-		Formatter string `yaml:"formatter"`
+		Formatter string `yaml:"formatter,omitempty"`
 
 		// Fields allows users to specify static string fields to include in
 		// the logger context.
-		Fields map[string]interface{} `yaml:"fields"`
+		Fields map[string]interface{} `yaml:"fields,omitempty"`
 	}
 
 	// Loglevel is the level at which registry operations are logged. This is
 	// deprecated. Please use Log.Level in the future.
-	Loglevel Loglevel `yaml:"loglevel"`
+	Loglevel Loglevel `yaml:"loglevel,omitempty"`
 
 	// Storage is the configuration for the registry's storage driver
 	Storage Storage `yaml:"storage"`

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -18,8 +18,8 @@ var configStruct = Configuration{
 	Version: "0.1",
 	Log: struct {
 		Level     Loglevel               `yaml:"level"`
-		Formatter string                 `yaml:"formatter"`
-		Fields    map[string]interface{} `yaml:"fields"`
+		Formatter string                 `yaml:"formatter,omitempty"`
+		Fields    map[string]interface{} `yaml:"fields,omitempty"`
 	}{
 		Fields: map[string]interface{}{"environment": "test"},
 	},


### PR DESCRIPTION
Includes deprecated Loglevel, Log.Formatter, and Log.Fields