### PR TITLE
Return after error in handler

### DIFF
--- a/registry/handlers/layerupload.go
+++ b/registry/handlers/layerupload.go
@@ -202,6 +202,7 @@ func (luh *layerUploadHandler) PutLayerUploadComplete(w http.ResponseWriter, r *
 		ctxu.GetLogger(luh).Errorf("unknown error copying into upload: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		luh.Errors.Push(v2.ErrorCodeUnknown, err)
+		return
 	}
 
 	layer, err := luh.Upload.Finish(dgst)


### PR DESCRIPTION
This adds a missing return statement. It is not strictly needed since if the
io.Copy fails, the Finish operation will fail. Currently, the client reports
both errors where this new code will correctly only report the io.Copy error.

Signed-off-by: Stephen J Day <stephen.day@docker.com>