### PR TITLE
simplify the embedded method expression of repository

### DIFF
--- a/registry/storage/layerstore.go
+++ b/registry/storage/layerstore.go
@@ -65,7 +65,7 @@ func (ls *layerStore) Upload() (distribution.LayerUpload, error) {
 	uuid := uuid.New()
 	startedAt := time.Now().UTC()
 
-	path, err := ls.repository.registry.pm.path(uploadDataPathSpec{
+	path, err := ls.repository.pm.path(uploadDataPathSpec{
 		name: ls.repository.Name(),
 		uuid: uuid,
 	})
@@ -74,7 +74,7 @@ func (ls *layerStore) Upload() (distribution.LayerUpload, error) {
 		return nil, err
 	}
 
-	startedAtPath, err := ls.repository.registry.pm.path(uploadStartedAtPathSpec{
+	startedAtPath, err := ls.repository.pm.path(uploadStartedAtPathSpec{
 		name: ls.repository.Name(),
 		uuid: uuid,
 	})
@@ -95,7 +95,7 @@ func (ls *layerStore) Upload() (distribution.LayerUpload, error) {
 // state of the upload.
 func (ls *layerStore) Resume(uuid string) (distribution.LayerUpload, error) {
 	ctxu.GetLogger(ls.repository.ctx).Debug("(*layerStore).Resume")
-	startedAtPath, err := ls.repository.registry.pm.path(uploadStartedAtPathSpec{
+	startedAtPath, err := ls.repository.pm.path(uploadStartedAtPathSpec{
 		name: ls.repository.Name(),
 		uuid: uuid,
 	})
@@ -152,7 +152,7 @@ func (ls *layerStore) newLayerUpload(uuid, path string, startedAt time.Time) (di
 
 func (ls *layerStore) path(dgst digest.Digest) (string, error) {
 	// We must traverse this path through the link to enforce ownership.
-	layerLinkPath, err := ls.repository.registry.pm.path(layerLinkPathSpec{name: ls.repository.Name(), digest: dgst})
+	layerLinkPath, err := ls.repository.pm.path(layerLinkPathSpec{name: ls.repository.Name(), digest: dgst})
 	if err != nil {
 		return "", err
 	}

--- a/registry/storage/layerwriter.go
+++ b/registry/storage/layerwriter.go
@@ -158,7 +158,7 @@ type hashStateEntry struct {
 
 // getStoredHashStates returns a slice of hashStateEntries for this upload.
 func (lw *layerWriter) getStoredHashStates() ([]hashStateEntry, error) {
-	uploadHashStatePathPrefix, err := lw.layerStore.repository.registry.pm.path(uploadHashStatePathSpec{
+	uploadHashStatePathPrefix, err := lw.layerStore.repository.pm.path(uploadHashStatePathSpec{
 		name: lw.layerStore.repository.Name(),
 		uuid: lw.uuid,
 		alg:  lw.resumableDigester.Digest().Algorithm(),
@@ -271,7 +271,7 @@ func (lw *layerWriter) resumeHashAt(offset int64) error {
 }
 
 func (lw *layerWriter) storeHashState() error {
-	uploadHashStatePath, err := lw.layerStore.repository.registry.pm.path(uploadHashStatePathSpec{
+	uploadHashStatePath, err := lw.layerStore.repository.pm.path(uploadHashStatePathSpec{
 		name:   lw.layerStore.repository.Name(),
 		uuid:   lw.uuid,
 		alg:    lw.resumableDigester.Digest().Algorithm(),
@@ -360,7 +360,7 @@ func (lw *layerWriter) validateLayer(dgst digest.Digest) (digest.Digest, error) 
 // identified by dgst. The layer should be validated before commencing the
 // move.
 func (lw *layerWriter) moveLayer(dgst digest.Digest) error {
-	blobPath, err := lw.layerStore.repository.registry.pm.path(blobDataPathSpec{
+	blobPath, err := lw.layerStore.repository.pm.path(blobDataPathSpec{
 		digest: dgst,
 	})
 
@@ -426,7 +426,7 @@ func (lw *layerWriter) linkLayer(canonical digest.Digest, aliases ...digest.Dige
 		}
 		seenDigests[dgst] = struct{}{}
 
-		layerLinkPath, err := lw.layerStore.repository.registry.pm.path(layerLinkPathSpec{
+		layerLinkPath, err := lw.layerStore.repository.pm.path(layerLinkPathSpec{
 			name:   lw.layerStore.repository.Name(),
 			digest: dgst,
 		})
@@ -435,7 +435,7 @@ func (lw *layerWriter) linkLayer(canonical digest.Digest, aliases ...digest.Dige
 			return err
 		}
 
-		if err := lw.layerStore.repository.registry.driver.PutContent(layerLinkPath, []byte(canonical)); err != nil {
+		if err := lw.layerStore.repository.driver.PutContent(layerLinkPath, []byte(canonical)); err != nil {
 			return err
 		}
 	}
@@ -447,7 +447,7 @@ func (lw *layerWriter) linkLayer(canonical digest.Digest, aliases ...digest.Dige
 // instance. An error will be returned if the clean up cannot proceed. If the
 // resources are already not present, no error will be returned.
 func (lw *layerWriter) removeResources() error {
-	dataPath, err := lw.layerStore.repository.registry.pm.path(uploadDataPathSpec{
+	dataPath, err := lw.layerStore.repository.pm.path(uploadDataPathSpec{
 		name: lw.layerStore.repository.Name(),
 		uuid: lw.uuid,
 	})


### PR DESCRIPTION
@stevvooe 
struct `registry` is the only embedded field of `repository`.
However, these 2 files use repository.registry expression, which seems superfluous.
So, I simplify them, to use `repository.{registry_field}` directly.
* `registry` fields as pm, blobStore, etc, match repository property. So that modification make code context meaning clearer.
* Better Uniform expression in  *layerstore.go*, *manifeststore.go*, and etc on purpose of my patch.
* The project will re-factor Distribution interface as your proposal #354. Simplifying can make re-factoring cooperation easily;
Do you agree? if yes, please help review it. Thanks a lot!

Signed-off-by: xiekeyang <xiekeyang@huawei.com>