### PR TITLE
Expose storage driver names for tracing

### DIFF
--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -94,6 +94,9 @@ func New(accountName, accountKey, container, realm string) (*Driver, error) {
 }
 
 // Implement the storagedriver.StorageDriver interface.
+func (d *driver) Name() string {
+	return driverName
+}
 
 // GetContent retrieves the content stored at "path" as a []byte.
 func (d *driver) GetContent(path string) ([]byte, error) {

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -53,7 +53,7 @@ type Base struct {
 // GetContent wraps GetContent of underlying storage driver.
 func (base *Base) GetContent(path string) ([]byte, error) {
 	_, done := context.WithTrace(context.Background())
-	defer done("Base.GetContent(\"%s\")", path)
+	defer done("%s.GetContent(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return nil, storagedriver.InvalidPathError{Path: path}
@@ -65,7 +65,7 @@ func (base *Base) GetContent(path string) ([]byte, error) {
 // PutContent wraps PutContent of underlying storage driver.
 func (base *Base) PutContent(path string, content []byte) error {
 	_, done := context.WithTrace(context.Background())
-	defer done("Base.PutContent(\"%s\")", path)
+	defer done("%s.PutContent(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return storagedriver.InvalidPathError{Path: path}
@@ -77,7 +77,7 @@ func (base *Base) PutContent(path string, content []byte) error {
 // ReadStream wraps ReadStream of underlying storage driver.
 func (base *Base) ReadStream(path string, offset int64) (io.ReadCloser, error) {
 	_, done := context.WithTrace(context.Background())
-	defer done("Base.ReadStream(\"%s\", %d)", path, offset)
+	defer done("%s.ReadStream(%q, %d)", base.Name(), path, offset)
 
 	if offset < 0 {
 		return nil, storagedriver.InvalidOffsetError{Path: path, Offset: offset}
@@ -93,7 +93,7 @@ func (base *Base) ReadStream(path string, offset int64) (io.ReadCloser, error) {
 // WriteStream wraps WriteStream of underlying storage driver.
 func (base *Base) WriteStream(path string, offset int64, reader io.Reader) (nn int64, err error) {
 	_, done := context.WithTrace(context.Background())
-	defer done("Base.WriteStream(\"%s\", %d)", path, offset)
+	defer done("%s.WriteStream(%q, %d)", base.Name(), path, offset)
 
 	if offset < 0 {
 		return 0, storagedriver.InvalidOffsetError{Path: path, Offset: offset}
@@ -109,7 +109,7 @@ func (base *Base) WriteStream(path string, offset int64, reader io.Reader) (nn i
 // Stat wraps Stat of underlying storage driver.
 func (base *Base) Stat(path string) (storagedriver.FileInfo, error) {
 	_, done := context.WithTrace(context.Background())
-	defer done("Base.Stat(\"%s\")", path)
+	defer done("%s.Stat(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return nil, storagedriver.InvalidPathError{Path: path}
@@ -121,7 +121,7 @@ func (base *Base) Stat(path string) (storagedriver.FileInfo, error) {
 // List wraps List of underlying storage driver.
 func (base *Base) List(path string) ([]string, error) {
 	_, done := context.WithTrace(context.Background())
-	defer done("Base.List(\"%s\")", path)
+	defer done("%s.List(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) && path != "/" {
 		return nil, storagedriver.InvalidPathError{Path: path}
@@ -133,7 +133,7 @@ func (base *Base) List(path string) ([]string, error) {
 // Move wraps Move of underlying storage driver.
 func (base *Base) Move(sourcePath string, destPath string) error {
 	_, done := context.WithTrace(context.Background())
-	defer done("Base.Move(\"%s\", \"%s\"", sourcePath, destPath)
+	defer done("%s.Move(%q, %q", base.Name(), sourcePath, destPath)
 
 	if !storagedriver.PathRegexp.MatchString(sourcePath) {
 		return storagedriver.InvalidPathError{Path: sourcePath}
@@ -147,7 +147,7 @@ func (base *Base) Move(sourcePath string, destPath string) error {
 // Delete wraps Delete of underlying storage driver.
 func (base *Base) Delete(path string) error {
 	_, done := context.WithTrace(context.Background())
-	defer done("Base.Delete(\"%s\")", path)
+	defer done("%s.Delete(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return storagedriver.InvalidPathError{Path: path}
@@ -159,7 +159,7 @@ func (base *Base) Delete(path string) error {
 // URLFor wraps URLFor of underlying storage driver.
 func (base *Base) URLFor(path string, options map[string]interface{}) (string, error) {
 	_, done := context.WithTrace(context.Background())
-	defer done("Base.URLFor(\"%s\")", path)
+	defer done("%s.URLFor(%q)", base.Name(), path)
 
 	if !storagedriver.PathRegexp.MatchString(path) {
 		return "", storagedriver.InvalidPathError{Path: path}

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -71,6 +71,10 @@ func New(rootDirectory string) *Driver {
 
 // Implement the storagedriver.StorageDriver interface
 
+func (d *driver) Name() string {
+	return driverName
+}
+
 // GetContent retrieves the content stored at "path" as a []byte.
 func (d *driver) GetContent(path string) ([]byte, error) {
 	rc, err := d.ReadStream(path, 0)

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -64,6 +64,10 @@ func New() *Driver {
 
 // Implement the storagedriver.StorageDriver interface.
 
+func (d *driver) Name() string {
+	return driverName
+}
+
 // GetContent retrieves the content stored at "path" as a []byte.
 func (d *driver) GetContent(path string) ([]byte, error) {
 	d.mutex.RLock()

--- a/registry/storage/driver/s3/s3.go
+++ b/registry/storage/driver/s3/s3.go
@@ -261,6 +261,10 @@ func New(params DriverParameters) (*Driver, error) {
 
 // Implement the storagedriver.StorageDriver interface
 
+func (d *driver) Name() string {
+	return driverName
+}
+
 // GetContent retrieves the content stored at "path" as a []byte.
 func (d *driver) GetContent(path string) ([]byte, error) {
 	content, err := d.Bucket.Get(d.s3Path(path))

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -35,6 +35,11 @@ const CurrentVersion Version = "0.1"
 // StorageDriver defines methods that a Storage Driver must implement for a
 // filesystem-like key/value object storage.
 type StorageDriver interface {
+	// Name returns the human-readable "name" of the driver, useful in error
+	// messages and logging. By convention, this will just be the registration
+	// name, but drivers may provide other information here.
+	Name() string
+
 	// GetContent retrieves the content stored at "path" as a []byte.
 	// This should primarily be used for small objects.
 	GetContent(path string) ([]byte, error)


### PR DESCRIPTION
This simply adds a `Name` method to the storage driver interface. This can be used so drivers can report their name in errors and logs.