### PR TITLE
Disable goverall for now

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,7 +58,9 @@ dependencies:
   # For the stable go version, additionally install linting tools
     - >
       gvm use stable &&
-      go get github.com/axw/gocov/gocov github.com/mattn/goveralls github.com/golang/lint/golint
+      go get github.com/axw/gocov/gocov github.com/golang/lint/golint
+  # Disabling goveralls for now
+  # go get github.com/axw/gocov/gocov github.com/mattn/goveralls github.com/golang/lint/golint
 
 test:
   pre:


### PR DESCRIPTION
See #578 for context.
Goveralls does fetch google uuid with it.
Builds that should fail for failure to find uuid are actually passing.
Though goveralls is installed only on "stable", the build should still fail for go1.3 - but apparently we disabled it :-)

This build here should FAIL and this is expected (save circleci caching)