### PR TITLE
spec file for build rpm

### DIFF
--- a/docker-distribution.spec
+++ b/docker-distribution.spec
@@ -1,0 +1,45 @@
+%define version    2.0.1
+%define debug_package %{nil}
+Name: docker-distribution
+Version: %{version}
+Release:  1%{?dist}
+Summary: Docker Distribution server v2
+
+Group: Container Management
+License: Apache License
+URL: https://github.com/docker/distribution
+Source0: https://github.com/docker/distribution/archive/v%{version}.tar.gz
+
+BuildRequires: make
+Requires: nginx
+
+%description
+Docker Distribution server
+
+%prep
+%setup -q -n distribution-%{version}
+
+
+%build
+DISTRIBUTION_DIR=%{_topdir}/BUILD/distribution-%{version}
+GOPATH=$DISTRIBUTION_DIR/Godeps/_workspace:%{_topdir}/BUILD
+export GOPATH DISTRIBUTION_DIR
+make PREFIX=%{_topdir}/BUILD/distribution-%{version}/usr clean binaries
+
+%install
+mkdir -p %{buildroot}/usr/bin
+cp -p ./usr/bin/registry %{buildroot}/usr/bin/registry
+cp -p ./usr/bin/dist %{buildroot}/usr/bin/dist
+cp -p ./usr/bin/registry-api-descriptor-template %{buildroot}/usr/bin/registry-api-descriptor-template
+
+%files
+%doc
+/usr/bin/registry
+/usr/bin/dist
+/usr/bin/registry-api-descriptor-template
+
+
+%changelog
+
+
+


### PR DESCRIPTION
this spec allow to build rpm for centos and fedora OS.
init scripts and config not included , because it is specific for different use case(for me it is responsibility of puppet)
