### PR TITLE
Fixed links for storage drivers

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,3 +7,7 @@
 - ['registry/spec/json.md', 'Reference', '&nbsp;&nbsp;&nbsp;&nbsp;&blacksquare;&nbsp; JSON format' ]
 - ['registry/spec/auth/token.md', 'Reference', '&nbsp;&nbsp;&nbsp;&nbsp;&blacksquare;&nbsp; Authenticate via central service' ]
 
+- ['registry/storage-drivers/azure.md', 'HIDDEN' ]
+- ['registry/storage-drivers/filesystem.md', 'HIDDEN' ]
+- ['registry/storage-drivers/inmemory.md', 'HIDDEN' ]
+- ['registry/storage-drivers/s3.md', 'Reference', 'HIDDEN' ]

--- a/docs/storagedrivers.md
+++ b/docs/storagedrivers.md
@@ -8,10 +8,10 @@ Provided Drivers
 
 This storage driver package comes bundled with several drivers:
 
-- [inmemory](storage-drivers/inmemory): A temporary storage driver using a local inmemory map. This exists solely for reference and testing.
-- [filesystem](storage-drivers/filesystem): A local storage driver configured to use a directory tree in the local filesystem.
-- [s3](storage-drivers/s3): A driver storing objects in an Amazon Simple Storage Solution (S3) bucket.
-- [azure](storage-drivers/azure): A driver storing objects in [Microsoft Azure Blob Storage](http://azure.microsoft.com/en-us/services/storage/).
+- [inmemory](storage-drivers/inmemory.md): A temporary storage driver using a local inmemory map. This exists solely for reference and testing.
+- [filesystem](storage-drivers/filesystem.md): A local storage driver configured to use a directory tree in the local filesystem.
+- [s3](storage-drivers/s3.md): A driver storing objects in an Amazon Simple Storage Solution (S3) bucket.
+- [azure](storage-drivers/azure.md): A driver storing objects in [Microsoft Azure Blob Storage](http://azure.microsoft.com/en-us/services/storage/).
 
 Storage Driver API
 ==================


### PR DESCRIPTION
Side note: after reading docs it seems like v2 is still far in the future and incomplete. It make sense to proof-read docs by someone who wasn't working on the spec directly to fix that.