### PR TITLE
Fix rados build, remove uuid dependency

### DIFF
--- a/registry/storage/driver/rados/rados.go
+++ b/registry/storage/driver/rados/rados.go
@@ -9,12 +9,12 @@ import (
 	"path"
 	"strconv"
 
-	"code.google.com/p/go-uuid/uuid"
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/base"
 	"github.com/docker/distribution/registry/storage/driver/factory"
+	"github.com/docker/distribution/uuid"
 	"github.com/noahdesu/go-ceph/rados"
 )
 
@@ -497,7 +497,7 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 
 // Generate a blob identifier
 func (d *driver) generateOid() string {
-	return objectBlobPrefix + uuid.New()
+	return objectBlobPrefix + uuid.Generate().String()
 }
 
 // Reference a object and its hierarchy


### PR DESCRIPTION
Build with rados is broken since #556 (rados driver used code.google.com/p/go-uuid/uuid too).

@stevvooe @dmp42 Could you please check if there is any chance that the CI keeps the removed uuid dependency? Most recent CI builds should have failed. Thanks.