### PR TITLE
feature of web panic handler

### DIFF
--- a/cmd/registry/config.yml
+++ b/cmd/registry/config.yml
@@ -4,6 +4,16 @@ log:
   fields:
     service: registry
     environment: development
+handlers:
+    error:
+      - type: email
+        smtp_host: mail.example.com
+        smtp_port: 25
+        smtp_login: mailuser
+        smtp_password: password
+        smtp_insecure: true
+        from_addr: registry@$HOSTNAME
+        to_addr: errors@example.com
 storage:
     cache:
         layerinfo: inmemory
@@ -39,3 +49,8 @@ notifications:
           threshold: 10
           backoff: 1s
           disabled: true
+reporting:
+  bugsnag:
+      apikey: 
+      releasestage: production
+      endpoint: localhost:7092 

--- a/cmd/registry/webpanic_test.go
+++ b/cmd/registry/webpanic_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	log "github.com/Sirupsen/logrus"
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/docker/distribution/registry/handlers"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+var (
+	exceptPanic = "It is test Panic!"
+	exceptError = "It is test Error!"
+)
+
+func TestWebPanic(t *testing.T) {
+	var app handlers.App
+	app.Config.Reporting.Bugsnag.APIKey = "12345678901234567890123456789012"
+	app.Config.Reporting.Bugsnag.Endpoint = "localhost:7092"
+	app.Config.Reporting.Bugsnag.ReleaseStage = "production"
+	if err := configureReportingBugsnag(&app); err != nil {
+		t.Fatalf("%v", err)
+	}
+	portMap := strings.Split(app.Config.Reporting.Bugsnag.Endpoint, ":")
+	port := ":" + portMap[1]
+	go http.ListenAndServe(port, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var notice struct {
+			Events []struct {
+				Exceptions []struct {
+					Message string `json:"message"`
+				} `json:"exceptions"`
+			} `json:"events"`
+		}
+		data, _ := ioutil.ReadAll(r.Body)
+		if err := json.Unmarshal(data, &notice); err != nil {
+			log.Error(err)
+			return
+		}
+		_ = r.Body.Close()
+		if notice.Events[0].Exceptions[0].Message == exceptError {
+			t.Fatalf("Out of Panic Level!")
+		} else if notice.Events[0].Exceptions[0].Message != exceptPanic {
+			t.Fatalf("Unexcepted Info!")
+		}
+	}))
+
+	log.WithFields(log.Fields{
+		"error": errors.New(exceptError),
+	}).Error("Won't dispplay in handler")
+	defer bugsnag.Recover()
+	panic(exceptPanic)
+}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -121,6 +121,17 @@ type Configuration struct {
 			IdleTimeout time.Duration `yaml:"idletimeout,omitempty"`
 		} `yaml:"pool,omitempty"`
 	} `yaml:"redis,omitempty"`
+	Handlers struct {
+		Mail struct {
+			Host     string   `yaml:"smtp_host,omitempty"`
+			Port     string   `yaml:"smtp_port,omitempty"`
+			Login    string   `yaml:"smtp_login,omitempty"`
+			Password string   `yaml:"smtp_password,omitempty"`
+			Insecure bool     `yaml:"smtp_insecure,omitempty"`
+			FromAddr string   `yaml:"from_addr,omitempty"`
+			ToAddr   []string `yaml:"to_addr,omitempty"`
+		}
+	} `yaml:"handlers,omitempty"`
 }
 
 // v0_1Configuration is a Version 0.1 Configuration struct


### PR DESCRIPTION
@stevvooe 
This PR is for issue **email after registry webapp panic** #41.
It can snag panic, and emit notification by mail.
Please help to take a review. Any defect, please point out freely. Thanks a lot!

### Implementation Description
Change `bugsnag.Configure`, as ready to catch panic. Refer package description: it is "also responsible for installing the global panic handler".

New and Add `logrus_bugsnag hook` after configuration.

The above do in 'main.go', for "it should be called as early as possible in your initialization process" (in package description).

When panic happens, `bugsnag.Recover` is necessary, to call handler function.

```bash
defer bugsnag.Recover()
panic(exceptPanic)
``` 

process enters pre-setting http handler. In handler function, next steps be executed: 
* Parser http received message(panic info); 
* Send mail via `net/smtp` package;

the bugsnag package makes sure the loggers lower than panic level will not trig the hook.

Add the necessary items in` config.yml`, and `configuration.go`.

Unit test `webpanic_test.go` simulates the process successfully.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>