### PR TITLE
context, registry/handlers: instantiate http context before dispatch

### DIFF
--- a/context/http.go
+++ b/context/http.go
@@ -15,7 +15,8 @@ import (
 
 // Common errors used with this package.
 var (
-	ErrNoRequestContext = errors.New("no http request in context")
+	ErrNoRequestContext        = errors.New("no http request in context")
+	ErrNoResponseWriterContext = errors.New("no http response in context")
 )
 
 func parseIP(ipStr string) net.IP {
@@ -108,6 +109,20 @@ func WithResponseWriter(ctx Context, w http.ResponseWriter) (Context, http.Respo
 	}
 
 	return irw, irw
+}
+
+// GetResponseWriter returns the http.ResponseWriter from the provided
+// context. If not present, ErrNoResponseWriterContext is returned. The
+// returned instance provides instrumentation in the context.
+func GetResponseWriter(ctx Context) (http.ResponseWriter, error) {
+	v := ctx.Value("http.response")
+
+	rw, ok := v.(http.ResponseWriter)
+	if !ok || rw == nil {
+		return nil, ErrNoResponseWriterContext
+	}
+
+	return rw, nil
 }
 
 // getVarsFromRequest let's us change request vars implementation for testing


### PR DESCRIPTION
Ensure that the status is logged in the context by instantiating before the request is routed to handlers. While this requires some level of hacking to achieve, the result is that the context value of "http.request.status" is as accurate as possible for each request.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #356