### PR TITLE
doc/spec: coherence between requests and parameters + typo

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -992,7 +992,7 @@ The following parameters should be specified on the request:
 |`Host`|header|Standard HTTP Host Header. Should be set to the registry host.|
 |`Authorization`|header|An RFC7235 compliant authorization header.|
 |`name`|path|Name of the target repository.|
-|`tag`|path|Tag of the target manifiest.|
+|`reference`|path|Tag or digest of the target manifest.|
 
 
 
@@ -1160,7 +1160,7 @@ The following parameters should be specified on the request:
 |`Host`|header|Standard HTTP Host Header. Should be set to the registry host.|
 |`Authorization`|header|An RFC7235 compliant authorization header.|
 |`name`|path|Name of the target repository.|
-|`tag`|path|Tag of the target manifiest.|
+|`reference`|path|Tag or digest of the target manifest.|
 
 
 
@@ -1344,7 +1344,7 @@ The following parameters should be specified on the request:
 |`Host`|header|Standard HTTP Host Header. Should be set to the registry host.|
 |`Authorization`|header|An RFC7235 compliant authorization header.|
 |`name`|path|Name of the target repository.|
-|`tag`|path|Tag of the target manifiest.|
+|`reference`|path|Tag or digest of the target manifest.|
 
 
 

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -16,12 +16,12 @@ var (
 		Description: `Name of the target repository.`,
 	}
 
-	tagParameterDescriptor = ParameterDescriptor{
-		Name:        "tag",
+	referenceParameterDescriptor = ParameterDescriptor{
+		Name:        "reference",
 		Type:        "string",
 		Format:      TagNameRegexp.String(),
 		Required:    true,
-		Description: `Tag of the target manifiest.`,
+		Description: `Tag or digest of the target manifest.`,
 	}
 
 	uuidParameterDescriptor = ParameterDescriptor{
@@ -476,7 +476,7 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
-							tagParameterDescriptor,
+							referenceParameterDescriptor,
 						},
 						Successes: []ResponseDescriptor{
 							{
@@ -542,7 +542,7 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
-							tagParameterDescriptor,
+							referenceParameterDescriptor,
 						},
 						Body: BodyDescriptor{
 							ContentType: "application/json; charset=utf-8",
@@ -648,7 +648,7 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
-							tagParameterDescriptor,
+							referenceParameterDescriptor,
 						},
 						Successes: []ResponseDescriptor{
 							{


### PR DESCRIPTION
In the request parameters lists `tag` was used instead of
`reference` present in the HTTP requests paths.