### PR TITLE
cmd/registry: correctly log application version

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -47,6 +47,7 @@ func main() {
 	}
 
 	ctx := context.Background()
+	ctx = context.WithValue(ctx, "version", version.Version)
 
 	config, err := resolveConfiguration()
 	if err != nil {
@@ -226,7 +227,7 @@ func configureLogging(ctx context.Context, config *configuration.Configuration) 
 	}
 
 	// log the application version with messages
-	ctx = context.WithValue(ctx, "version", version.Version)
+	ctx = context.WithLogger(ctx, context.GetLogger(ctx, "version"))
 
 	if len(config.Log.Fields) > 0 {
 		// build up the static fields, if present.


### PR DESCRIPTION
This was a regression from some changes made to the logging setup.

Example output:

```
INFO[0000] endpoint local-8082 disabled, skipping        environment=development instance.id=8cd53d89-d823-4ed4-8afa-1e034ecb1900 service=registry version=v2.0.0-rc.3-3-g600de20.m
INFO[0000] endpoint local-8083 disabled, skipping        environment=development instance.id=8cd53d89-d823-4ed4-8afa-1e034ecb1900 service=registry version=v2.0.0-rc.3-3-g600de20.m
INFO[0000] using inmemory layerinfo cache                environment=development instance.id=8cd53d89-d823-4ed4-8afa-1e034ecb1900 service=registry version=v2.0.0-rc.3-3-g600de20.m
INFO[0000] listening on :5000                            environment=development instance.id=8cd53d89-d823-4ed4-8afa-1e034ecb1900 service=registry version=v2.0.0-rc.3-3-g600de20.m
```

Signed-off-by: Stephen J Day <stephen.day@docker.com>