### PR TITLE
Switch Dockerfile to use a wrapper script as ENTRYPOINT for the best of both worlds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ COPY . $DISTRIBUTION_DIR
 RUN make PREFIX=/go clean binaries
 
 EXPOSE 5000
-ENTRYPOINT ["registry"]
-CMD ["cmd/registry/config.yml"]
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["registry", "cmd/registry/config.yml"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+	set -- registry "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This is as was discussed over in https://github.com/docker-library/official-images/pull/643#issuecomment-93818039.

This makes it so that `docker run <image> --args` still works, but `docker run <image> bash` works as well.  It might make sense to add a similar check for something like `[[ "$1" == *.yml ]]` so that `docker run <image> some/other/config.yml` still works -- thoughts on how common it is to specify a custom configuration file and no other arguments?

cc @bfirsh