### PR TITLE
manifestStore: Remove unused method

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -80,9 +80,6 @@ type ManifestService interface {
 	// Tags lists the tags under the named repository.
 	Tags() ([]string, error)
 
-	// ExistsByTag returns true if the manifest exists.
-	ExistsByTag(tag string) (bool, error)
-
 	// GetByTag retrieves the named manifest, if it exists.
 	GetByTag(tag string) (*manifest.SignedManifest, error)
 

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -63,11 +63,6 @@ func (ms *manifestStore) Tags() ([]string, error) {
 	return ms.tagStore.tags()
 }
 
-func (ms *manifestStore) ExistsByTag(tag string) (bool, error) {
-	ctxu.GetLogger(ms.repository.ctx).Debug("(*manifestStore).ExistsByTag")
-	return ms.tagStore.exists(tag)
-}
-
 func (ms *manifestStore) GetByTag(tag string) (*manifest.SignedManifest, error) {
 	ctxu.GetLogger(ms.repository.ctx).Debug("(*manifestStore).GetByTag")
 	dgst, err := ms.tagStore.resolve(tag)

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -51,15 +51,6 @@ func TestManifestStorage(t *testing.T) {
 	env := newManifestStoreTestEnv(t, "foo/bar", "thetag")
 	ms := env.repository.Manifests()
 
-	exists, err := ms.ExistsByTag(env.tag)
-	if err != nil {
-		t.Fatalf("unexpected error checking manifest existence: %v", err)
-	}
-
-	if exists {
-		t.Fatalf("manifest should not exist")
-	}
-
 	if _, err := ms.GetByTag(env.tag); true {
 		switch err.(type) {
 		case distribution.ErrManifestUnknown:
@@ -130,15 +121,6 @@ func TestManifestStorage(t *testing.T) {
 		t.Fatalf("unexpected error putting manifest: %v", err)
 	}
 
-	exists, err = ms.ExistsByTag(env.tag)
-	if err != nil {
-		t.Fatalf("unexpected error checking manifest existence: %v", err)
-	}
-
-	if !exists {
-		t.Fatalf("manifest should exist")
-	}
-
 	fetchedManifest, err := ms.GetByTag(env.tag)
 	if err != nil {
 		t.Fatalf("unexpected error fetching manifest: %v", err)
@@ -165,7 +147,7 @@ func TestManifestStorage(t *testing.T) {
 		t.Fatalf("error getting manifest digest: %v", err)
 	}
 
-	exists, err = ms.Exists(dgst)
+	exists, err := ms.Exists(dgst)
 	if err != nil {
 		t.Fatalf("error checking manifest existence by digest: %v", err)
 	}

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -42,24 +42,6 @@ func (ts *tagStore) tags() ([]string, error) {
 	return tags, nil
 }
 
-// exists returns true if the specified manifest tag exists in the repository.
-func (ts *tagStore) exists(tag string) (bool, error) {
-	tagPath, err := ts.pm.path(manifestTagCurrentPathSpec{
-		name: ts.Name(),
-		tag:  tag,
-	})
-	if err != nil {
-		return false, err
-	}
-
-	exists, err := exists(ts.driver, tagPath)
-	if err != nil {
-		return false, err
-	}
-
-	return exists, nil
-}
-
 // tag tags the digest with the given tag, updating the the store to point at
 // the current tag. The digest must point to a manifest.
 func (ts *tagStore) tag(tag string, revision digest.Digest) error {


### PR DESCRIPTION
@stevvooe 
`manifestStore.ExistsByTag` hasn't been used. And, `manifestStore` will be re-factored. Its functions relevant to tags will be implemented in `tagStore`.
So, it had better to be removed, to prepare a clear and simply structure for re-factor job.
Please help review. Thanks so much!

Signed-off-by: xiekeyang <xiekeyang@huawei.com>