### PR TITLE
Replace io.ReadFull with the helper from crypto/rand

### DIFF
--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -7,7 +7,6 @@ package uuid
 import (
 	"crypto/rand"
 	"fmt"
-	"io"
 	"log"
 	"syscall"
 	"time"
@@ -59,7 +58,7 @@ func Generate() (u UUID) {
 		time.Sleep(b)
 		totalBackoff += b
 
-		_, err := io.ReadFull(rand.Reader, u[:])
+		_, err := rand.Read(u[:])
 		if err != nil {
 			if err == syscall.EPERM {
 				// EPERM represents an entropy pool exhaustion, a condition under


### PR DESCRIPTION
Also I'm not sure about checking **EPERM** there.
I came across man of `getrandom`, the implementations in go:
https://github.com/golang/go/blob/release-branch.go1.4/src/crypto/rand/rand_linux.go#L37
https://github.com/golang/go/blob/release-branch.go1.4/src/crypto/rand/rand_unix.go#L47
https://github.com/golang/go/blob/release-branch.go1.4/src/crypto/rand/rand_unix.go#L94
I didn't find anything about **EPERM**. Even **EAGAIN** is trapped. The default Linux implementation is blocking.
Why should **EPERM** be checked?