### PR TITLE
Updating the Request Header directive for compatibility with httpd 2.2

### DIFF
--- a/contrib/apache/apache.conf
+++ b/contrib/apache/apache.conf
@@ -44,8 +44,8 @@
   ErrorLog ${APACHE_LOG_DIR}/registry_error_ssl_log
   CustomLog ${APACHE_LOG_DIR}/registry_access_ssl_log combined env=!dontlog
 
-  Header set Host "registry.example.com"
-  Header set "Docker-Distribution-Api-Version" "registry/2.0"
+  Header always set "Docker-Distribution-Api-Version" "registry/2.0"
+  Header onsuccess set "Docker-Distribution-Api-Version" "registry/2.0"
   RequestHeader set X-Forwarded-Proto "https"
 
   ProxyRequests     off


### PR DESCRIPTION
I'm submitting an update to https://github.com/docker/distribution/pull/423 authored by @hgomez for compatibility with httpd 2.2.

See [my comment](https://github.com/docker/distribution/issues/397#issuecomment-98828277) in the original issue.

Also I don't think that the Host header directive is necessary, especially in conjunction with `ProxyPreserveHost`.