### PR TITLE
Refactor client auth

### DIFF
--- a/registry/client/auth/api_version.go
+++ b/registry/client/auth/api_version.go
@@ -12,7 +12,7 @@ type APIVersion struct {
 	// such as "registry"
 	Type string
 
-	// Version is the vesion of the API specification implemented,
+	// Version is the version of the API specification implemented,
 	// This may omit the revision number and only include
 	// the major and minor version, such as "2.0"
 	Version string

--- a/registry/client/auth/api_version.go
+++ b/registry/client/auth/api_version.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// APIVersion represents a version of an API including its
+// type and version number.
+type APIVersion struct {
+	// Type refers to the name of a specific API specification
+	// such as "registry"
+	Type string
+
+	// Version is the vesion of the API specification implemented,
+	// This may omit the revision number and only include
+	// the major and minor version, such as "2.0"
+	Version string
+}
+
+// String returns the string formatted API Version
+func (v APIVersion) String() string {
+	return v.Type + "/" + v.Version
+}
+
+// APIVersions gets the API versions out of an HTTP response using the provided
+// version header as the key for the HTTP header.
+func APIVersions(resp *http.Response, versionHeader string) []APIVersion {
+	versions := []APIVersion{}
+	if versionHeader != "" {
+		for _, supportedVersions := range resp.Header[http.CanonicalHeaderKey(versionHeader)] {
+			for _, version := range strings.Fields(supportedVersions) {
+				versions = append(versions, ParseAPIVersion(version))
+			}
+		}
+	}
+	return versions
+}
+
+// ParseAPIVersion parses an API version string into an APIVersion
+// Format (Expected, not enforced):
+// API version string = <API type> '/' <API version>
+// API type = [a-z][a-z0-9]*
+// API version = [0-9]+(\.[0-9]+)?
+// TODO(dmcgowan): Enforce format, add error condition, remove unknown type
+func ParseAPIVersion(versionStr string) APIVersion {
+	idx := strings.IndexRune(versionStr, '/')
+	if idx == -1 {
+		return APIVersion{
+			Type:    "unknown",
+			Version: versionStr,
+		}
+	}
+	return APIVersion{
+		Type:    strings.ToLower(versionStr[:idx]),
+		Version: versionStr[idx+1:],
+	}
+}

--- a/registry/client/auth/authchallenge_test.go
+++ b/registry/client/auth/authchallenge_test.go
@@ -1,4 +1,4 @@
-package transport
+package auth
 
 import (
 	"net/http"
@@ -13,7 +13,7 @@ func TestAuthChallengeParse(t *testing.T) {
 	if len(challenges) != 1 {
 		t.Fatalf("Unexpected number of auth challenges: %d, expected 1", len(challenges))
 	}
-	challenge := challenges["bearer"]
+	challenge := challenges[0]
 
 	if expected := "bearer"; challenge.Scheme != expected {
 		t.Fatalf("Unexpected scheme: %s, expected: %s", challenge.Scheme, expected)

--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -1,4 +1,4 @@
-package transport
+package auth
 
 import (
 	"encoding/json"
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/docker/distribution/registry/client/transport"
 )
 
 // AuthenticationHandler is an interface for authorizing a request from
@@ -32,71 +34,24 @@ type CredentialStore interface {
 
 // NewAuthorizer creates an authorizer which can handle multiple authentication
 // schemes. The handlers are tried in order, the higher priority authentication
-// methods should be first.
-func NewAuthorizer(transport http.RoundTripper, handlers ...AuthenticationHandler) RequestModifier {
-	return &tokenAuthorizer{
-		challenges: map[string]map[string]authorizationChallenge{},
+// methods should be first. The challengeMap holds a list of challenges for
+// a given root API endpoint (for example "https://registry-1.docker.io/v2/").
+func NewAuthorizer(challengeMap map[string][]Challenge, handlers ...AuthenticationHandler) transport.RequestModifier {
+	return &endpointAuthorizer{
+		challenges: challengeMap,
 		handlers:   handlers,
-		transport:  transport,
 	}
 }
 
-type tokenAuthorizer struct {
-	challenges map[string]map[string]authorizationChallenge
+type endpointAuthorizer struct {
+	challenges map[string][]Challenge
 	handlers   []AuthenticationHandler
 	transport  http.RoundTripper
 }
 
-func (ta *tokenAuthorizer) ping(endpoint string) (map[string]authorizationChallenge, error) {
-	req, err := http.NewRequest("GET", endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	client := &http.Client{
-		Transport: ta.transport,
-		// Ping should fail fast
-		Timeout: 5 * time.Second,
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	// TODO(dmcgowan): Add version string which would allow skipping this section
-	var supportsV2 bool
-HeaderLoop:
-	for _, supportedVersions := range resp.Header[http.CanonicalHeaderKey("Docker-Distribution-API-Version")] {
-		for _, versionName := range strings.Fields(supportedVersions) {
-			if versionName == "registry/2.0" {
-				supportsV2 = true
-				break HeaderLoop
-			}
-		}
-	}
-
-	if !supportsV2 {
-		return nil, fmt.Errorf("%s does not appear to be a v2 registry endpoint", endpoint)
-	}
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		// Parse the WWW-Authenticate Header and store the challenges
-		// on this endpoint object.
-		return parseAuthHeader(resp.Header), nil
-	} else if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unable to get valid ping response: %d", resp.StatusCode)
-	}
-
-	return nil, nil
-}
-
-func (ta *tokenAuthorizer) ModifyRequest(req *http.Request) error {
+func (ea *endpointAuthorizer) ModifyRequest(req *http.Request) error {
 	v2Root := strings.Index(req.URL.Path, "/v2/")
-	// Test if /v2/ does not exist or not at beginning
-	// TODO(dmcgowan) support v2 endpoints which have a prefix before /v2/
-	if v2Root == -1 || v2Root > 0 {
+	if v2Root == -1 {
 		return nil
 	}
 
@@ -108,19 +63,16 @@ func (ta *tokenAuthorizer) ModifyRequest(req *http.Request) error {
 
 	pingEndpoint := ping.String()
 
-	challenges, ok := ta.challenges[pingEndpoint]
+	challenges, ok := ea.challenges[pingEndpoint]
 	if !ok {
-		var err error
-		challenges, err = ta.ping(pingEndpoint)
-		if err != nil {
-			return err
-		}
-		ta.challenges[pingEndpoint] = challenges
+		return nil
 	}
 
-	for _, handler := range ta.handlers {
-		challenge, ok := challenges[handler.Scheme()]
-		if ok {
+	for _, handler := range ea.handlers {
+		for _, challenge := range challenges {
+			if challenge.Scheme != handler.Scheme() {
+				continue
+			}
 			if err := handler.AuthorizeRequest(req, challenge.Parameters); err != nil {
 				return err
 			}
@@ -133,7 +85,7 @@ func (ta *tokenAuthorizer) ModifyRequest(req *http.Request) error {
 type tokenHandler struct {
 	header    http.Header
 	creds     CredentialStore
-	scope     TokenScope
+	scope     tokenScope
 	transport http.RoundTripper
 
 	tokenLock       sync.Mutex
@@ -141,25 +93,29 @@ type tokenHandler struct {
 	tokenExpiration time.Time
 }
 
-// TokenScope represents the scope at which a token will be requested.
+// tokenScope represents the scope at which a token will be requested.
 // This represents a specific action on a registry resource.
-type TokenScope struct {
+type tokenScope struct {
 	Resource string
 	Scope    string
 	Actions  []string
 }
 
-func (ts TokenScope) String() string {
+func (ts tokenScope) String() string {
 	return fmt.Sprintf("%s:%s:%s", ts.Resource, ts.Scope, strings.Join(ts.Actions, ","))
 }
 
 // NewTokenHandler creates a new AuthenicationHandler which supports
 // fetching tokens from a remote token server.
-func NewTokenHandler(transport http.RoundTripper, creds CredentialStore, scope TokenScope) AuthenticationHandler {
+func NewTokenHandler(transport http.RoundTripper, creds CredentialStore, scope string, actions ...string) AuthenticationHandler {
 	return &tokenHandler{
 		transport: transport,
 		creds:     creds,
-		scope:     scope,
+		scope: tokenScope{
+			Resource: "repository",
+			Scope:    scope,
+			Actions:  actions,
+		},
 	}
 }
 


### PR DESCRIPTION
Move client auth into a separate package.
Separate ping from the authorizer and export Challenges type.

This will allow for separating the ping logic from the transport. The ping can cleanly be done before creating the transport. This may lead to a condition where if multiple endpoints need to be called, the ping is not done. This case can be avoided by pinging each endpoint which may require an authentication challenge.