### PR TITLE
Fixes Issue #471 with Publish

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -7,11 +7,13 @@ COPY . /src
 # Reset the /docs dir so we can replace the theme meta with the new repo's git info
 RUN git reset --hard
 
+RUN grep "VERSION =" /src/version/version.go  | sed 's/.*"\(.*\)".*/\1/' > /docs/VERSION
+
+
 #
 # RUN git describe --match 'v[0-9]*' --dirty='.m' --always > /docs/VERSION
 # The above line causes a floating point error in our tools
 #
-RUN grep "VERSION =" /src/version/version.go  | sed 's/.*"\(.*\)".*/\1/' > /docs/VERSION
 COPY docs/* /docs/sources/registry/
 COPY docs/images/* /docs/sources/registry/images/
 COPY docs/spec/* /docs/sources/registry/spec/
@@ -19,6 +21,17 @@ COPY docs/spec/auth/* /docs/sources/registry/spec/auth/
 COPY docs/storage-drivers/* /docs/sources/registry/storage-drivers/
 COPY docs/mkdocs.yml /docs/mkdocs-distribution.yml
 
+RUN sed -i.old '1s;^;no_version_dropdown: true;' \
+  /docs/sources/registry/*.md \
+  /docs/sources/registry/spec/*.md \
+  /docs/sources/registry/spec/auth/*.md \
+  /docs/sources/registry/storage-drivers/*.md 
+
+RUN sed -i.old  -e '/^<!--GITHUB/g' -e '/^IGNORES-->/g'\
+  /docs/sources/registry/*.md \
+  /docs/sources/registry/spec/*.md \
+  /docs/sources/registry/spec/auth/*.md \
+  /docs/sources/registry/storage-drivers/*.md 
 
 # Then build everything together, ready for mkdocs
 RUN /docs/build.sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,8 @@
+<!--GITHUB
 page_title: Configure a Registry
 page_description: Explains how to deploy a registry 
 page_keywords: registry, service, images, repository
+IGNORES-->
 
 
 # Registry Configuration Reference

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,6 +1,9 @@
+<!--GITHUB
 page_title: Deploying a registry server
 page_description: Explains how to deploy a registry server
 page_keywords: registry, service, images, repository
+IGNORES-->
+
 
 # Deploying a registry server
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
+<!--GITHUB
 page_title: Docker Registry 2.0
 page_description: Introduces the Docker Registry
 page_keywords: registry, images, repository
+IGNORES-->
 
 # Docker Registry 2.0
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,6 +1,9 @@
+<!--GITHUB
 page_title: Work with Notifications
 page_description: Explains how to deploy a registry server
 page_keywords: registry, service, images, repository
+IGNORES-->
+
 
 # Notifications
 

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1,3 +1,9 @@
+<!--GITHUB
+page_title: Docker Registry HTTP API V2
+page_description: Explains how to use registry API
+page_keywords: registry, service, driver, images, storage, api
+IGNORES-->
+
 # Docker Registry HTTP API V2
 
 ## Introduction

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -1,3 +1,9 @@
+<!--GITHUB
+page_title: Docker Registry HTTP API V2
+page_description: Explains how to use registry API
+page_keywords: registry, service, driver, images, storage, api
+IGNORES-->
+
 # Docker Registry HTTP API V2
 
 ## Introduction

--- a/docs/spec/auth/token.md
+++ b/docs/spec/auth/token.md
@@ -1,3 +1,10 @@
+<!--GITHUB
+page_title: Docker Registry v2 Authentication
+page_description: Introduces the Docker Registry v2 authentication
+page_keywords: registry, images, repository, v2, authentication
+IGNORES-->
+
+
 # Docker Registry v2 authentication via central service
 
 Today a Docker Registry can run in standalone mode in which there are no

--- a/docs/spec/json.md
+++ b/docs/spec/json.md
@@ -1,3 +1,10 @@
+<!--GITHUB
+page_title: Docker Distribution JSON Canonicalization
+page_description: Explains registry JSON objects
+page_keywords: registry, service, images, repository, json
+IGNORES-->
+
+
 # Docker Distribution JSON Canonicalization
 
 To provide consistent content hashing of JSON objects throughout Docker

--- a/docs/storage-drivers/azure.md
+++ b/docs/storage-drivers/azure.md
@@ -1,5 +1,10 @@
-# Microsoft Azure storage driver
+<!--GITHUB
+page_title: Microsoft Azure storage driver
+page_description: Explains how to use the Azure storage drivers
+page_keywords: registry, service, driver, images, storage, azure
+IGNORES-->
 
+# Microsoft Azure storage driver
 
 An implementation of the `storagedriver.StorageDriver` interface which uses [Microsoft Azure Blob Storage][azure-blob-storage] for object storage.
 

--- a/docs/storage-drivers/filesystem.md
+++ b/docs/storage-drivers/filesystem.md
@@ -1,3 +1,9 @@
+<!--GITHUB
+page_title: Filesystem storage driver
+page_description: Explains how to use the filesystem storage drivers
+page_keywords: registry, service, driver, images, storage, filesystem
+IGNORES-->
+
 # Filesystem storage driver
 
 An implementation of the `storagedriver.StorageDriver` interface which uses the local filesystem.

--- a/docs/storage-drivers/inmemory.md
+++ b/docs/storage-drivers/inmemory.md
@@ -1,3 +1,9 @@
+<!--GITHUB
+page_title: In-memory storage driver
+page_description: Explains how to use the in-memory storage drivers
+page_keywords: registry, service, driver, images, storage, in-memory
+IGNORES-->
+
 # In-memory storage driver
 
 An implementation of the `storagedriver.StorageDriver` interface which uses local memory for object storage.

--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -1,3 +1,9 @@
+<!--GITHUB
+page_title: S3 storage driver
+page_description: Explains how to use the S3 storage drivers
+page_keywords: registry, service, driver, images, storage, S3
+IGNORES-->
+
 # S3 storage driver
 
 An implementation of the `storagedriver.StorageDriver` interface which uses Amazon S3 for object storage.

--- a/docs/storagedrivers.md
+++ b/docs/storagedrivers.md
@@ -1,4 +1,10 @@
-# Docker-Registry Storage Driver
+<!--GITHUB
+page_title: Docker Registry Storage Driver
+page_description: Explains how to use the storage drivers
+page_keywords: registry, service, driver, images, storage
+IGNORES-->
+
+# Docker Registry Storage Driver
 
 This document describes the registry storage driver model, implementation, and explains how to contribute new storage drivers.
 


### PR DESCRIPTION
Fix issue #471 

- Add sed to Dockerfile; this sed exists on publish script; breaks headings/nav in files without metadata
- Ensure sed runs over storage-driver/ subdir
- Add metadata to all the files (including specs) that don't have it; this ensures they display correctly on publish

Signed-off-by: Mary Anthony <mary@docker.com>