### PR TITLE
Changed cmd/registry/main.go resolveConfiguration to read the env REG…

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -137,10 +137,10 @@ func fatalf(format string, args ...interface{}) {
 func resolveConfiguration() (*configuration.Configuration, error) {
 	var configurationPath string
 
-	if flag.NArg() > 0 {
-		configurationPath = flag.Arg(0)
-	} else if os.Getenv("REGISTRY_CONFIGURATION_PATH") != "" {
+	if os.Getenv("REGISTRY_CONFIGURATION_PATH") != "" {
 		configurationPath = os.Getenv("REGISTRY_CONFIGURATION_PATH")
+	} else if flag.NArg() > 0 {
+		configurationPath = flag.Arg(0)
 	}
 
 	if configurationPath == "" {


### PR DESCRIPTION
…ISTRY_CONFIGURATION_PATH before reading the arguments.  With the supplied Dockerfile you can now specify a configuration file without having to rebuild the container.

Signed-off-by: Nick Halm <nick.halm@live.com>