### PR TITLE
Add golang/x/net/context.Context to storage driver method calls

### DIFF
--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -17,11 +17,12 @@ import (
 )
 
 func TestListener(t *testing.T) {
-	registry := storage.NewRegistryWithDriver(inmemory.New(), cache.NewInMemoryLayerInfoCache())
+	ctx := context.Background()
+	registry := storage.NewRegistryWithDriver(ctx, inmemory.New(), cache.NewInMemoryLayerInfoCache())
 	tl := &testListener{
 		ops: make(map[string]int),
 	}
-	ctx := context.Background()
+
 	repository, err := registry.Repository(ctx, "foo/bar")
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -24,12 +24,13 @@ import (
 // tested individually.
 func TestAppDispatcher(t *testing.T) {
 	driver := inmemory.New()
+	ctx := context.Background()
 	app := &App{
 		Config:   configuration.Configuration{},
-		Context:  context.Background(),
+		Context:  ctx,
 		router:   v2.Router(),
 		driver:   driver,
-		registry: storage.NewRegistryWithDriver(driver, cache.NewInMemoryLayerInfoCache()),
+		registry: storage.NewRegistryWithDriver(ctx, driver, cache.NewInMemoryLayerInfoCache()),
 	}
 	server := httptest.NewServer(app)
 	router := v2.Router()

--- a/registry/handlers/layer.go
+++ b/registry/handlers/layer.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/docker/distribution"
-	ctxu "github.com/docker/distribution/context"
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/gorilla/handlers"
@@ -48,7 +48,7 @@ type layerHandler struct {
 // GetLayer fetches the binary data from backend storage returns it in the
 // response.
 func (lh *layerHandler) GetLayer(w http.ResponseWriter, r *http.Request) {
-	ctxu.GetLogger(lh).Debug("GetImageLayer")
+	context.GetLogger(lh).Debug("GetImageLayer")
 	layers := lh.Repository.Layers()
 	layer, err := layers.Fetch(lh.Digest)
 
@@ -65,7 +65,7 @@ func (lh *layerHandler) GetLayer(w http.ResponseWriter, r *http.Request) {
 
 	handler, err := layer.Handler(r)
 	if err != nil {
-		ctxu.GetLogger(lh).Debugf("unexpected error getting layer HTTP handler: %s", err)
+		context.GetLogger(lh).Debugf("unexpected error getting layer HTTP handler: %s", err)
 		lh.Errors.Push(v2.ErrorCodeUnknown, err)
 		return
 	}

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -51,32 +51,32 @@ type Base struct {
 }
 
 // GetContent wraps GetContent of underlying storage driver.
-func (base *Base) GetContent(path string) ([]byte, error) {
-	_, done := context.WithTrace(context.Background())
+func (base *Base) GetContent(ctx context.Context, path string) ([]byte, error) {
+	ctx, done := context.WithTrace(ctx)
 	defer done("%s.GetContent(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return nil, storagedriver.InvalidPathError{Path: path}
 	}
 
-	return base.StorageDriver.GetContent(path)
+	return base.StorageDriver.GetContent(ctx, path)
 }
 
 // PutContent wraps PutContent of underlying storage driver.
-func (base *Base) PutContent(path string, content []byte) error {
-	_, done := context.WithTrace(context.Background())
+func (base *Base) PutContent(ctx context.Context, path string, content []byte) error {
+	ctx, done := context.WithTrace(context.Background())
 	defer done("%s.PutContent(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return storagedriver.InvalidPathError{Path: path}
 	}
 
-	return base.StorageDriver.PutContent(path, content)
+	return base.StorageDriver.PutContent(ctx, path, content)
 }
 
 // ReadStream wraps ReadStream of underlying storage driver.
-func (base *Base) ReadStream(path string, offset int64) (io.ReadCloser, error) {
-	_, done := context.WithTrace(context.Background())
+func (base *Base) ReadStream(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
+	ctx, done := context.WithTrace(context.Background())
 	defer done("%s.ReadStream(%q, %d)", base.Name(), path, offset)
 
 	if offset < 0 {
@@ -87,12 +87,12 @@ func (base *Base) ReadStream(path string, offset int64) (io.ReadCloser, error) {
 		return nil, storagedriver.InvalidPathError{Path: path}
 	}
 
-	return base.StorageDriver.ReadStream(path, offset)
+	return base.StorageDriver.ReadStream(ctx, path, offset)
 }
 
 // WriteStream wraps WriteStream of underlying storage driver.
-func (base *Base) WriteStream(path string, offset int64, reader io.Reader) (nn int64, err error) {
-	_, done := context.WithTrace(context.Background())
+func (base *Base) WriteStream(ctx context.Context, path string, offset int64, reader io.Reader) (nn int64, err error) {
+	ctx, done := context.WithTrace(ctx)
 	defer done("%s.WriteStream(%q, %d)", base.Name(), path, offset)
 
 	if offset < 0 {
@@ -103,36 +103,36 @@ func (base *Base) WriteStream(path string, offset int64, reader io.Reader) (nn i
 		return 0, storagedriver.InvalidPathError{Path: path}
 	}
 
-	return base.StorageDriver.WriteStream(path, offset, reader)
+	return base.StorageDriver.WriteStream(ctx, path, offset, reader)
 }
 
 // Stat wraps Stat of underlying storage driver.
-func (base *Base) Stat(path string) (storagedriver.FileInfo, error) {
-	_, done := context.WithTrace(context.Background())
+func (base *Base) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
+	ctx, done := context.WithTrace(ctx)
 	defer done("%s.Stat(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return nil, storagedriver.InvalidPathError{Path: path}
 	}
 
-	return base.StorageDriver.Stat(path)
+	return base.StorageDriver.Stat(ctx, path)
 }
 
 // List wraps List of underlying storage driver.
-func (base *Base) List(path string) ([]string, error) {
-	_, done := context.WithTrace(context.Background())
+func (base *Base) List(ctx context.Context, path string) ([]string, error) {
+	ctx, done := context.WithTrace(ctx)
 	defer done("%s.List(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) && path != "/" {
 		return nil, storagedriver.InvalidPathError{Path: path}
 	}
 
-	return base.StorageDriver.List(path)
+	return base.StorageDriver.List(ctx, path)
 }
 
 // Move wraps Move of underlying storage driver.
-func (base *Base) Move(sourcePath string, destPath string) error {
-	_, done := context.WithTrace(context.Background())
+func (base *Base) Move(ctx context.Context, sourcePath string, destPath string) error {
+	ctx, done := context.WithTrace(ctx)
 	defer done("%s.Move(%q, %q", base.Name(), sourcePath, destPath)
 
 	if !storagedriver.PathRegexp.MatchString(sourcePath) {
@@ -141,29 +141,29 @@ func (base *Base) Move(sourcePath string, destPath string) error {
 		return storagedriver.InvalidPathError{Path: destPath}
 	}
 
-	return base.StorageDriver.Move(sourcePath, destPath)
+	return base.StorageDriver.Move(ctx, sourcePath, destPath)
 }
 
 // Delete wraps Delete of underlying storage driver.
-func (base *Base) Delete(path string) error {
-	_, done := context.WithTrace(context.Background())
+func (base *Base) Delete(ctx context.Context, path string) error {
+	ctx, done := context.WithTrace(ctx)
 	defer done("%s.Delete(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return storagedriver.InvalidPathError{Path: path}
 	}
 
-	return base.StorageDriver.Delete(path)
+	return base.StorageDriver.Delete(ctx, path)
 }
 
 // URLFor wraps URLFor of underlying storage driver.
-func (base *Base) URLFor(path string, options map[string]interface{}) (string, error) {
-	_, done := context.WithTrace(context.Background())
+func (base *Base) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+	ctx, done := context.WithTrace(ctx)
 	defer done("%s.URLFor(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return "", storagedriver.InvalidPathError{Path: path}
 	}
 
-	return base.StorageDriver.URLFor(path, options)
+	return base.StorageDriver.URLFor(ctx, path, options)
 }

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/base"
 	"github.com/docker/distribution/registry/storage/driver/factory"
@@ -69,11 +70,11 @@ func (d *driver) Name() string {
 }
 
 // GetContent retrieves the content stored at "path" as a []byte.
-func (d *driver) GetContent(path string) ([]byte, error) {
+func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
-	rc, err := d.ReadStream(path, 0)
+	rc, err := d.ReadStream(ctx, path, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ func (d *driver) GetContent(path string) ([]byte, error) {
 }
 
 // PutContent stores the []byte content at a location designated by "path".
-func (d *driver) PutContent(p string, contents []byte) error {
+func (d *driver) PutContent(ctx context.Context, p string, contents []byte) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -102,7 +103,7 @@ func (d *driver) PutContent(p string, contents []byte) error {
 
 // ReadStream retrieves an io.ReadCloser for the content stored at "path" with a
 // given byte offset.
-func (d *driver) ReadStream(path string, offset int64) (io.ReadCloser, error) {
+func (d *driver) ReadStream(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
@@ -126,7 +127,7 @@ func (d *driver) ReadStream(path string, offset int64) (io.ReadCloser, error) {
 
 // WriteStream stores the contents of the provided io.ReadCloser at a location
 // designated by the given path.
-func (d *driver) WriteStream(path string, offset int64, reader io.Reader) (nn int64, err error) {
+func (d *driver) WriteStream(ctx context.Context, path string, offset int64, reader io.Reader) (nn int64, err error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -167,7 +168,7 @@ func (d *driver) WriteStream(path string, offset int64, reader io.Reader) (nn in
 }
 
 // Stat returns info about the provided path.
-func (d *driver) Stat(path string) (storagedriver.FileInfo, error) {
+func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
@@ -193,7 +194,7 @@ func (d *driver) Stat(path string) (storagedriver.FileInfo, error) {
 
 // List returns a list of the objects that are direct descendants of the given
 // path.
-func (d *driver) List(path string) ([]string, error) {
+func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
@@ -223,7 +224,7 @@ func (d *driver) List(path string) ([]string, error) {
 
 // Move moves an object stored at sourcePath to destPath, removing the original
 // object.
-func (d *driver) Move(sourcePath string, destPath string) error {
+func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -239,7 +240,7 @@ func (d *driver) Move(sourcePath string, destPath string) error {
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
-func (d *driver) Delete(path string) error {
+func (d *driver) Delete(ctx context.Context, path string) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
@@ -256,6 +257,6 @@ func (d *driver) Delete(path string) error {
 
 // URLFor returns a URL which may be used to retrieve the content stored at the given path.
 // May return an UnsupportedMethodErr in certain StorageDriver implementations.
-func (d *driver) URLFor(path string, options map[string]interface{}) (string, error) {
+func (d *driver) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
 	return "", storagedriver.ErrUnsupportedMethod
 }

--- a/registry/storage/driver/middleware/cloudfront/middleware.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware.go
@@ -98,12 +98,12 @@ type S3BucketKeyer interface {
 
 // Resolve returns an http.Handler which can serve the contents of the given
 // Layer, or an error if not supported by the storagedriver.
-func (lh *cloudFrontStorageMiddleware) URLFor(path string, options map[string]interface{}) (string, error) {
+func (lh *cloudFrontStorageMiddleware) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
 	// TODO(endophage): currently only supports S3
 	keyer, ok := lh.StorageDriver.(S3BucketKeyer)
 	if !ok {
-		context.GetLogger(context.Background()).Warn("the CloudFront middleware does not support this backend storage driver")
-		return lh.StorageDriver.URLFor(path, options)
+		context.GetLogger(ctx).Warn("the CloudFront middleware does not support this backend storage driver")
+		return lh.StorageDriver.URLFor(ctx, path, options)
 	}
 
 	cfURL, err := lh.cloudfront.CannedSignedURL(keyer.S3BucketKey(path), "", time.Now().Add(lh.duration))

--- a/registry/storage/driver/s3/s3.go
+++ b/registry/storage/driver/s3/s3.go
@@ -29,6 +29,8 @@ import (
 	"github.com/AdRoll/goamz/aws"
 	"github.com/AdRoll/goamz/s3"
 	"github.com/Sirupsen/logrus"
+
+	"github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/base"
 	"github.com/docker/distribution/registry/storage/driver/factory"
@@ -267,7 +269,7 @@ func (d *driver) Name() string {
 }
 
 // GetContent retrieves the content stored at "path" as a []byte.
-func (d *driver) GetContent(path string) ([]byte, error) {
+func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
 	content, err := d.Bucket.Get(d.s3Path(path))
 	if err != nil {
 		return nil, parseError(path, err)
@@ -276,13 +278,13 @@ func (d *driver) GetContent(path string) ([]byte, error) {
 }
 
 // PutContent stores the []byte content at a location designated by "path".
-func (d *driver) PutContent(path string, contents []byte) error {
+func (d *driver) PutContent(ctx context.Context, path string, contents []byte) error {
 	return parseError(path, d.Bucket.Put(d.s3Path(path), contents, d.getContentType(), getPermissions(), d.getOptions()))
 }
 
 // ReadStream retrieves an io.ReadCloser for the content stored at "path" with a
 // given byte offset.
-func (d *driver) ReadStream(path string, offset int64) (io.ReadCloser, error) {
+func (d *driver) ReadStream(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
 	headers := make(http.Header)
 	headers.Add("Range", "bytes="+strconv.FormatInt(offset, 10)+"-")
 
@@ -304,7 +306,7 @@ func (d *driver) ReadStream(path string, offset int64) (io.ReadCloser, error) {
 // returned. May be used to resume writing a stream by providing a nonzero
 // offset. Offsets past the current size will write from the position
 // beyond the end of the file.
-func (d *driver) WriteStream(path string, offset int64, reader io.Reader) (totalRead int64, err error) {
+func (d *driver) WriteStream(ctx context.Context, path string, offset int64, reader io.Reader) (totalRead int64, err error) {
 	partNumber := 1
 	bytesRead := 0
 	var putErrChan chan error
@@ -348,7 +350,7 @@ func (d *driver) WriteStream(path string, offset int64, reader io.Reader) (total
 
 	// Fills from 0 to total from current
 	fromSmallCurrent := func(total int64) error {
-		current, err := d.ReadStream(path, 0)
+		current, err := d.ReadStream(ctx, path, 0)
 		if err != nil {
 			return err
 		}
@@ -628,7 +630,7 @@ func (d *driver) WriteStream(path string, offset int64, reader io.Reader) (total
 
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
-func (d *driver) Stat(path string) (storagedriver.FileInfo, error) {
+func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
 	listResponse, err := d.Bucket.List(d.s3Path(path), "", "", 1)
 	if err != nil {
 		return nil, err
@@ -661,7 +663,7 @@ func (d *driver) Stat(path string) (storagedriver.FileInfo, error) {
 }
 
 // List returns a list of the objects that are direct descendants of the given path.
-func (d *driver) List(path string) ([]string, error) {
+func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 	if path != "/" && path[len(path)-1] != '/' {
 		path = path + "/"
 	}
@@ -706,7 +708,7 @@ func (d *driver) List(path string) ([]string, error) {
 
 // Move moves an object stored at sourcePath to destPath, removing the original
 // object.
-func (d *driver) Move(sourcePath string, destPath string) error {
+func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) error {
 	/* This is terrible, but aws doesn't have an actual move. */
 	_, err := d.Bucket.PutCopy(d.s3Path(destPath), getPermissions(),
 		s3.CopyOptions{Options: d.getOptions(), ContentType: d.getContentType()}, d.Bucket.Name+"/"+d.s3Path(sourcePath))
@@ -714,11 +716,11 @@ func (d *driver) Move(sourcePath string, destPath string) error {
 		return parseError(sourcePath, err)
 	}
 
-	return d.Delete(sourcePath)
+	return d.Delete(ctx, sourcePath)
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
-func (d *driver) Delete(path string) error {
+func (d *driver) Delete(ctx context.Context, path string) error {
 	listResponse, err := d.Bucket.List(d.s3Path(path), "", "", listMax)
 	if err != nil || len(listResponse.Contents) == 0 {
 		return storagedriver.PathNotFoundError{Path: path}
@@ -747,7 +749,7 @@ func (d *driver) Delete(path string) error {
 
 // URLFor returns a URL which may be used to retrieve the content stored at the given path.
 // May return an UnsupportedMethodErr in certain StorageDriver implementations.
-func (d *driver) URLFor(path string, options map[string]interface{}) (string, error) {
+func (d *driver) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
 	methodString := "GET"
 	method, ok := options["method"]
 	if ok {

--- a/registry/storage/driver/s3/s3_test.go
+++ b/registry/storage/driver/s3/s3_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/AdRoll/goamz/aws"
+	"github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/testsuites"
 
@@ -134,16 +135,17 @@ func (suite *S3DriverSuite) TestEmptyRootList(c *check.C) {
 
 	filename := "/test"
 	contents := []byte("contents")
-	err = rootedDriver.PutContent(filename, contents)
+	ctx := context.Background()
+	err = rootedDriver.PutContent(ctx, filename, contents)
 	c.Assert(err, check.IsNil)
-	defer rootedDriver.Delete(filename)
+	defer rootedDriver.Delete(ctx, filename)
 
-	keys, err := emptyRootDriver.List("/")
+	keys, err := emptyRootDriver.List(ctx, "/")
 	for _, path := range keys {
 		c.Assert(storagedriver.PathRegexp.MatchString(path), check.Equals, true)
 	}
 
-	keys, err = slashRootDriver.List("/")
+	keys, err = slashRootDriver.List(ctx, "/")
 	for _, path := range keys {
 		c.Assert(storagedriver.PathRegexp.MatchString(path), check.Equals, true)
 	}

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/docker/distribution/context"
 )
 
 // Version is a string representing the storage driver version, of the form
@@ -42,45 +44,45 @@ type StorageDriver interface {
 
 	// GetContent retrieves the content stored at "path" as a []byte.
 	// This should primarily be used for small objects.
-	GetContent(path string) ([]byte, error)
+	GetContent(ctx context.Context, path string) ([]byte, error)
 
 	// PutContent stores the []byte content at a location designated by "path".
 	// This should primarily be used for small objects.
-	PutContent(path string, content []byte) error
+	PutContent(ctx context.Context, path string, content []byte) error
 
 	// ReadStream retrieves an io.ReadCloser for the content stored at "path"
 	// with a given byte offset.
 	// May be used to resume reading a stream by providing a nonzero offset.
-	ReadStream(path string, offset int64) (io.ReadCloser, error)
+	ReadStream(ctx context.Context, path string, offset int64) (io.ReadCloser, error)
 
 	// WriteStream stores the contents of the provided io.ReadCloser at a
 	// location designated by the given path.
 	// May be used to resume writing a stream by providing a nonzero offset.
 	// The offset must be no larger than the CurrentSize for this path.
-	WriteStream(path string, offset int64, reader io.Reader) (nn int64, err error)
+	WriteStream(ctx context.Context, path string, offset int64, reader io.Reader) (nn int64, err error)
 
 	// Stat retrieves the FileInfo for the given path, including the current
 	// size in bytes and the creation time.
-	Stat(path string) (FileInfo, error)
+	Stat(ctx context.Context, path string) (FileInfo, error)
 
 	// List returns a list of the objects that are direct descendants of the
 	//given path.
-	List(path string) ([]string, error)
+	List(ctx context.Context, path string) ([]string, error)
 
 	// Move moves an object stored at sourcePath to destPath, removing the
 	// original object.
 	// Note: This may be no more efficient than a copy followed by a delete for
 	// many implementations.
-	Move(sourcePath string, destPath string) error
+	Move(ctx context.Context, sourcePath string, destPath string) error
 
 	// Delete recursively deletes all objects stored at "path" and its subpaths.
-	Delete(path string) error
+	Delete(ctx context.Context, path string) error
 
 	// URLFor returns a URL which may be used to retrieve the content stored at
 	// the given path, possibly using the given options.
 	// May return an ErrUnsupportedMethod in certain StorageDriver
 	// implementations.
-	URLFor(path string, options map[string]interface{}) (string, error)
+	URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error)
 }
 
 // PathRegexp is the regular expression which each file path must match. A

--- a/registry/storage/filereader_test.go
+++ b/registry/storage/filereader_test.go
@@ -8,12 +8,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
 )
 
 func TestSimpleRead(t *testing.T) {
+	ctx := context.Background()
 	content := make([]byte, 1<<20)
 	n, err := rand.Read(content)
 	if err != nil {
@@ -21,7 +22,7 @@ func TestSimpleRead(t *testing.T) {
 	}
 
 	if n != len(content) {
-		t.Fatalf("random read did't fill buffer")
+		t.Fatalf("random read didn't fill buffer")
 	}
 
 	dgst, err := digest.FromReader(bytes.NewReader(content))
@@ -32,11 +33,11 @@ func TestSimpleRead(t *testing.T) {
 	driver := inmemory.New()
 	path := "/random"
 
-	if err := driver.PutContent(path, content); err != nil {
+	if err := driver.PutContent(ctx, path, content); err != nil {
 		t.Fatalf("error putting patterned content: %v", err)
 	}
 
-	fr, err := newFileReader(driver, path)
+	fr, err := newFileReader(ctx, driver, path)
 	if err != nil {
 		t.Fatalf("error allocating file reader: %v", err)
 	}
@@ -59,12 +60,13 @@ func TestFileReaderSeek(t *testing.T) {
 	repititions := 1024
 	path := "/patterned"
 	content := bytes.Repeat([]byte(pattern), repititions)
+	ctx := context.Background()
 
-	if err := driver.PutContent(path, content); err != nil {
+	if err := driver.PutContent(ctx, path, content); err != nil {
 		t.Fatalf("error putting patterned content: %v", err)
 	}
 
-	fr, err := newFileReader(driver, path)
+	fr, err := newFileReader(ctx, driver, path)
 
 	if err != nil {
 		t.Fatalf("unexpected error creating file reader: %v", err)
@@ -160,7 +162,7 @@ func TestFileReaderSeek(t *testing.T) {
 // read method, with an io.EOF error.
 func TestFileReaderNonExistentFile(t *testing.T) {
 	driver := inmemory.New()
-	fr, err := newFileReader(driver, "/doesnotexist")
+	fr, err := newFileReader(context.Background(), driver, "/doesnotexist")
 	if err != nil {
 		t.Fatalf("unexpected error initializing reader: %v", err)
 	}

--- a/registry/storage/filewriter_test.go
+++ b/registry/storage/filewriter_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
@@ -32,8 +33,9 @@ func TestSimpleWrite(t *testing.T) {
 
 	driver := inmemory.New()
 	path := "/random"
+	ctx := context.Background()
 
-	fw, err := newFileWriter(driver, path)
+	fw, err := newFileWriter(ctx, driver, path)
 	if err != nil {
 		t.Fatalf("unexpected error creating fileWriter: %v", err)
 	}
@@ -49,7 +51,7 @@ func TestSimpleWrite(t *testing.T) {
 		t.Fatalf("unexpected write length: %d != %d", n, len(content))
 	}
 
-	fr, err := newFileReader(driver, path)
+	fr, err := newFileReader(ctx, driver, path)
 	if err != nil {
 		t.Fatalf("unexpected error creating fileReader: %v", err)
 	}
@@ -92,7 +94,7 @@ func TestSimpleWrite(t *testing.T) {
 		t.Fatalf("writeat was short: %d != %d", n, len(content))
 	}
 
-	fr, err = newFileReader(driver, path)
+	fr, err = newFileReader(ctx, driver, path)
 	if err != nil {
 		t.Fatalf("unexpected error creating fileReader: %v", err)
 	}
@@ -122,13 +124,13 @@ func TestSimpleWrite(t *testing.T) {
 	// Now, we copy from one path to another, running the data through the
 	// fileReader to fileWriter, rather than the driver.Move command to ensure
 	// everything is working correctly.
-	fr, err = newFileReader(driver, path)
+	fr, err = newFileReader(ctx, driver, path)
 	if err != nil {
 		t.Fatalf("unexpected error creating fileReader: %v", err)
 	}
 	defer fr.Close()
 
-	fw, err = newFileWriter(driver, "/copied")
+	fw, err = newFileWriter(ctx, driver, "/copied")
 	if err != nil {
 		t.Fatalf("unexpected error creating fileWriter: %v", err)
 	}
@@ -143,7 +145,7 @@ func TestSimpleWrite(t *testing.T) {
 		t.Fatalf("unexpected copy length: %d != %d", nn, len(doubled))
 	}
 
-	fr, err = newFileReader(driver, "/copied")
+	fr, err = newFileReader(ctx, driver, "/copied")
 	if err != nil {
 		t.Fatalf("unexpected error creating fileReader: %v", err)
 	}
@@ -162,7 +164,8 @@ func TestSimpleWrite(t *testing.T) {
 }
 
 func TestBufferedFileWriter(t *testing.T) {
-	writer, err := newFileWriter(inmemory.New(), "/random")
+	ctx := context.Background()
+	writer, err := newFileWriter(ctx, inmemory.New(), "/random")
 
 	if err != nil {
 		t.Fatalf("Failed to initialize bufferedFileWriter: %v", err.Error())
@@ -203,8 +206,8 @@ func BenchmarkFileWriter(b *testing.B) {
 			driver: inmemory.New(),
 			path:   "/random",
 		}
-
-		if fi, err := fw.driver.Stat(fw.path); err != nil {
+		ctx := context.Background()
+		if fi, err := fw.driver.Stat(ctx, fw.path); err != nil {
 			switch err := err.(type) {
 			case storagedriver.PathNotFoundError:
 				// ignore, offset is zero
@@ -236,8 +239,9 @@ func BenchmarkFileWriter(b *testing.B) {
 
 func BenchmarkBufferedFileWriter(b *testing.B) {
 	b.StopTimer() // not sure how long setup above will take
+	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		bfw, err := newFileWriter(inmemory.New(), "/random")
+		bfw, err := newFileWriter(ctx, inmemory.New(), "/random")
 
 		if err != nil {
 			b.Fatalf("Failed to initialize bufferedFileWriter: %v", err.Error())

--- a/registry/storage/layer_test.go
+++ b/registry/storage/layer_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/storage/cache"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
 	"github.com/docker/distribution/testutil"
-	"golang.org/x/net/context"
 )
 
 // TestSimpleLayerUpload covers the layer upload process, exercising common
@@ -36,7 +36,7 @@ func TestSimpleLayerUpload(t *testing.T) {
 	ctx := context.Background()
 	imageName := "foo/bar"
 	driver := inmemory.New()
-	registry := NewRegistryWithDriver(driver, cache.NewInMemoryLayerInfoCache())
+	registry := NewRegistryWithDriver(ctx, driver, cache.NewInMemoryLayerInfoCache())
 	repository, err := registry.Repository(ctx, imageName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -144,7 +144,7 @@ func TestSimpleLayerRead(t *testing.T) {
 	ctx := context.Background()
 	imageName := "foo/bar"
 	driver := inmemory.New()
-	registry := NewRegistryWithDriver(driver, cache.NewInMemoryLayerInfoCache())
+	registry := NewRegistryWithDriver(ctx, driver, cache.NewInMemoryLayerInfoCache())
 	repository, err := registry.Repository(ctx, imageName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -253,7 +253,7 @@ func TestLayerUploadZeroLength(t *testing.T) {
 	ctx := context.Background()
 	imageName := "foo/bar"
 	driver := inmemory.New()
-	registry := NewRegistryWithDriver(driver, cache.NewInMemoryLayerInfoCache())
+	registry := NewRegistryWithDriver(ctx, driver, cache.NewInMemoryLayerInfoCache())
 	repository, err := registry.Repository(ctx, imageName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -353,7 +353,8 @@ func writeTestLayer(driver storagedriver.StorageDriver, pathMapper *pathMapper, 
 		digest: dgst,
 	})
 
-	if err := driver.PutContent(blobPath, p); err != nil {
+	ctx := context.Background()
+	if err := driver.PutContent(ctx, blobPath, p); err != nil {
 		return "", err
 	}
 
@@ -370,7 +371,7 @@ func writeTestLayer(driver storagedriver.StorageDriver, pathMapper *pathMapper, 
 		return "", err
 	}
 
-	if err := driver.PutContent(layerLinkPath, []byte(dgst)); err != nil {
+	if err := driver.PutContent(ctx, layerLinkPath, []byte(dgst)); err != nil {
 		return "", nil
 	}
 

--- a/registry/storage/layerreader.go
+++ b/registry/storage/layerreader.go
@@ -54,7 +54,7 @@ func (lr *layerReader) Close() error {
 func (lr *layerReader) Handler(r *http.Request) (h http.Handler, err error) {
 	var handlerFunc http.HandlerFunc
 
-	redirectURL, err := lr.fileReader.driver.URLFor(lr.path, map[string]interface{}{"method": r.Method})
+	redirectURL, err := lr.fileReader.driver.URLFor(lr.ctx, lr.path, map[string]interface{}{"method": r.Method})
 
 	switch err {
 	case nil:

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -30,7 +30,7 @@ type manifestStoreTestEnv struct {
 func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestEnv {
 	ctx := context.Background()
 	driver := inmemory.New()
-	registry := NewRegistryWithDriver(driver, cache.NewInMemoryLayerInfoCache())
+	registry := NewRegistryWithDriver(ctx, driver, cache.NewInMemoryLayerInfoCache())
 
 	repo, err := registry.Repository(ctx, name)
 	if err != nil {

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -20,10 +20,11 @@ type registry struct {
 // NewRegistryWithDriver creates a new registry instance from the provided
 // driver. The resulting registry may be shared by multiple goroutines but is
 // cheap to allocate.
-func NewRegistryWithDriver(driver storagedriver.StorageDriver, layerInfoCache cache.LayerInfoCache) distribution.Namespace {
+func NewRegistryWithDriver(ctx context.Context, driver storagedriver.StorageDriver, layerInfoCache cache.LayerInfoCache) distribution.Namespace {
 	bs := &blobStore{
 		driver: driver,
 		pm:     defaultPathMapper,
+		ctx:    ctx,
 	}
 
 	return &registry{

--- a/registry/storage/revisionstore.go
+++ b/registry/storage/revisionstore.go
@@ -26,7 +26,7 @@ func (rs *revisionStore) exists(revision digest.Digest) (bool, error) {
 		return false, err
 	}
 
-	exists, err := exists(rs.driver, revpath)
+	exists, err := exists(rs.repository.ctx, rs.driver, revpath)
 	if err != nil {
 		return false, err
 	}
@@ -121,7 +121,7 @@ func (rs *revisionStore) link(revision digest.Digest) error {
 		return err
 	}
 
-	if exists, err := exists(rs.driver, revisionPath); err != nil {
+	if exists, err := exists(rs.repository.ctx, rs.driver, revisionPath); err != nil {
 		return err
 	} else if exists {
 		// Revision has already been linked!
@@ -142,5 +142,5 @@ func (rs *revisionStore) delete(revision digest.Digest) error {
 		return err
 	}
 
-	return rs.driver.Delete(revisionPath)
+	return rs.driver.Delete(rs.repository.ctx, revisionPath)
 }

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -30,7 +30,7 @@ func (s *signatureStore) Get(dgst digest.Digest) ([][]byte, error) {
 	// can be eliminated by implementing listAll on drivers.
 	signaturesPath = path.Join(signaturesPath, "sha256")
 
-	signaturePaths, err := s.driver.List(signaturesPath)
+	signaturePaths, err := s.driver.List(s.repository.ctx, signaturesPath)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -4,6 +4,7 @@ import (
 	"path"
 
 	"github.com/docker/distribution"
+	//	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 )
@@ -23,7 +24,7 @@ func (ts *tagStore) tags() ([]string, error) {
 	}
 
 	var tags []string
-	entries, err := ts.driver.List(p)
+	entries, err := ts.driver.List(ts.repository.ctx, p)
 	if err != nil {
 		switch err := err.(type) {
 		case storagedriver.PathNotFoundError:
@@ -52,7 +53,7 @@ func (ts *tagStore) exists(tag string) (bool, error) {
 		return false, err
 	}
 
-	exists, err := exists(ts.driver, tagPath)
+	exists, err := exists(ts.repository.ctx, ts.driver, tagPath)
 	if err != nil {
 		return false, err
 	}
@@ -102,7 +103,7 @@ func (ts *tagStore) resolve(tag string) (digest.Digest, error) {
 		return "", err
 	}
 
-	if exists, err := exists(ts.driver, currentPath); err != nil {
+	if exists, err := exists(ts.repository.ctx, ts.driver, currentPath); err != nil {
 		return "", err
 	} else if !exists {
 		return "", distribution.ErrManifestUnknown{Name: ts.Name(), Tag: tag}
@@ -130,7 +131,7 @@ func (ts *tagStore) revisions(tag string) ([]digest.Digest, error) {
 	// TODO(stevvooe): Need to append digest alg to get listing of revisions.
 	manifestTagIndexPath = path.Join(manifestTagIndexPath, "sha256")
 
-	entries, err := ts.driver.List(manifestTagIndexPath)
+	entries, err := ts.driver.List(ts.repository.ctx, manifestTagIndexPath)
 	if err != nil {
 		return nil, err
 	}
@@ -154,5 +155,5 @@ func (ts *tagStore) delete(tag string) error {
 		return err
 	}
 
-	return ts.driver.Delete(tagPath)
+	return ts.driver.Delete(ts.repository.ctx, tagPath)
 }

--- a/registry/storage/walk.go
+++ b/registry/storage/walk.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/docker/distribution/context"
 	storageDriver "github.com/docker/distribution/registry/storage/driver"
 )
 
@@ -20,13 +21,13 @@ type WalkFn func(fileInfo storageDriver.FileInfo) error
 
 // Walk traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file
-func Walk(driver storageDriver.StorageDriver, from string, f WalkFn) error {
-	children, err := driver.List(from)
+func Walk(ctx context.Context, driver storageDriver.StorageDriver, from string, f WalkFn) error {
+	children, err := driver.List(ctx, from)
 	if err != nil {
 		return err
 	}
 	for _, child := range children {
-		fileInfo, err := driver.Stat(child)
+		fileInfo, err := driver.Stat(ctx, child)
 		if err != nil {
 			return err
 		}
@@ -37,7 +38,7 @@ func Walk(driver storageDriver.StorageDriver, from string, f WalkFn) error {
 		}
 
 		if fileInfo.IsDir() && !skipDir {
-			Walk(driver, child, f)
+			Walk(ctx, driver, child, f)
 		}
 	}
 	return nil


### PR DESCRIPTION
Make Storage Driver API calls context aware.
    
     - Change driver interface to take a context as its first argument
     - Make newFileReader take a context as its first argument
     - Make newFileWriter take a context as its first argument
     - Make blobstore exists and delete take a context as a first argument
     - Pass the layerreader's context to the storage layer
     - Pass the app's context to purgeuploads
     - Store the app's context into the blobstore (was previously null)
     - Pass the trace'd context to the storage drivers
    
    Signed-off-by: Richard Scothern <richard.scothern@gmail.com>

Closes: #264 