### PR TITLE
docs/spec: correct doc/spec to docs/spec everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,11 @@ PR titles should be lowercased, except for proper noun references (such a
 method name or type).
 
 PR titles should be prefixed with affected directories, comma separated. For
-example, if a specification is modified, the prefix would be "doc/spec". If
+example, if a specification is modified, the prefix would be "docs/spec". If
 the modifications are only in the root, do not include it. If multiple
 directories are modified, include each, separated by a comma and space.
 
 Here are some examples:
 
-- doc/spec: move API specification into correct position
+- docs/spec: move API specification into correct position
 - context, registry, auth, auth/token, cmd/registry: context aware logging

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ implementation.
 
 Registry 2.0 is the first release of the next-generation registry. This is primarily
 focused on implementing the [new registry
-API](https://github.com/docker/distribution/blob/master/doc/spec/api.md), with
+API](https://github.com/docker/distribution/blob/master/docs/spec/api.md), with
 a focus on security and performance.
 
 #### Registry 2.0

--- a/cmd/registry-api-descriptor-template/main.go
+++ b/cmd/registry-api-descriptor-template/main.go
@@ -4,7 +4,7 @@
 // For example, to generate a new API specification, one would execute the
 // following command from the repo root:
 //
-// 	$ registry-api-descriptor-template doc/spec/api.md.tmpl > doc/spec/api.md
+// 	$ registry-api-descriptor-template docs/spec/api.md.tmpl > docs/spec/api.md
 //
 // The templates are passed in the api/v2.APIDescriptor object. Please see the
 // package documentation for fields available on that object. The template


### PR DESCRIPTION
this fixes a broken link on the ROADMAP doc page, and confusing references elsewhere.