### PR TITLE
Update nginx proxy setting to set forward headers

### DIFF
--- a/contrib/compose/nginx/docker-registry-v2.conf
+++ b/contrib/compose/nginx/docker-registry-v2.conf
@@ -1,4 +1,6 @@
-proxy_pass                       http://docker-registry-v2;
-proxy_set_header  Host           $http_host;   # required for docker client's sake
-proxy_set_header  X-Real-IP      $remote_addr; # pass on real client's IP
-proxy_read_timeout               900;
+proxy_pass                          http://docker-registry-v2;
+proxy_set_header  Host              $http_host;   # required for docker client's sake
+proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header  X-Forwarded-Proto $scheme;
+proxy_read_timeout                  900;

--- a/contrib/compose/nginx/docker-registry.conf
+++ b/contrib/compose/nginx/docker-registry.conf
@@ -1,5 +1,7 @@
-proxy_pass                       http://docker-registry;
-proxy_set_header  Host           $http_host;   # required for docker client's sake
-proxy_set_header  X-Real-IP      $remote_addr; # pass on real client's IP
-proxy_set_header  Authorization  ""; # see https://github.com/docker/docker-registry/issues/170
-proxy_read_timeout               900;
+proxy_pass                          http://docker-registry;
+proxy_set_header  Host              $http_host;   # required for docker client's sake
+proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header  X-Forwarded-Proto $scheme;
+proxy_set_header  Authorization     ""; # see https://github.com/docker/docker-registry/issues/170
+proxy_read_timeout                  900;


### PR DESCRIPTION
Set forward headers so the IP and scheme get sent to the registry. This allows the registry to set a proper redirect with the correct scheme when HTTPS is being used.
