### PR TITLE
configuration/README.md: correct the environment variable key

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -117,7 +117,7 @@ To support the workflow of running a docker registry from a standard container w
 
 Any configuration field other than version can be replaced by providing an environment variable of the following form: `REGISTRY_<uppercase key>[_<uppercase key>]...`.
 
-For example, to change the loglevel to `error`, one can provide `REGISTRY_LOGLEVEL=error`, and to change the s3 storage driver's region parameter to `us-west-1`, one can provide `REGISTRY_STORAGE_S3_LOGLEVEL=us-west-1`.
+For example, to change the loglevel to `error`, one can provide `REGISTRY_LOGLEVEL=error`, and to change the s3 storage driver's region parameter to `us-west-1`, one can provide `REGISTRY_STORAGE_S3_REGION=us-west-1`.
 
 ### Notes
 If an environment variable changes a map value into a string, such as replacing the storage driver type with `REGISTRY_STORAGE=filesystem`, then all sub-fields will be erased. As such, specifying the storage type in the environment will remove all parameters related to the old storage configuration.


### PR DESCRIPTION
The docs refer to region, but the environment variable used loglevel