### PR TITLE
Remove set header in compose script

### DIFF
--- a/contrib/compose/nginx/registry.conf
+++ b/contrib/compose/nginx/registry.conf
@@ -25,9 +25,11 @@ server {
     if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*$" ) {
       return 404;
     }
-    
-    # The docker client expects this header from the /v2/ endpoint.
-    more_set_headers 'Docker-Distribution-Api-Version: registry/2.0';
+
+    # To add basic authentication to v2 use auth_basic setting plus add_header
+    # auth_basic "registry.localhost";
+    # auth_basic_user_file test.password;
+    # add_header 'Docker-Distribution-Api-Version' 'registry/2.0' always;
 
     include               docker-registry-v2.conf;
   }


### PR DESCRIPTION
This configuration setting should not be set in the compose configuration. This configuration (or the `add_header` configuration) will only be needed when using basic auth in nginx. This is needed because the registry will not get a chance to set the distribution header and it will be the responsibility of nginx to set the header on 403. The v2 registry will correctly set this header variable in this configuration and it is not necessary for nginx to interfere. The cases where this is needed should be referenced in the documentation, not here.