### PR TITLE
Disable go1.3 tests for circle and upgrade to go1.4.2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,8 @@ machine:
 
   post:
   # Install many go versions
-    - gvm install go1.3.3 -B --name=old
-    - gvm install go1.4 -B --name=stable
+    # - gvm install go1.3.3 -B --name=old
+    - gvm install go1.4.2 -B --name=stable
     # - gvm install tip --name=bleed
 
   environment:
@@ -28,10 +28,10 @@ machine:
 dependencies:
   pre:
   # Copy the code to the gopath of all go versions
-    - >
-      gvm use old &&
-      mkdir -p "$(dirname $BASE_OLD)" &&
-      cp -R "$CHECKOUT" "$BASE_OLD"
+    # - >
+    #   gvm use old &&
+    #   mkdir -p "$(dirname $BASE_OLD)" &&
+    #   cp -R "$CHECKOUT" "$BASE_OLD"
 
     - >
       gvm use stable &&
@@ -45,8 +45,8 @@ dependencies:
 
   override:
   # Install dependencies for every copied clone/go version
-    - gvm use old && go get github.com/tools/godep:
-        pwd: $BASE_OLD
+    # - gvm use old && go get github.com/tools/godep:
+    #     pwd: $BASE_OLD
 
     - gvm use stable && go get github.com/tools/godep:
         pwd: $BASE_STABLE
@@ -63,7 +63,7 @@ dependencies:
 test:
   pre:
   # Output the go versions we are going to test
-    - gvm use old && go version
+    # - gvm use old && go version
     - gvm use stable && go version
     # - gvm use bleed && go version
 
@@ -81,9 +81,9 @@ test:
 
   override:
   # Test every version we have (but stable)
-    - gvm use old; godep go test -test.v -test.short ./...:
-        timeout: 600
-        pwd: $BASE_OLD
+    # - gvm use old; godep go test -test.v -test.short ./...:
+    #     timeout: 600
+    #     pwd: $BASE_OLD
 
     # - gvm use bleed; go test -test.v -test.short ./...:
     #     timeout: 600


### PR DESCRIPTION
This should massively speed up the unit tests. We don't really use go1.3 anymore.

Signed-off-by: Stephen J Day <stephen.day@docker.com>