### PR TITLE
Add support for colon as a name-segment delimiter.

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -157,7 +157,7 @@ enforce this. The rules for a repository name are as follows:
 1. A repository name is broken up into _path components_. A component of a
    repository name must be at least two lowercase, alpha-numeric characters,
    optionally separated by periods, dashes or underscores. More strictly, it
-   must match the regular expression `[a-z0-9]+(?:[._-][a-z0-9]+)*` and the
+   must match the regular expression `[a-z0-9]+(?:[.:_-][a-z0-9]+)*` and the
    matched result must be 2 or more characters in length.
 2. The name of a repository must have at least two path components, separated
    by a forward slash.

--- a/registry/api/v2/names.go
+++ b/registry/api/v2/names.go
@@ -26,8 +26,8 @@ const (
 
 // RepositoryNameComponentRegexp restricts registry path component names to
 // start with at least one letter or number, with following parts able to
-// be separated by one period, dash or underscore.
-var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[._-][a-z0-9]+)*`)
+// be separated by one period, colon, dash or underscore.
+var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[.:_-][a-z0-9]+)*`)
 
 // RepositoryNameComponentAnchoredRegexp is the version of
 // RepositoryNameComponentRegexp which must completely match the content

--- a/registry/api/v2/names_test.go
+++ b/registry/api/v2/names_test.go
@@ -43,6 +43,9 @@ func TestRepositoryNameRegexp(t *testing.T) {
 			input: "blog.foo.com/bar/baz",
 		},
 		{
+			input: "registry.bar.net/dog.cat:fish-taco/baz",
+		},
+		{
 			input: "asdf",
 		},
 		{


### PR DESCRIPTION
This proposed change relaxes the character restrictions on a repository namespace (further) to allow for colon as a name-segment delimiter in addition to dot, colon, and underscore.

For example, on Google's Cloud, we allow domain-scoped namespaces (e.g. moore.com:matt), which enables enterprise customers to have a namespace prefix under which all possible names belong to them.


An alternative approach to this one (of changing the canonical registry) would be to simply enable registries to have provider-specific validation, and simply avoid (or make quite liberal) the client-side validation and wording in the v2 API spec.

Happy to discuss how best to accommodate our use case.