### PR TITLE
Prevent Close() from being called after Finish()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ Andrey Kostov <kostov.andrey@gmail.com>
 Andy Goldstein <agoldste@redhat.com>
 Anton Tiurin <noxiouz@yandex.ru>
 Arnaud Porterie <arnaud.porterie@docker.com>
+Ben Firshman <ben@firshman.co.uk>
 Brian Bland <brian.bland@docker.com>
 David Lawrence <david.lawrence@docker.com>
 Derek McGowan <derek@mcgstyle.net>
@@ -11,11 +12,13 @@ Diogo Mónica <diogo.monica@gmail.com>
 Donald Huang <don.hcd@gmail.com>
 Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
 Josh Hawn <josh.hawn@docker.com>
+Mary Anthony <mary@docker.com>
+Nathan Sullivan <nathan@nightsys.net>
 Nghia Tran <tcnghia@gmail.com>
 Olivier Gambier <olivier@docker.com>
 Richard <richard.scothern@gmail.com>
 Shreyas Karnik <karnik.shreyas@gmail.com>
+Simon Thulbourn <simon+github@thulbourn.com>
 Stephen J Day <stephen.day@docker.com>
 Tianon Gravi <admwiggin@gmail.com>
 xiekeyang <xiekeyang@huawei.com>
-Mary Anthony <mary.anthony@docker.com>

--- a/registry/storage/layerwriter.go
+++ b/registry/storage/layerwriter.go
@@ -109,6 +109,10 @@ func (lw *layerWriter) ReadFrom(r io.Reader) (n int64, err error) {
 }
 
 func (lw *layerWriter) Close() error {
+	if lw.err != nil {
+		return lw.err
+	}
+
 	if err := lw.storeHashState(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Close() writes hash state to the filesystem.  If Finish has already been called, return the underlying error to prevent this.