### PR TITLE
Manifest and blob soft deletion

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -92,6 +92,9 @@ type BlobDescriptorService interface {
 	// the restriction that the algorithm of the descriptor must match the
 	// canonical algorithm (ie sha256) of the annotator.
 	SetDescriptor(ctx context.Context, dgst digest.Digest, desc Descriptor) error
+
+	// Delete enables descriptors to be unlinked
+	Delete(ctx context.Context, dgst digest.Digest) error
 }
 
 // ReadSeekCloser is the primary reader type for blob data, combining

--- a/blobs.go
+++ b/blobs.go
@@ -70,6 +70,11 @@ type BlobStatter interface {
 	Stat(ctx context.Context, dgst digest.Digest) (Descriptor, error)
 }
 
+// BlobDeleter enables deleting blobs from storage.
+type BlobDeleter interface {
+	Delete(ctx context.Context, dgst digest.Digest) error
+}
+
 // BlobDescriptorService manages metadata about a blob by digest. Most
 // implementations will not expose such an interface explicitly. Such mappings
 // should be maintained by interacting with the BlobIngester. Hence, this is
@@ -183,8 +188,9 @@ type BlobService interface {
 }
 
 // BlobStore represent the entire suite of blob related operations. Such an
-// implementation can access, read, write and serve blobs.
+// implementation can access, read, write, delete and serve blobs.
 type BlobStore interface {
 	BlobService
 	BlobServer
+	BlobDeleter
 }

--- a/blobs.go
+++ b/blobs.go
@@ -27,6 +27,9 @@ var (
 	// ErrBlobInvalidLength returned when the blob has an expected length on
 	// commit, meaning mismatched with the descriptor or an invalid value.
 	ErrBlobInvalidLength = errors.New("blob invalid length")
+
+	// ErrUnsupported returned when an unsupported operation is attempted
+	ErrUnsupported = errors.New("unsupported operation")
 )
 
 // ErrBlobInvalidDigest returned when digest check fails.

--- a/cmd/registry/config.yml
+++ b/cmd/registry/config.yml
@@ -5,7 +5,7 @@ log:
     service: registry
     environment: development
   hooks:
-    - type: mail
+    - type: mailtruth
       disabled: true
       levels:
         - panic
@@ -19,6 +19,8 @@ log:
         to:
           - errors@example.com
 storage:
+    delete:
+      enabled: false
     cache:
         blobdescriptor: inmemory
     filesystem:

--- a/cmd/registry/config.yml
+++ b/cmd/registry/config.yml
@@ -5,7 +5,7 @@ log:
     service: registry
     environment: development
   hooks:
-    - type: mailtruth
+    - type: mail
       disabled: true
       levels:
         - panic

--- a/cmd/registry/config.yml
+++ b/cmd/registry/config.yml
@@ -20,7 +20,7 @@ log:
           - errors@example.com
 storage:
     cache:
-        blobdescriptor: redis
+        blobdescriptor: inmemory
     filesystem:
         rootdirectory: /tmp/registry-dev
     maintenance:

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -240,6 +240,8 @@ func (storage Storage) Type() string {
 			// allow configuration of maintenance
 		case "cache":
 			// allow configuration of caching
+		case "delete":
+			// allow configuration of delete
 		default:
 			return k
 		}
@@ -271,6 +273,9 @@ func (storage *Storage) UnmarshalYAML(unmarshal func(interface{}) error) error {
 					// allow for configuration of maintenance
 				case "cache":
 					// allow configuration of caching
+				case "delete":
+					// allow configuration of delete
+
 				default:
 					types = append(types, k)
 				}

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -690,6 +690,21 @@ Note that the upload url will not be available forever. If the upload uuid is
 unknown to the registry, a `404 Not Found` response will be returned and the
 client must restart the upload process.
 
+### Deleting a Layer
+
+A layer may be deleted from the registry via its `name` and `reference`. A
+delete may be issued with the following request format:
+
+    DELETE /v2/<name>/blobs/<digest>
+
+If the blob exists and has been successfully deleted, the following response will be issued:
+
+    202 Accepted
+    Content-Length: None
+
+If the blob had already been deleted or did not exist, a `404 Not Found`
+response will be issued instead.
+
 #### Pushing an Image Manifest
 
 Once all of the layers for an image are uploaded, the client can upload the
@@ -808,6 +823,7 @@ A list of methods and URIs are covered in the table below:
 | PATCH | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Upload a chunk of data for the specified upload. |
 | PUT | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Complete the upload specified by `uuid`, optionally appending the body as the final chunk. |
 | DELETE | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Cancel outstanding upload processes, releasing associated resources. If this is not called, the unfinished uploads will eventually timeout. |
+| DELETE | `/v2/<name>/blobs/<digest>` | Blob delete | Delete the blob identified by `name` and `reference`|
 
 
 The detail for each endpoint is covered in the following sections.
@@ -1407,6 +1423,7 @@ The error codes that may be included in the response body are enumerated below:
 
 
 #### DELETE Manifest
+
 
 Delete the manifest identified by `name` and `reference`. Note that a manifest can _only_ be deleted by `digest`.
 

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -116,6 +116,13 @@ indicating what is different. Optionally, we may start marking parts of the
 specification to correspond with the versions enumerated here.
 
 <dl>
+  <dt>2.0.3</dt>
+	<dd>
+        <ul>
+	     	<li>Implement the delete API for blobs and manifests by using tombstone files to represent deleted data</li>
+	</ul>
+  </dd>
+
   <dt>2.0.2</dt>
   <dd>
     <li>Added section covering digest format.</li>

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -116,13 +116,20 @@ indicating what is different. Optionally, we may start marking parts of the
 specification to correspond with the versions enumerated here.
 
 <dl>
+	<dt>2.1</dt>
+	<dd>
+		<ul>
+	        	<li>Implement the delete API for blobs and manifests by using tombstone files to represent deleted data</li>
+		</ul>
+	</dd>
+
   <dt>2.0.2</dt>
   <dd>
     <li>Added section covering digest format.</li>
     <li>Added more clarification that manifest cannot be deleted by tag.</li>
   </dd>
 
-	<dt>2.0.1</dt>
+        <dt>2.0.1</dt>
 	<dd>
 		<ul>
 			<li>Added capability of doing streaming upload to PATCH blob upload.</li>
@@ -705,6 +712,9 @@ will be issued:
 
 If the blob had already been deleted or did not exist, a `404 Not Found`
 response will be issued instead.
+
+If a layer is deleted which is referenced by a manifest in the registry,
+some manifest operations may not succeed.
 
 #### Pushing an Image Manifest
 

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -116,12 +116,12 @@ indicating what is different. Optionally, we may start marking parts of the
 specification to correspond with the versions enumerated here.
 
 <dl>
-	<dt>2.1</dt>
+  <dt>2.0.3</dt>
 	<dd>
-		<ul>
-	        	<li>Implement the delete API for blobs and manifests by using tombstone files to represent deleted data</li>
-		</ul>
-	</dd>
+        <ul>
+	     	<li>Implement the delete API for blobs and manifests by using tombstone files to represent deleted data</li>
+	</ul>
+  </dd>
 
   <dt>2.0.2</dt>
   <dd>

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -690,6 +690,22 @@ Note that the upload url will not be available forever. If the upload uuid is
 unknown to the registry, a `404 Not Found` response will be returned and the
 client must restart the upload process.
 
+### Deleting a Layer
+
+A layer may be deleted from the registry via its `name` and `reference`. A
+delete may be issued with the following request format:
+
+    DELETE /v2/<name>/blobs/<digest>
+
+If the blob exists and has been successfully deleted, the following response
+will be issued:
+
+    202 Accepted
+    Content-Length: None
+
+If the blob had already been deleted or did not exist, a `404 Not Found`
+response will be issued instead.
+
 #### Pushing an Image Manifest
 
 Once all of the layers for an image are uploaded, the client can upload the

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestListener(t *testing.T) {
 	ctx := context.Background()
-	registry := storage.NewRegistryWithDriver(ctx, inmemory.New(), memory.NewInMemoryBlobDescriptorCacheProvider())
+	registry := storage.NewRegistryWithDriver(ctx, inmemory.New(), memory.NewInMemoryBlobDescriptorCacheProvider(), true)
 	tl := &testListener{
 		ops: make(map[string]int),
 	}

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -1376,13 +1376,6 @@ var errorDescriptors = []ErrorDescriptor{
 		response status.`,
 	},
 	{
-		Code:    ErrorCodeDisabled,
-		Value:   "DISABLED",
-		Message: "The operation is not enabled.",
-		Description: `The operation was not able to complete because
-                it has been disabled.`,
-	},
-	{
 		Code:    ErrorCodeDigestInvalid,
 		Value:   "DIGEST_INVALID",
 		Message: "provided digest did not match uploaded content",

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -1376,6 +1376,13 @@ var errorDescriptors = []ErrorDescriptor{
 		response status.`,
 	},
 	{
+		Code:    ErrorCodeDisabled,
+		Value:   "DISABLED",
+		Message: "The operation is not enabled.",
+		Description: `The operation was not able to complete because
+                it has been disabled.`,
+	},
+	{
 		Code:    ErrorCodeDigestInvalid,
 		Value:   "DIGEST_INVALID",
 		Message: "provided digest did not match uploaded content",

--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -19,6 +19,9 @@ const (
 	// ErrorCodeUnauthorized is returned if a request is not authorized.
 	ErrorCodeUnauthorized
 
+	// ErrorCodeDisabled is returned when a feature has been disabled
+	ErrorCodeDisabled
+
 	// ErrorCodeDigestInvalid is returned when uploading a blob if the
 	// provided digest does not match the blob contents.
 	ErrorCodeDigestInvalid

--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -19,9 +19,6 @@ const (
 	// ErrorCodeUnauthorized is returned if a request is not authorized.
 	ErrorCodeUnauthorized
 
-	// ErrorCodeDisabled is returned when a feature has been disabled
-	ErrorCodeDisabled
-
 	// ErrorCodeDigestInvalid is returned when uploading a blob if the
 	// provided digest does not match the blob contents.
 	ErrorCodeDigestInvalid

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -100,7 +100,6 @@ func TestBlobDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	l := r.Blobs(ctx)
-
 	err = l.Delete(ctx, dgst)
 	if err != nil {
 		t.Errorf("Error deleting blob: %s", err.Error())

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -74,6 +74,39 @@ func addTestFetch(repo string, dgst digest.Digest, content []byte, m *testutil.R
 	})
 }
 
+func TestBlobDelete(t *testing.T) {
+	dgst, _ := newRandomBlob(1024)
+	var m testutil.RequestResponseMap
+	repo := "test.example.com/repo1"
+	m = append(m, testutil.RequestResponseMapping{
+		Request: testutil.Request{
+			Method: "DELETE",
+			Route:  "/v2/" + repo + "/blobs/" + dgst.String(),
+		},
+		Response: testutil.Response{
+			StatusCode: http.StatusAccepted,
+			Headers: http.Header(map[string][]string{
+				"Content-Length": {"0"},
+			}),
+		},
+	})
+
+	e, c := testServer(m)
+	defer c()
+
+	ctx := context.Background()
+	r, err := NewRepository(ctx, repo, e, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := r.Blobs(ctx)
+
+	err = l.Delete(ctx, dgst)
+	if err != nil {
+		t.Errorf("Error deleting blob: %s", err.Error())
+	}
+}
+
 func TestBlobFetch(t *testing.T) {
 	d1, b1 := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
@@ -529,7 +562,7 @@ func TestManifestDelete(t *testing.T) {
 			Route:  "/v2/" + repo + "/manifests/" + dgst1.String(),
 		},
 		Response: testutil.Response{
-			StatusCode: http.StatusOK,
+			StatusCode: http.StatusAccepted,
 			Headers: http.Header(map[string][]string{
 				"Content-Length": {"0"},
 			}),

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -310,6 +310,80 @@ func TestBlobAPI(t *testing.T) {
 	// Missing tests:
 	// 	- Upload the same tarsum file under and different repository and
 	//       ensure the content remains uncorrupted.
+
+	// ---------------
+	// Delete a layer
+	resp, err = httpDelete(layerURL)
+	if err != nil {
+		t.Fatalf("unexpected error deleting layer: %v", err)
+	}
+
+	checkResponse(t, "deleting layer", resp, http.StatusAccepted)
+	checkHeaders(t, resp, http.Header{
+		"Content-Length": []string{"0"},
+	})
+
+	// ---------------
+	// Try and get it back
+	// Use a head request to see if the layer exists.
+	resp, err = http.Head(layerURL)
+	if err != nil {
+		t.Fatalf("unexpected error checking head on existing layer: %v", err)
+	}
+
+	checkResponse(t, "checking existence of deleted layer", resp, http.StatusNotFound)
+
+	// ----------------
+	// Delete already deleted layer
+	resp, err = httpDelete(layerURL)
+	if err != nil {
+		t.Fatalf("unexpected error deleting layer: %v", err)
+	}
+
+	checkResponse(t, "deleting layer", resp, http.StatusNotFound)
+
+	// ----------------
+	// Attempt to delete a layer with an invalid digest
+	resp, err = httpDelete(badURL)
+	if err != nil {
+		t.Fatalf("unexpected error fetching layer: %v", err)
+	}
+
+	checkResponse(t, "deleting layer bad digest", resp, http.StatusBadRequest)
+
+	// ----------------
+	// Reupload previously deleted blob
+	layerFile.Seek(0, os.SEEK_SET)
+
+	uploadURLBase, uploadUUID = startPushLayer(t, env.builder, imageName)
+	pushLayer(t, env.builder, imageName, layerDigest, uploadURLBase, layerFile)
+
+	// ------------------------
+	// Use a head request to see if it exists
+	resp, err = http.Get(layerURL)
+	if err != nil {
+		t.Fatalf("unexpected error checking head on existing layer: %v", err)
+	}
+
+	checkResponse(t, "checking head on reuploaded layer", resp, http.StatusOK)
+	checkHeaders(t, resp, http.Header{
+		"Content-Length":        []string{fmt.Sprint(layerLength)},
+		"Docker-Content-Digest": []string{canonicalDigest.String()},
+	})
+}
+
+func httpDelete(url string) (*http.Response, error) {
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	//	defer resp.Body.Close()
+	return resp, err
 }
 
 func TestManifestAPI(t *testing.T) {
@@ -509,6 +583,61 @@ func TestManifestAPI(t *testing.T) {
 	if tagsResponse.Tags[0] != tag {
 		t.Fatalf("tag not as expected: %q != %q", tagsResponse.Tags[0], tag)
 	}
+
+	// ---------------
+	// Delete by digest
+	resp, err = httpDelete(manifestDigestURL)
+	checkErr(t, err, "deleting manifest by digest")
+
+	checkResponse(t, "deleting manifest", resp, http.StatusAccepted)
+	checkHeaders(t, resp, http.Header{
+		"Content-Length": []string{"0"},
+	})
+
+	// ---------------
+	// Attempt to fetch deleted manifest
+	resp, err = http.Get(manifestDigestURL)
+	checkErr(t, err, "fetching deleted manifest by digest")
+	defer resp.Body.Close()
+
+	checkResponse(t, "fetching deleted manifest", resp, http.StatusNotFound)
+
+	// ---------------
+	// Delete already deleted manifest by digest
+	resp, err = httpDelete(manifestDigestURL)
+	checkErr(t, err, "re-deleting manifest by digest")
+
+	checkResponse(t, "re-deleting manifest", resp, http.StatusNotFound)
+
+	// --------------------
+	// Re-upload manifest by digest
+	resp = putManifest(t, "putting signed manifest", manifestDigestURL, signedManifest)
+	checkResponse(t, "putting signed manifest", resp, http.StatusAccepted)
+	checkHeaders(t, resp, http.Header{
+		"Location":              []string{manifestDigestURL},
+		"Docker-Content-Digest": []string{dgst.String()},
+	})
+
+	// ---------------
+	// Attempt to fetch re-uploaded deleted digest
+	resp, err = http.Get(manifestDigestURL)
+	checkErr(t, err, "fetching re-uploaded manifest by digest")
+	defer resp.Body.Close()
+
+	checkResponse(t, "fetching re-uploaded manifest", resp, http.StatusOK)
+	checkHeaders(t, resp, http.Header{
+		"Docker-Content-Digest": []string{dgst.String()},
+	})
+
+	// ---------------
+	// Attempt to delete an unknown manifest
+	unknownDigest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	unknownManifestDigestURL, err := env.builder.BuildManifestURL(imageName, unknownDigest)
+	checkErr(t, err, "building unknown manifest url")
+
+	resp, err = httpDelete(unknownManifestDigestURL)
+	checkErr(t, err, "delting unknown manifest by digest")
+	checkResponse(t, "fetching deleted manifest", resp, http.StatusNotFound)
 }
 
 type testEnv struct {
@@ -823,7 +952,7 @@ func checkHeaders(t *testing.T, resp *http.Response, headers http.Header) {
 
 			for _, hv := range resp.Header[k] {
 				if hv != v {
-					t.Fatalf("%v header value not matched in response: %q != %q", k, hv, v)
+					t.Fatalf("%+v %v header value not matched in response: %q != %q", resp.Header, k, hv, v)
 				}
 			}
 		}

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -104,6 +104,16 @@ func NewApp(ctx context.Context, configuration configuration.Configuration) *App
 	app.configureRedis(&configuration)
 	app.configureLogHook(&configuration)
 
+	deleteEnabled := false
+	if d, ok := configuration.Storage["delete"]; ok {
+		e, ok := d["enabled"]
+		if ok {
+			if deleteEnabled, ok = e.(bool); !ok {
+				deleteEnabled = false
+			}
+		}
+	}
+
 	// configure storage caches
 	if cc, ok := configuration.Storage["cache"]; ok {
 		v, ok := cc["blobdescriptor"]
@@ -117,10 +127,10 @@ func NewApp(ctx context.Context, configuration configuration.Configuration) *App
 			if app.redis == nil {
 				panic("redis configuration required to use for layerinfo cache")
 			}
-			app.registry = storage.NewRegistryWithDriver(app, app.driver, rediscache.NewRedisBlobDescriptorCacheProvider(app.redis))
+			app.registry = storage.NewRegistryWithDriver(app, app.driver, rediscache.NewRedisBlobDescriptorCacheProvider(app.redis), deleteEnabled)
 			ctxu.GetLogger(app).Infof("using redis blob descriptor cache")
 		case "inmemory":
-			app.registry = storage.NewRegistryWithDriver(app, app.driver, memorycache.NewInMemoryBlobDescriptorCacheProvider())
+			app.registry = storage.NewRegistryWithDriver(app, app.driver, memorycache.NewInMemoryBlobDescriptorCacheProvider(), deleteEnabled)
 			ctxu.GetLogger(app).Infof("using inmemory blob descriptor cache")
 		default:
 			if v != "" {
@@ -131,7 +141,7 @@ func NewApp(ctx context.Context, configuration configuration.Configuration) *App
 
 	if app.registry == nil {
 		// configure the registry if no cache section is available.
-		app.registry = storage.NewRegistryWithDriver(app.Context, app.driver, nil)
+		app.registry = storage.NewRegistryWithDriver(app.Context, app.driver, nil, deleteEnabled)
 	}
 
 	app.registry, err = applyRegistryMiddleware(app.registry, configuration.Middleware["registry"])

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -30,7 +30,7 @@ func TestAppDispatcher(t *testing.T) {
 		Context:  ctx,
 		router:   v2.Router(),
 		driver:   driver,
-		registry: storage.NewRegistryWithDriver(ctx, driver, memorycache.NewInMemoryBlobDescriptorCacheProvider()),
+		registry: storage.NewRegistryWithDriver(ctx, driver, memorycache.NewInMemoryBlobDescriptorCacheProvider(), true),
 	}
 	server := httptest.NewServer(app)
 	router := v2.Router()

--- a/registry/handlers/blob.go
+++ b/registry/handlers/blob.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/storage"
 	"github.com/gorilla/handlers"
 )
 
@@ -69,7 +70,7 @@ func (bh *blobHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// DeleteBlob performs a soft delete of a layer blob
+// DeleteBlob deletes a layer blob
 func (bh *blobHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 	context.GetLogger(bh).Debug("DeleteBlob")
 
@@ -80,6 +81,9 @@ func (bh *blobHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 		case distribution.ErrBlobUnknown:
 			w.WriteHeader(http.StatusNotFound)
 			bh.Errors.Push(v2.ErrorCodeBlobUnknown, bh.Digest)
+		case storage.ErrDeleteDisabled:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			bh.Errors.Push(v2.ErrorCodeDisabled, bh.Digest)
 		default:
 			bh.Errors.Push(v2.ErrorCodeUnknown, err)
 		}

--- a/registry/handlers/blob.go
+++ b/registry/handlers/blob.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/api/v2"
-	"github.com/docker/distribution/registry/storage"
 	"github.com/gorilla/handlers"
 )
 
@@ -81,9 +80,9 @@ func (bh *blobHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 		case distribution.ErrBlobUnknown:
 			w.WriteHeader(http.StatusNotFound)
 			bh.Errors.Push(v2.ErrorCodeBlobUnknown, bh.Digest)
-		case storage.ErrDeleteDisabled:
+		case distribution.ErrUnsupported:
 			w.WriteHeader(http.StatusMethodNotAllowed)
-			bh.Errors.Push(v2.ErrorCodeDisabled, bh.Digest)
+			bh.Errors.Push(v2.ErrorCodeUnsupported, bh.Digest)
 		default:
 			bh.Errors.Push(v2.ErrorCodeUnknown, err)
 		}

--- a/registry/handlers/blob.go
+++ b/registry/handlers/blob.go
@@ -33,8 +33,9 @@ func blobDispatcher(ctx *Context, r *http.Request) http.Handler {
 	}
 
 	return handlers.MethodHandler{
-		"GET":  http.HandlerFunc(blobHandler.GetBlob),
-		"HEAD": http.HandlerFunc(blobHandler.GetBlob),
+		"GET":    http.HandlerFunc(blobHandler.GetBlob),
+		"HEAD":   http.HandlerFunc(blobHandler.GetBlob),
+		"DELETE": http.HandlerFunc(blobHandler.DeleteBlob),
 	}
 }
 
@@ -66,4 +67,25 @@ func (bh *blobHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
 		bh.Errors.Push(v2.ErrorCodeUnknown, err)
 		return
 	}
+}
+
+// DeleteBlob performs a soft delete of a layer blob
+func (bh *blobHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
+	context.GetLogger(bh).Debug("DeleteBlob")
+
+	blobs := bh.Repository.Blobs(bh)
+	err := blobs.Delete(bh, bh.Digest)
+	if err != nil {
+		switch err {
+		case distribution.ErrBlobUnknown:
+			w.WriteHeader(http.StatusNotFound)
+			bh.Errors.Push(v2.ErrorCodeBlobUnknown, bh.Digest)
+		default:
+			bh.Errors.Push(v2.ErrorCodeUnknown, err)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Length", "0")
+	w.WriteHeader(http.StatusAccepted)
 }

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/storage"
 	"github.com/gorilla/handlers"
 	"golang.org/x/net/context"
 )
@@ -187,6 +188,9 @@ func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *h
 			imh.Errors.Push(v2.ErrorCodeManifestUnknown)
 			w.WriteHeader(http.StatusNotFound)
 			return
+		case storage.ErrDeleteDisabled:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			imh.Errors.Push(v2.ErrorCodeDisabled, imh.Digest)
 		default:
 			imh.Errors.PushErr(err)
 			w.WriteHeader(http.StatusBadRequest)

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -170,17 +170,31 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 	w.WriteHeader(http.StatusAccepted)
 }
 
-// DeleteImageManifest removes the image with the given tag from the registry.
+// DeleteImageManifest removes the manifest with the given digest from the registry.
 func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *http.Request) {
 	ctxu.GetLogger(imh).Debug("DeleteImageManifest")
 
-	// TODO(stevvooe): Unfortunately, at this point, manifest deletes are
-	// unsupported. There are issues with schema version 1 that make removing
-	// tag index entries a serious problem in eventually consistent storage.
-	// Once we work out schema version 2, the full deletion system will be
-	// worked out and we can add support back.
-	imh.Errors.Push(v2.ErrorCodeUnsupported)
-	w.WriteHeader(http.StatusBadRequest)
+	manifests := imh.Repository.Manifests()
+	err := manifests.Delete(imh.Digest)
+	if err != nil {
+		switch err {
+		case digest.ErrDigestUnsupported:
+		case digest.ErrDigestInvalidFormat:
+			imh.Errors.PushErr(err)
+			//			w.WriteHeader(http.StatusBadRequest)
+			return
+		case distribution.ErrBlobUnknown:
+			imh.Errors.Push(v2.ErrorCodeManifestUnknown)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		default:
+			imh.Errors.PushErr(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusAccepted)
 }
 
 // digestManifest takes a digest of the given manifest. This belongs somewhere

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/registry/api/v2"
-	"github.com/docker/distribution/registry/storage"
 	"github.com/gorilla/handlers"
 	"golang.org/x/net/context"
 )
@@ -188,9 +187,9 @@ func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *h
 			imh.Errors.Push(v2.ErrorCodeManifestUnknown)
 			w.WriteHeader(http.StatusNotFound)
 			return
-		case storage.ErrDeleteDisabled:
+		case distribution.ErrUnsupported:
 			w.WriteHeader(http.StatusMethodNotAllowed)
-			imh.Errors.Push(v2.ErrorCodeDisabled, imh.Digest)
+			imh.Errors.Push(v2.ErrorCodeUnsupported, imh.Digest)
 		default:
 			imh.Errors.PushErr(err)
 			w.WriteHeader(http.StatusBadRequest)

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -141,7 +141,7 @@ func (bs *blobStore) resolve(ctx context.Context, path string) (string, error) {
 type blobStatter struct {
 	driver driver.StorageDriver
 	pm     *pathMapper
-	tomb   tomb
+	tomb   *tomb
 }
 
 var _ distribution.BlobStatter = &blobStatter{}

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/distribution/registry/storage/driver"
 )
 
-// blobStore implements a the read side of the blob store interface over a
+// blobStore implements the read side of the blob store interface over a
 // driver without enforcing per-repository membership. This object is
 // intentionally a leaky abstraction, providing utility methods that support
 // creating and traversing backend links.
@@ -141,6 +141,7 @@ func (bs *blobStore) resolve(ctx context.Context, path string) (string, error) {
 type blobStatter struct {
 	driver driver.StorageDriver
 	pm     *pathMapper
+	tomb   tomb
 }
 
 var _ distribution.BlobStatter = &blobStatter{}

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -143,7 +143,7 @@ type blobStatter struct {
 	pm     *pathMapper
 }
 
-var _ distribution.BlobStatter = &blobStatter{}
+var _ distribution.BlobDescriptorService = &blobStatter{}
 
 // Stat implements BlobStatter.Stat by returning the descriptor for the blob
 // in the main blob store. If this method returns successfully, there is
@@ -187,4 +187,12 @@ func (bs *blobStatter) Stat(ctx context.Context, dgst digest.Digest) (distributi
 		MediaType: "application/octet-stream",
 		Digest:    dgst,
 	}, nil
+}
+
+func (bs *blobStatter) Delete(ctx context.Context, dgst digest.Digest) error {
+	return distribution.ErrUnsupported
+}
+
+func (bs *blobStatter) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
+	return distribution.ErrUnsupported
 }

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -141,7 +141,6 @@ func (bs *blobStore) resolve(ctx context.Context, path string) (string, error) {
 type blobStatter struct {
 	driver driver.StorageDriver
 	pm     *pathMapper
-	tomb   *tomb
 }
 
 var _ distribution.BlobStatter = &blobStatter{}

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -72,7 +72,7 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 	// If this upload is replacing a previously deleted file, remove the tombstone
 	// If tombstones deletes are not enabled, fall through
 	exists, err := bw.blobStore.tomb.tombstoneExists(ctx, bw.blobStore.repository.Name(), desc.Digest)
-	if err != nil && err != ErrDeleteDisabled {
+	if err != nil && err != distribution.ErrUnsupported {
 		return distribution.Descriptor{}, err
 	}
 	if exists {

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -70,8 +70,9 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 	}
 
 	// If this upload is replacing a previously deleted file, remove the tombstone
+	// If tombstones deletes are not enabled, fall through
 	exists, err := bw.blobStore.tomb.tombstoneExists(ctx, bw.blobStore.repository.Name(), desc.Digest)
-	if err != nil {
+	if err != nil && err != ErrDeleteDisabled {
 		return distribution.Descriptor{}, err
 	}
 	if exists {

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -69,16 +69,9 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 		return distribution.Descriptor{}, err
 	}
 
-	// If this upload is replacing a previously deleted file, remove the tombstone
-	// If tombstones deletes are not enabled, fall through
-	exists, err := bw.blobStore.tomb.tombstoneExists(ctx, bw.blobStore.repository.Name(), desc.Digest)
-	if err != nil && err != distribution.ErrUnsupported {
+	err = bw.blobStore.blobAccessController.SetDescriptor(ctx, desc.Digest, desc)
+	if err != nil {
 		return distribution.Descriptor{}, err
-	}
-	if exists {
-		if err := bw.blobStore.tomb.deleteTombstone(ctx, bw.blobStore.repository.Name(), desc.Digest); err != nil {
-			return distribution.Descriptor{}, err
-		}
 	}
 
 	return canonical, nil

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -69,6 +69,17 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 		return distribution.Descriptor{}, err
 	}
 
+	// If this upload is replacing a previously deleted file, remove the tombstone
+	exists, err := bw.blobStore.tomb.tombstoneExists(ctx, bw.blobStore.repository.Name(), desc.Digest)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	if exists {
+		if err := bw.blobStore.tomb.deleteTombstone(ctx, bw.blobStore.repository.Name(), desc.Digest); err != nil {
+			return distribution.Descriptor{}, err
+		}
+	}
+
 	return canonical, nil
 }
 

--- a/registry/storage/cache/cachedblobdescriptorstore.go
+++ b/registry/storage/cache/cachedblobdescriptorstore.go
@@ -26,13 +26,13 @@ type MetricsTracker interface {
 
 type cachedBlobStatter struct {
 	cache   distribution.BlobDescriptorService
-	backend distribution.BlobStatter
+	backend distribution.BlobDescriptorService
 	tracker MetricsTracker
 }
 
 // NewCachedBlobStatter creates a new statter which prefers a cache and
 // falls back to a backend.
-func NewCachedBlobStatter(cache distribution.BlobDescriptorService, backend distribution.BlobStatter) distribution.BlobDescriptorService {
+func NewCachedBlobStatter(cache distribution.BlobDescriptorService, backend distribution.BlobDescriptorService) distribution.BlobDescriptorService {
 	return &cachedBlobStatter{
 		cache:   cache,
 		backend: backend,
@@ -41,7 +41,7 @@ func NewCachedBlobStatter(cache distribution.BlobDescriptorService, backend dist
 
 // NewCachedBlobStatterWithMetrics creates a new statter which prefers a cache and
 // falls back to a backend. Hits and misses will send to the tracker.
-func NewCachedBlobStatterWithMetrics(cache distribution.BlobDescriptorService, backend distribution.BlobStatter, tracker MetricsTracker) distribution.BlobStatter {
+func NewCachedBlobStatterWithMetrics(cache distribution.BlobDescriptorService, backend distribution.BlobDescriptorService, tracker MetricsTracker) distribution.BlobStatter {
 	return &cachedBlobStatter{
 		cache:   cache,
 		backend: backend,
@@ -81,7 +81,16 @@ fallback:
 }
 
 func (cbds *cachedBlobStatter) Delete(ctx context.Context, dgst digest.Digest) error {
-	return cbds.cache.Delete(ctx, dgst)
+	err := cbds.cache.Delete(ctx, dgst)
+	if err != nil {
+		return err
+	}
+
+	err = cbds.backend.Delete(ctx, dgst)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (cbds *cachedBlobStatter) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {

--- a/registry/storage/cache/cachedblobdescriptorstore.go
+++ b/registry/storage/cache/cachedblobdescriptorstore.go
@@ -32,7 +32,7 @@ type cachedBlobStatter struct {
 
 // NewCachedBlobStatter creates a new statter which prefers a cache and
 // falls back to a backend.
-func NewCachedBlobStatter(cache distribution.BlobDescriptorService, backend distribution.BlobStatter) distribution.BlobStatter {
+func NewCachedBlobStatter(cache distribution.BlobDescriptorService, backend distribution.BlobStatter) distribution.BlobDescriptorService {
 	return &cachedBlobStatter{
 		cache:   cache,
 		backend: backend,
@@ -77,4 +77,16 @@ fallback:
 	}
 
 	return desc, err
+
+}
+
+func (cbds *cachedBlobStatter) Delete(ctx context.Context, dgst digest.Digest) error {
+	return cbds.cache.Delete(ctx, dgst)
+}
+
+func (cbds *cachedBlobStatter) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
+	if err := cbds.cache.SetDescriptor(ctx, dgst, desc); err != nil {
+		context.GetLogger(ctx).Errorf("error adding descriptor %v to cache: %v", desc.Digest, err)
+	}
+	return nil
 }

--- a/registry/storage/cache/memory/memory.go
+++ b/registry/storage/cache/memory/memory.go
@@ -44,6 +44,10 @@ func (imbdcp *inMemoryBlobDescriptorCacheProvider) Stat(ctx context.Context, dgs
 	return imbdcp.global.Stat(ctx, dgst)
 }
 
+func (imbdcp *inMemoryBlobDescriptorCacheProvider) Delete(ctx context.Context, dgst digest.Digest) error {
+	return imbdcp.global.Delete(ctx, dgst)
+}
+
 func (imbdcp *inMemoryBlobDescriptorCacheProvider) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
 	_, err := imbdcp.Stat(ctx, dgst)
 	if err == distribution.ErrBlobUnknown {
@@ -78,6 +82,14 @@ func (rsimbdcp *repositoryScopedInMemoryBlobDescriptorCache) Stat(ctx context.Co
 	}
 
 	return rsimbdcp.repository.Stat(ctx, dgst)
+}
+
+func (rsimbdcp *repositoryScopedInMemoryBlobDescriptorCache) Delete(ctx context.Context, dgst digest.Digest) error {
+	if rsimbdcp.repository == nil {
+		return distribution.ErrBlobUnknown
+	}
+
+	return rsimbdcp.repository.Delete(ctx, dgst)
 }
 
 func (rsimbdcp *repositoryScopedInMemoryBlobDescriptorCache) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
@@ -131,6 +143,14 @@ func (mbdc *mapBlobDescriptorCache) Stat(ctx context.Context, dgst digest.Digest
 	}
 
 	return desc, nil
+}
+
+func (mbdc *mapBlobDescriptorCache) Delete(ctx context.Context, dgst digest.Digest) error {
+	mbdc.mu.Lock()
+	defer mbdc.mu.Unlock()
+
+	delete(mbdc.descriptors, dgst)
+	return nil
 }
 
 func (mbdc *mapBlobDescriptorCache) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {

--- a/registry/storage/cache/redis/redis.go
+++ b/registry/storage/cache/redis/redis.go
@@ -12,7 +12,7 @@ import (
 )
 
 // redisBlobStatService provides an implementation of
-// BlobDescriptorCacheProvider based on redis. Blob descritors are stored in
+// BlobDescriptorCacheProvider based on redis. Blob descriptors are stored in
 // two parts. The first provide fast access to repository membership through a
 // redis set for each repo. The second is a redis hash keyed by the digest of
 // the layer, providing path, length and mediatype information. There is also
@@ -61,6 +61,27 @@ func (rbds *redisBlobDescriptorService) Stat(ctx context.Context, dgst digest.Di
 	defer conn.Close()
 
 	return rbds.stat(ctx, conn, dgst)
+}
+
+func (rbds *redisBlobDescriptorService) Delete(ctx context.Context, dgst digest.Digest) error {
+	if err := dgst.Validate(); err != nil {
+		return err
+	}
+
+	conn := rbds.pool.Get()
+	defer conn.Close()
+
+	// Not atomic in redis <= 2.3
+	reply, err := conn.Do("HDEL", rbds.blobDescriptorHashKey(dgst), "digest", "length", "mediatype")
+	if err != nil {
+		return err
+	}
+
+	if reply == 0 {
+		return distribution.ErrBlobUnknown
+	}
+
+	return nil
 }
 
 // stat provides an internal stat call that takes a connection parameter. This
@@ -165,6 +186,29 @@ func (rsrbds *repositoryScopedRedisBlobDescriptorService) Stat(ctx context.Conte
 	}
 
 	return upstream, nil
+}
+
+// Delete ensures that the descriptor belongs to the scoped repository and forwards the delete request
+// upstream to the global descriptor store
+func (rsrbds *repositoryScopedRedisBlobDescriptorService) Delete(ctx context.Context, dgst digest.Digest) error {
+	if err := dgst.Validate(); err != nil {
+		return err
+	}
+
+	conn := rsrbds.upstream.pool.Get()
+	defer conn.Close()
+
+	// Check membership to repository first
+	member, err := redis.Bool(conn.Do("SISMEMBER", rsrbds.repositoryBlobSetKey(rsrbds.repo), dgst))
+	if err != nil {
+		return err
+	}
+
+	if !member {
+		return distribution.ErrBlobUnknown
+	}
+
+	return rsrbds.upstream.Delete(ctx, dgst)
 }
 
 func (rsrbds *repositoryScopedRedisBlobDescriptorService) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {

--- a/registry/storage/cache/suite.go
+++ b/registry/storage/cache/suite.go
@@ -139,3 +139,40 @@ func checkBlobDescriptorCacheSetAndRead(t *testing.T, ctx context.Context, provi
 		t.Fatalf("unexpected descriptor: %#v != %#v", desc, expected)
 	}
 }
+
+func checkBlobDescriptorDelete(t *testing.T, ctx context.Context, provider BlobDescriptorCacheProvider) {
+	localDigest := digest.Digest("sha384:abc")
+	expected := distribution.Descriptor{
+		Digest:    "sha256:abc",
+		Length:    10,
+		MediaType: "application/octet-stream"}
+
+	cache, err := provider.RepositoryScoped("foo/bar")
+	if err != nil {
+		t.Fatalf("unexpected error getting scoped cache: %v", err)
+	}
+
+	if err := cache.SetDescriptor(ctx, localDigest, expected); err != nil {
+		t.Fatalf("error setting descriptor: %v", err)
+	}
+
+	desc, err := cache.Stat(ctx, localDigest)
+	if err != nil {
+		t.Fatalf("unexpected error statting fake2:abc: %v", err)
+	}
+
+	if expected != desc {
+		t.Fatalf("unexpected descriptor: %#v != %#v", expected, desc)
+	}
+
+	err = cache.Delete(ctx, localDigest)
+	if err != nil {
+		t.Fatalf("unexpected error deleting descriptor")
+	}
+
+	nonExistantDigest := digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	err = cache.Delete(ctx, nonExistantDigest)
+	if err == nil {
+		t.Fatalf("expected error deleting unknown descriptor")
+	}
+}

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -80,7 +80,7 @@ func (lbs *linkedBlobStore) Put(ctx context.Context, mediaType string, p []byte)
 	// deletes are not enabled, fall through
 	dgst, err := digest.FromBytes(p)
 	tombstoneExists, err := lbs.tomb.tombstoneExists(ctx, lbs.repository.Name(), dgst)
-	if err != nil && err != ErrDeleteDisabled {
+	if err != nil && err != distribution.ErrUnsupported {
 		return distribution.Descriptor{}, err
 	}
 	if tombstoneExists {
@@ -170,7 +170,7 @@ func (lbs *linkedBlobStore) Resume(ctx context.Context, id string) (distribution
 
 func (lbs *linkedBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	if !lbs.tomb.enabled {
-		return ErrDeleteDisabled
+		return distribution.ErrUnsupported
 	}
 
 	_, err := lbs.statter.Stat(ctx, dgst)
@@ -254,7 +254,7 @@ var _ distribution.BlobDescriptorService = &linkedBlobStatter{}
 
 func (lbs *linkedBlobStatter) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
 	tombstoneExists, err := lbs.tomb.tombstoneExists(ctx, lbs.repository.Name(), dgst)
-	if err != nil && err != ErrDeleteDisabled {
+	if err != nil && err != distribution.ErrUnsupported {
 		return distribution.Descriptor{}, err
 	}
 	if tombstoneExists {

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -19,6 +19,7 @@ type linkedBlobStore struct {
 	blobServer distribution.BlobServer
 	statter    distribution.BlobStatter
 	repository distribution.Repository
+	tomb       tomb
 	ctx        context.Context // only to be used where context can't come through method args
 
 	// linkPath allows one to control the repository blob link set to which
@@ -31,6 +32,13 @@ type linkedBlobStore struct {
 var _ distribution.BlobStore = &linkedBlobStore{}
 
 func (lbs *linkedBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	tombstoneExists, err := lbs.tomb.tombstoneExists(ctx, lbs.repository.Name(), dgst)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	if tombstoneExists {
+		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	}
 	return lbs.statter.Stat(ctx, dgst)
 }
 
@@ -72,6 +80,19 @@ func (lbs *linkedBlobStore) Put(ctx context.Context, mediaType string, p []byte)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("error putting into main store: %v", err)
 		return distribution.Descriptor{}, err
+	}
+
+	// Remove a tombstone if one exists for this blob.  Continue to write
+	// the blob as it may have been removed by the GC sweep process
+	dgst, err := digest.FromBytes(p)
+	tombstoneExists, err := lbs.tomb.tombstoneExists(ctx, lbs.repository.Name(), dgst)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	if tombstoneExists {
+		if err := lbs.tomb.deleteTombstone(ctx, lbs.repository.Name(), dgst); err != nil {
+			return distribution.Descriptor{}, err
+		}
 	}
 
 	// TODO(stevvooe): Write out mediatype if incoming differs from what is
@@ -153,7 +174,23 @@ func (lbs *linkedBlobStore) Resume(ctx context.Context, id string) (distribution
 	return lbs.newBlobUpload(ctx, id, path, startedAt)
 }
 
-// newLayerUpload allocates a new upload controller with the given state.
+func (lbs *linkedBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	_, err := lbs.statter.Stat(ctx, dgst)
+	if err != nil {
+		return err
+	}
+	if err == distribution.ErrBlobUnknown {
+		return distribution.ErrBlobUnknown
+	}
+
+	if err := lbs.tomb.putTombstone(ctx, lbs.repository.Name(), dgst); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// newBlobUpload allocates a new upload controller with the given state.
 func (lbs *linkedBlobStore) newBlobUpload(ctx context.Context, uuid, path string, startedAt time.Time) (distribution.BlobWriter, error) {
 	fw, err := newFileWriter(ctx, lbs.driver, path)
 	if err != nil {
@@ -205,6 +242,7 @@ func (lbs *linkedBlobStore) linkBlob(ctx context.Context, canonical distribution
 type linkedBlobStatter struct {
 	*blobStore
 	repository distribution.Repository
+	tomb       tomb
 
 	// linkPath allows one to control the repository blob link set to which
 	// the blob store dispatches. This is required because manifest and layer
@@ -216,6 +254,14 @@ type linkedBlobStatter struct {
 var _ distribution.BlobStatter = &linkedBlobStatter{}
 
 func (lbs *linkedBlobStatter) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	tombstoneExists, err := lbs.tomb.tombstoneExists(ctx, lbs.repository.Name(), dgst)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	if tombstoneExists {
+		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	}
+
 	blobLinkPath, err := lbs.linkPath(lbs.pm, lbs.repository.Name(), dgst)
 	if err != nil {
 		return distribution.Descriptor{}, err

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -59,8 +59,8 @@ func (ms *manifestStore) Put(manifest *manifest.SignedManifest) error {
 
 // Delete removes the revision of the specified manfiest.
 func (ms *manifestStore) Delete(dgst digest.Digest) error {
-	context.GetLogger(ms.ctx).Debug("(*manifestStore).Delete - unsupported")
-	return fmt.Errorf("deletion of manifests not supported")
+	context.GetLogger(ms.ctx).Debug("(*manifestStore).Delete")
+	return ms.revisionStore.delete(ms.ctx, dgst)
 }
 
 func (ms *manifestStore) Tags() ([]string, error) {

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -29,7 +29,7 @@ type manifestStoreTestEnv struct {
 func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestEnv {
 	ctx := context.Background()
 	driver := inmemory.New()
-	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider())
+	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), true)
 	repo, err := registry.Repository(ctx, name)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -340,5 +340,18 @@ func TestManifestStorage(t *testing.T) {
 	}
 	if deletedManifest == nil {
 		t.Errorf("Deleted manifest get returned non-nil")
+	}
+
+	ctx := env.ctx
+
+	r := NewRegistryWithDriver(ctx, env.driver, memory.NewInMemoryBlobDescriptorCacheProvider(), false)
+	repo, err := r.Repository(ctx, env.name)
+	if err != nil {
+		t.Fatalf("unexpected error getting repo: %v", err)
+	}
+	ms = repo.Manifests()
+	err = ms.Delete(dgst)
+	if err == nil {
+		t.Errorf("Unexpected success deleting while disabled")
 	}
 }

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -30,7 +30,6 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 	ctx := context.Background()
 	driver := inmemory.New()
 	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider())
-
 	repo, err := registry.Repository(ctx, name)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -292,11 +291,54 @@ func TestManifestStorage(t *testing.T) {
 		}
 	}
 
-	// TODO(stevvooe): Currently, deletes are not supported due to some
-	// complexity around managing tag indexes. We'll add this support back in
-	// when the manifest format has settled. For now, we expect an error for
-	// all deletes.
-	if err := ms.Delete(dgst); err == nil {
+	// Test deleting manifests
+	err = ms.Delete(dgst)
+	if err != nil {
 		t.Fatalf("unexpected an error deleting manifest by digest: %v", err)
+	}
+
+	exists, err = ms.Exists(dgst)
+	if err != nil {
+		t.Fatalf("Error querying manifest existence")
+	}
+	if exists {
+		t.Errorf("Deleted manifest should not exist")
+	}
+
+	deletedManifest, err := ms.Get(dgst)
+	if err == nil {
+		t.Errorf("Unexpected success getting deleted manifest")
+	}
+	switch err.(type) {
+	case distribution.ErrManifestUnknownRevision:
+		break
+	default:
+		t.Errorf("Unexpected error getting deleted manifest: %s", reflect.ValueOf(err).Type())
+	}
+
+	if deletedManifest != nil {
+		t.Errorf("Deleted manifest get returned non-nil")
+	}
+
+	// Re-upload should restore manifest to a good state
+	err = ms.Put(sm)
+	if err != nil {
+		t.Errorf("Error re-uploading deleted manifest")
+	}
+
+	exists, err = ms.Exists(dgst)
+	if err != nil {
+		t.Fatalf("Error querying manifest existence")
+	}
+	if !exists {
+		t.Errorf("Restored manifest should exist")
+	}
+
+	deletedManifest, err = ms.Get(dgst)
+	if err != nil {
+		t.Errorf("Unexpected error getting manifest")
+	}
+	if deletedManifest == nil {
+		t.Errorf("Deleted manifest get returned non-nil")
 	}
 }

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -151,6 +151,7 @@ func TestManifestStorage(t *testing.T) {
 	}
 
 	fetchedManifest, err := ms.GetByTag(env.tag)
+
 	if err != nil {
 		t.Fatalf("unexpected error fetching manifest: %v", err)
 	}

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -265,6 +265,14 @@ func (pm *pathMapper) path(spec pathSpec) (string, error) {
 		return path.Join(append(repoPrefix, v.name, "_uploads", v.id, "hashstates", string(v.alg), offset)...), nil
 	case repositoriesRootPathSpec:
 		return path.Join(repoPrefix...), nil
+	case tombstoneSpec:
+		components, err := digestPathComponents(v.digest, false)
+		if err != nil {
+			return "", err
+		}
+		deletedRoot := append(repoPrefix, v.name, "_deleted")
+		tombstonePath := append(components, "link")
+		return path.Join(append(deletedRoot, tombstonePath...)...), nil
 	default:
 		// TODO(sday): This is an internal error. Ensure it doesn't escape (panic?).
 		return "", fmt.Errorf("unknown path spec: %#v", v)
@@ -459,6 +467,15 @@ type repositoriesRootPathSpec struct {
 }
 
 func (repositoriesRootPathSpec) pathSpec() {}
+
+// tombstoneSpec represent files marked for deletion
+// which have not yet been removed from storage
+type tombstoneSpec struct {
+	name   string
+	digest digest.Digest
+}
+
+func (tombstoneSpec) pathSpec() {}
 
 // digestPathComponents provides a consistent path breakdown for a given
 // digest. For a generic digest, it will be as follows:

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -34,6 +34,8 @@ const storagePathVersion = "v2"
 // 						data
 // 						startedat
 // 						hashstates/<algorithm>/<offset>
+//                                      -> _deleted/<id>
+//                                              -> link
 //			-> blob/<algorithm>
 //				<split directory content addressable storage>
 //

--- a/registry/storage/revisionstore.go
+++ b/registry/storage/revisionstore.go
@@ -17,19 +17,6 @@ type revisionStore struct {
 	ctx        context.Context
 }
 
-func newRevisionStore(ctx context.Context, repo *repository, blobStore *blobStore) *revisionStore {
-	return &revisionStore{
-		ctx:        ctx,
-		repository: repo,
-		blobStore: &linkedBlobStore{
-			blobStore:  blobStore,
-			repository: repo,
-			ctx:        ctx,
-			linkPath:   manifestRevisionLinkPath,
-		},
-	}
-}
-
 // get retrieves the manifest, keyed by revision digest.
 func (rs *revisionStore) get(ctx context.Context, revision digest.Digest) (*manifest.SignedManifest, error) {
 	// Ensure that this revision is available in this repository.
@@ -117,4 +104,10 @@ func (rs *revisionStore) put(ctx context.Context, sm *manifest.SignedManifest) (
 	}
 
 	return revision, nil
+}
+
+// delete creates a tombstone for the given digest revision.  The tombstone
+// is a link file which points to the deleted manifest.
+func (rs *revisionStore) delete(ctx context.Context, revision digest.Digest) error {
+	return rs.blobStore.Delete(ctx, revision)
 }

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -135,15 +135,9 @@ func (s *signatureStore) linkedBlobStore(ctx context.Context, revision digest.Di
 			blobStore:  s.blobStore,
 			repository: s.repository,
 			linkPath:   linkpath,
-			tomb: tomb{
-				pm:     defaultPathMapper,
-				driver: s.repository.registry.blobStore.driver,
-			},
+			tomb:       s.repository.tomb,
 		},
 		linkPath: linkpath,
-		tomb: tomb{
-			pm:     defaultPathMapper,
-			driver: s.repository.registry.blobStore.driver,
-		},
+		tomb:     s.repository.tomb,
 	}
 }

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -131,13 +131,12 @@ func (s *signatureStore) linkedBlobStore(ctx context.Context, revision digest.Di
 		ctx:        ctx,
 		repository: s.repository,
 		blobStore:  s.blobStore,
-		statter: &linkedBlobStatter{
+		blobAccessController: &linkedBlobStatter{
 			blobStore:  s.blobStore,
 			repository: s.repository,
 			linkPath:   linkpath,
 			tomb:       s.repository.tomb,
 		},
 		linkPath: linkpath,
-		tomb:     s.repository.tomb,
 	}
 }

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -115,8 +115,8 @@ func (s *signatureStore) Put(dgst digest.Digest, signatures ...[]byte) error {
 	return nil
 }
 
-// namedBlobStore returns the namedBlobStore of the signatures for the
-// manifest with the given digest. Effectively, each singature link path
+// linkedBlobStore returns the namedBlobStore of the signatures for the
+// manifest with the given digest. Effectively, each signature link path
 // layout is a unique linked blob store.
 func (s *signatureStore) linkedBlobStore(ctx context.Context, revision digest.Digest) *linkedBlobStore {
 	linkpath := func(pm *pathMapper, name string, dgst digest.Digest) (string, error) {
@@ -135,7 +135,15 @@ func (s *signatureStore) linkedBlobStore(ctx context.Context, revision digest.Di
 			blobStore:  s.blobStore,
 			repository: s.repository,
 			linkPath:   linkpath,
+			tomb: tomb{
+				pm:     defaultPathMapper,
+				driver: s.repository.registry.blobStore.driver,
+			},
 		},
 		linkPath: linkpath,
+		tomb: tomb{
+			pm:     defaultPathMapper,
+			driver: s.repository.registry.blobStore.driver,
+		},
 	}
 }

--- a/registry/storage/tombstone.go
+++ b/registry/storage/tombstone.go
@@ -1,0 +1,55 @@
+package storage
+
+// Functions for manipulating tombstones
+
+import (
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+)
+
+type tomb struct {
+	pm     *pathMapper
+	driver storagedriver.StorageDriver
+}
+
+func (t *tomb) tombstoneExists(ctx context.Context, repositoryName string, digest digest.Digest) (bool, error) {
+	tombstone, err := t.pm.path(tombstoneSpec{name: repositoryName, digest: digest})
+	if err != nil {
+		return false, err
+	}
+
+	tombstoneExists, err := exists(ctx, t.driver, tombstone)
+	if err != nil {
+		return false, err
+	}
+
+	return tombstoneExists, nil
+}
+
+func (t *tomb) putTombstone(ctx context.Context, repositoryName string, digest digest.Digest) error {
+	tombstone, err := t.pm.path(tombstoneSpec{name: repositoryName, digest: digest})
+	if err != nil {
+		return err
+	}
+
+	if err := t.driver.PutContent(ctx, tombstone, []byte(digest)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *tomb) deleteTombstone(ctx context.Context, repositoryName string, digest digest.Digest) error {
+	tombstone, err := t.pm.path(tombstoneSpec{name: repositoryName, digest: digest})
+	if err != nil {
+		return err
+	}
+
+	err = t.driver.Delete(ctx, tombstone)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/registry/storage/tombstone.go
+++ b/registry/storage/tombstone.go
@@ -6,7 +6,7 @@ package storage
 // the existence of tombstone files and act accordingly.
 
 import (
-	"fmt"
+	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/storage/driver"
@@ -19,14 +19,10 @@ type tomb struct {
 	enabled bool
 }
 
-// ErrDeleteDisabled is returned from tombstone functions
-// if delete has not been enabled in the app configuration
-var ErrDeleteDisabled = fmt.Errorf("Delete disabled")
-
 // tombstoneExists queries existance of a tombstone for the given digest
 func (t *tomb) tombstoneExists(ctx context.Context, repositoryName string, digest digest.Digest) (bool, error) {
 	if !t.enabled {
-		return false, ErrDeleteDisabled
+		return false, distribution.ErrUnsupported
 	}
 	tombstone, err := t.pm.path(tombstoneSpec{name: repositoryName, digest: digest})
 	if err != nil {
@@ -44,7 +40,7 @@ func (t *tomb) tombstoneExists(ctx context.Context, repositoryName string, diges
 // putTombstone creates a tombstone for the given digest
 func (t *tomb) putTombstone(ctx context.Context, repositoryName string, digest digest.Digest) error {
 	if !t.enabled {
-		return ErrDeleteDisabled
+		return distribution.ErrUnsupported
 	}
 
 	tombstone, err := t.pm.path(tombstoneSpec{name: repositoryName, digest: digest})
@@ -62,7 +58,7 @@ func (t *tomb) putTombstone(ctx context.Context, repositoryName string, digest d
 // deleteTombstone deletes a tombstone for the given digest
 func (t *tomb) deleteTombstone(ctx context.Context, repositoryName string, digest digest.Digest) error {
 	if !t.enabled {
-		return ErrDeleteDisabled
+		return distribution.ErrUnsupported
 	}
 
 	tombstone, err := t.pm.path(tombstoneSpec{name: repositoryName, digest: digest})


### PR DESCRIPTION
Implement manifest and blob soft deletion by placing tombstones in
the storage representing deleted files.  Add a tomb to the following
structs:

linkedBlobStatter: to account for tombstones in Stat
manifestStore: for deleting manifests
linkedBlobStore: for deleting blobs

Implement delete in the registry client

Closes #461 
Closes #549 
Replaces #508 