### PR TITLE
docs/spec: catalog V2 API specification proposal

### DIFF
--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -120,6 +120,16 @@ indicating what is different. Optionally, we may start marking parts of the
 specification to correspond with the versions enumerated here.
 
 <dl>
+
+  <dt>2.0.4</dt>>
+  <dd>
+    <ul>
+      <li>Added support for listing registry contents.</li>
+      <li>Added pagination to tags API.</li>
+      <li>Added common approach to support pagination.</li>
+    </ul>
+  </dd>
+
   <dt>2.0.3</dt>
   <dd>
     <li>Allow repository name components to be one character.</li>
@@ -131,7 +141,6 @@ specification to correspond with the versions enumerated here.
     <li>Added section covering digest format.</li>
     <li>Added more clarification that manifest cannot be deleted by tag.</li>
   </dd>
-
 	<dt>2.0.1</dt>
 	<dd>
 		<ul>
@@ -745,7 +754,9 @@ each unknown blob. The response format is as follows:
         ]
     }
 
-#### Listing Image Tags
+
+
+### Listing Image Tags
 
 It may be necessary to list all of the tags under a given repository. The tags
 for an image repository can be retrieved with the following request:
@@ -766,8 +777,166 @@ The response will be in the following format:
     }
 
 For repositories with a large number of tags, this response may be quite
-large, so care should be taken by the client when parsing the response to
-reduce copying.
+large. If such a response is expected, one should use the pagination.
+
+#### Pagination
+
+Paginated tag results can be retrieved by adding the appropriate pagination
+parameters. Starting a paginated flow may begin as follows:
+
+```
+GET /v2/<name>/tags/list?n=<integer>
+```
+
+The above specifies that a tags response should be returned, from the start of
+the result set, ordered lexically, limiting the number of results to `n`. The
+response to such a request would look as follows:
+
+```
+200 OK
+Content-Type: application/json
+
+{
+  "name": <name>,
+  "tags": [
+    <tag>,
+    ...
+  ]
+  "next": <url>?n=<n from the request>&last=<last tag value from previous response>
+}
+```
+
+> __TODO(stevvooe):__ Consider using a Header here, rather than a body parameter. A
+header would allow one to issue the next request before parsing the response
+body.
+
+To get the next result set, a client would issue the request as follows, using
+the value of "next" from the response body:
+
+```
+GET /v2/<name>/tags/list?n=<n from the request>&last=<last tag value from previous response>
+```
+
+The above process should then be repeated until the `next` parameter is no
+longer set in the response.
+
+The behavior of `last` is quite simple and can be demonstrated with an
+example. Let's say the repository has the following tags:
+
+```
+a
+b
+c
+d
+```
+
+If the value of `n` is 2, _a_ and _b_ will be returned on the first response.
+The `next` url within the respone will have `n` set to 2 and last set to _b_:
+
+```
+"next": <url>?n=2&last=b
+```
+
+The client can then issue the response, receiving the values _c_ and _d_. Note
+that n may change on second to last response or be omitted fully, if the
+server may so choose.
+
+### Listing Repositories
+
+Images are stored in collections, known as a _repository_, which is keyed by a
+`name`, as seen throughout the API specification. A registry instance may
+contain several repositories. The list of available repositories, or image
+names, is made available through the _catalog_.
+
+The catalog for a given registry can be retrived with the following request:
+
+```
+GET /v2/_catalog
+```
+
+The response will be in the following format:
+
+```
+200 OK
+Content-Type: application/json
+
+{
+  "repositories": [
+    <name>,
+    ...
+  ]
+}
+```
+
+For registries with a large number of repositories, this response may be quite
+large. If such a response is expected, one should use the pagination.
+
+#### Pagination
+
+Paginated repository results can be retrieved by adding the appropriate
+pagination parameters, which are similar to those available in the tag API.
+Starting a paginated flow may begin as follows:
+
+```
+GET /v2/_catalog?n=<integer>
+```
+
+The above specifies that a catalog response should be returned, from the start of
+the result set, ordered lexically, limiting the number of results to `n`. The
+response to such a request would look as follows:
+
+```
+200 OK
+Content-Type: application/json
+
+{
+  "repositories": [
+    <name>,
+    ...
+  ]
+  "next": <url>?n=<n from the request>&last=<last repository value from previous response>
+}
+```
+
+> __TODO(stevvooe):__ Consider using a Header here, rather than a body parameter. A
+header would allow one to issue the next request before parsing the response
+body.
+
+To get the next result set, a client would issue the request as follows, using
+the value of "next" from the response body:
+
+```
+GET /v2/_catalog?n=<n from the request>&last=<last repostory value from previous response>
+```
+
+The above process should then be repeated until the `next` parameter is no
+longer set in the response.
+
+The result set of repository names is represented abstractly as a lexically
+sorted list, where the position in that list can be specified by the query
+term `last`. The entries in the response start _after_ the term specified by
+`last`, up to `n` entries.
+
+The behavior of `last` is quite simple when demonstrated with an example.
+Let's say the registry has the following repositories:
+
+```
+a
+b
+c
+d
+```
+
+If the value of `n` is 2, _a_ and _b_ will be returned on the first response.
+The `next` url within the respone will have `n` set to 2 and last set to _b_:
+
+```
+"next": <url>?n=2&last=b
+```
+
+The client can then issue the request with above value of `next`, receiving
+the values _c_ and _d_. Note that n may change on second to last response or
+be omitted fully, if the server may so choose.
 
 ### Deleting an Image
 
@@ -867,8 +1036,13 @@ Content-Type: {{.Body.ContentType}}{{end}}{{if .Body.Format}}
 ```
 
 {{.Description}}
+{{if .Fields}}The following fields may be returned in the response body:
 
-{{if .Headers}}The following headers will be returned with the response:
+|Name|Description|
+|----|-----------|
+{{range .Fields}}|`{{.Name}}`|{{.Description}}|
+{{end}}{{end}}{{if .Headers}}
+The following headers will be returned with the response:
 
 |Name|Description|
 |----|-----------|

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -754,7 +754,129 @@ each unknown blob. The response format is as follows:
         ]
     }
 
+### Listing Repositories
 
+Images are stored in collections, known as a _repository_, which is keyed by a
+`name`, as seen throughout the API specification. A registry instance may
+contain several repositories. The list of available repositories is made
+available through the _catalog_.
+
+The catalog for a given registry can be retrived with the following request:
+
+```
+GET /v2/_catalog
+```
+
+The response will be in the following format:
+
+```
+200 OK
+Content-Type: application/json
+
+{
+  "repositories": [
+    <name>,
+    ...
+  ]
+}
+```
+
+Note that the contents of the response are specific to the registry
+implementation. Some registries may opt to provide a full catalog output,
+limit it based on the user's access level or omit upstream results, if
+providing mirroring functionality. Subsequently, the presence of a repository
+in the catalog listing only means that the registry *may* provide access to
+the repository at the time of the request. Conversely, a missing entry does
+*not* mean that the registry does not have the repository. More succinctly,
+the presence of a repository only guarantees that it is there but not that it
+is _not_ there.
+
+For registries with a large number of repositories, this response may be quite
+large. If such a response is expected, one should use pagination.
+
+#### Pagination
+
+Paginated catalog results can be retrieved by adding an `n` parameter to the
+request URL, declaring that the response should be limited to `n` results.
+Starting a paginated flow begins as follows:
+
+```
+GET /v2/_catalog?n=<integer>
+```
+
+The above specifies that a catalog response should be returned, from the start of
+the result set, ordered lexically, limiting the number of results to `n`. The
+response to such a request would look as follows:
+
+```
+200 OK
+Content-Type: application/json
+Link: <<url>?n=<n from the request>&last=<last repository in response>>; rel="next"
+
+{
+  "repositories": [
+    <name>,
+    ...
+  ]
+}
+```
+
+The above includes the _first_ `n` entries from the result set. To get the
+_next_ `n` entries, one can create a URL where the argument `last` has the
+value from `repositories[len(repositories)-1]`. If there are indeed more
+results, the URL for the next block is encoded in an
+[RFC5988](https://tools.ietf.org/html/rfc5988) `Link` header, as a "next"
+relation. The presence of the `Link` header communicates to the client that
+the entire result set has not been returned and another request must be
+issued. If the header is not present, the client can assume that all results
+have been recieved.
+
+> __NOTE:__ In the request template above, note that the brackets
+> are required. For example, if the url is
+> `http://example.com/v2/_catalog?n=20&last=b`, the value of the header would
+> be `<http://example.com/v2/_catalog?n=20&last=b>; rel="next"`. Please see
+> [RFC5988](https://tools.ietf.org/html/rfc5988) for details.
+
+Compliant client implementations should always use the `Link` header
+value when proceeding through results linearly. The client may construct URLs
+to skip forward in the catalog.
+
+To get the next result set, a client would issue the request as follows, using
+the URL encoded in the described `Link` header:
+
+```
+GET /v2/_catalog?n=<n from the request>&last=<last repostory value from previous response>
+```
+
+The above process should then be repeated until the `Link` header is no longer
+set.
+
+The catalog result set is represented abstractly as a lexically sorted list,
+where the position in that list can be specified by the query term `last`. The
+entries in the response start _after_ the term specified by `last`, up to `n`
+entries.
+
+The behavior of `last` is quite simple when demonstrated with an example. Let
+us say the registry has the following repositories:
+
+```
+a
+b
+c
+d
+```
+
+If the value of `n` is 2, _a_ and _b_ will be returned on the first response.
+The `Link` header returned on the response will have `n` set to 2 and last set
+to _b_:
+
+```
+Link: <<url>?n=2&last=b>; rel="next"
+```
+
+The client can then issue the request with above value from the `Link` header,
+receiving the values _c_ and _d_. Note that n may change on second to last
+response or be omitted fully, if the server may so choose.
 
 ### Listing Image Tags
 
@@ -781,8 +903,12 @@ large. If such a response is expected, one should use the pagination.
 
 #### Pagination
 
-Paginated tag results can be retrieved by adding the appropriate pagination
-parameters. Starting a paginated flow may begin as follows:
+Paginated tag results can be retrieved by adding the appropriate parameters to
+the request URL described above. The behavior of tag pagination is identical
+to that specified for catalog pagination. We cover a simple flow to highlight
+any differences.
+
+Starting a paginated flow may begin as follows:
 
 ```
 GET /v2/<name>/tags/list?n=<integer>
@@ -795,6 +921,7 @@ response to such a request would look as follows:
 ```
 200 OK
 Content-Type: application/json
+Link: <<url>?n=<n from the request>&last=<last tag value from previous response>>; rel="next"
 
 {
   "name": <name>,
@@ -802,141 +929,21 @@ Content-Type: application/json
     <tag>,
     ...
   ]
-  "next": <url>?n=<n from the request>&last=<last tag value from previous response>
 }
 ```
 
-> __TODO(stevvooe):__ Consider using a Header here, rather than a body parameter. A
-header would allow one to issue the next request before parsing the response
-body.
-
 To get the next result set, a client would issue the request as follows, using
-the value of "next" from the response body:
+the value encoded in the [RFC5988](https://tools.ietf.org/html/rfc5988) `Link`
+header:
 
 ```
 GET /v2/<name>/tags/list?n=<n from the request>&last=<last tag value from previous response>
 ```
 
-The above process should then be repeated until the `next` parameter is no
-longer set in the response.
-
-The behavior of `last` is quite simple and can be demonstrated with an
-example. Let's say the repository has the following tags:
-
-```
-a
-b
-c
-d
-```
-
-If the value of `n` is 2, _a_ and _b_ will be returned on the first response.
-The `next` url within the respone will have `n` set to 2 and last set to _b_:
-
-```
-"next": <url>?n=2&last=b
-```
-
-The client can then issue the response, receiving the values _c_ and _d_. Note
-that n may change on second to last response or be omitted fully, if the
-server may so choose.
-
-### Listing Repositories
-
-Images are stored in collections, known as a _repository_, which is keyed by a
-`name`, as seen throughout the API specification. A registry instance may
-contain several repositories. The list of available repositories, or image
-names, is made available through the _catalog_.
-
-The catalog for a given registry can be retrived with the following request:
-
-```
-GET /v2/_catalog
-```
-
-The response will be in the following format:
-
-```
-200 OK
-Content-Type: application/json
-
-{
-  "repositories": [
-    <name>,
-    ...
-  ]
-}
-```
-
-For registries with a large number of repositories, this response may be quite
-large. If such a response is expected, one should use the pagination.
-
-#### Pagination
-
-Paginated repository results can be retrieved by adding the appropriate
-pagination parameters, which are similar to those available in the tag API.
-Starting a paginated flow may begin as follows:
-
-```
-GET /v2/_catalog?n=<integer>
-```
-
-The above specifies that a catalog response should be returned, from the start of
-the result set, ordered lexically, limiting the number of results to `n`. The
-response to such a request would look as follows:
-
-```
-200 OK
-Content-Type: application/json
-
-{
-  "repositories": [
-    <name>,
-    ...
-  ]
-  "next": <url>?n=<n from the request>&last=<last repository value from previous response>
-}
-```
-
-> __TODO(stevvooe):__ Consider using a Header here, rather than a body parameter. A
-header would allow one to issue the next request before parsing the response
-body.
-
-To get the next result set, a client would issue the request as follows, using
-the value of "next" from the response body:
-
-```
-GET /v2/_catalog?n=<n from the request>&last=<last repostory value from previous response>
-```
-
-The above process should then be repeated until the `next` parameter is no
-longer set in the response.
-
-The result set of repository names is represented abstractly as a lexically
-sorted list, where the position in that list can be specified by the query
-term `last`. The entries in the response start _after_ the term specified by
-`last`, up to `n` entries.
-
-The behavior of `last` is quite simple when demonstrated with an example.
-Let's say the registry has the following repositories:
-
-```
-a
-b
-c
-d
-```
-
-If the value of `n` is 2, _a_ and _b_ will be returned on the first response.
-The `next` url within the respone will have `n` set to 2 and last set to _b_:
-
-```
-"next": <url>?n=2&last=b
-```
-
-The client can then issue the request with above value of `next`, receiving
-the values _c_ and _d_. Note that n may change on second to last response or
-be omitted fully, if the server may so choose.
+The above process should then be repeated until the `Link` header is no longer
+set in the response. The behavior of the `last` parameter, the provided
+response result, lexical ordering and encoding of the `Link` header are
+identical to that of catalog pagination.
 
 ### Deleting an Image
 

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -87,6 +87,13 @@ var (
 		Format:      "<digest>",
 	}
 
+	linkHeader = ParameterDescriptor{
+		Name:        "Link",
+		Type:        "link",
+		Description: "RFC5988 compliant rel='next' with URL to next result set, if available",
+		Format:      `<<url>?n=<last n value>&last=<last entry from response>>; rel="next"`,
+	}
+
 	paginationParameters = []ParameterDescriptor{
 		{
 			Name:        "n",
@@ -462,14 +469,7 @@ var routeDescriptors = []RouteDescriptor{
 										Description: "Length of the JSON response body.",
 										Format:      "<length>",
 									},
-								},
-								Fields: []ParameterDescriptor{
-									{
-										Name:        "next",
-										Type:        "url",
-										Description: "Provides the URL to get the next set of results, if available.",
-										Format:      "<url>",
-									},
+									linkHeader,
 								},
 								Body: BodyDescriptor{
 									ContentType: "application/json; charset=utf-8",
@@ -479,7 +479,6 @@ var routeDescriptors = []RouteDescriptor{
         <tag>,
         ...
     ],
-    "next": "<url>?last=<name>&n=<last value of n>"
 }`,
 								},
 							},
@@ -1439,14 +1438,7 @@ var routeDescriptors = []RouteDescriptor{
 										Description: "Length of the JSON response body.",
 										Format:      "<length>",
 									},
-								},
-								Fields: []ParameterDescriptor{
-									{
-										Name:        "next",
-										Type:        "url",
-										Description: "Provides the URL to get the next set of results, if available.",
-										Format:      "<url>",
-									},
+									linkHeader,
 								},
 							},
 						},

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -87,6 +87,23 @@ var (
 		Format:      "<digest>",
 	}
 
+	paginationParameters = []ParameterDescriptor{
+		{
+			Name:        "n",
+			Type:        "integer",
+			Description: "Limit the number of entries in each response. It not present, all entries will be returned.",
+			Format:      "<integer>",
+			Required:    false,
+		},
+		{
+			Name:        "last",
+			Type:        "string",
+			Description: "Result set will include values lexically after last.",
+			Format:      "<integer>",
+			Required:    false,
+		},
+	}
+
 	unauthorizedResponse = ResponseDescriptor{
 		Description: "The client does not have access to the repository.",
 		StatusCode:  http.StatusUnauthorized,
@@ -269,6 +286,9 @@ type ResponseDescriptor struct {
 	// Headers covers any headers that may be returned from the response.
 	Headers []ParameterDescriptor
 
+	// Fields describes any fields that may be present in the response.
+	Fields []ParameterDescriptor
+
 	// ErrorCodes enumerates the error codes that may be returned along with
 	// the response.
 	ErrorCodes []errcode.ErrorCode
@@ -423,6 +443,44 @@ var routeDescriptors = []RouteDescriptor{
 								},
 								ErrorCodes: []errcode.ErrorCode{
 									ErrorCodeUnauthorized,
+								},
+							},
+						},
+					},
+					{
+						Description:     "Return a portion of the tags for the specified repository.",
+						PathParameters:  []ParameterDescriptor{nameParameterDescriptor},
+						QueryParameters: paginationParameters,
+						Successes: []ResponseDescriptor{
+							{
+								StatusCode:  http.StatusOK,
+								Description: "A list of tags for the named repository.",
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON response body.",
+										Format:      "<length>",
+									},
+								},
+								Fields: []ParameterDescriptor{
+									{
+										Name:        "next",
+										Type:        "url",
+										Description: "Provides the URL to get the next set of results, if available.",
+										Format:      "<url>",
+									},
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format: `{
+    "name": <name>,
+    "tags": [
+        <tag>,
+        ...
+    ],
+    "next": "<url>?last=<name>&n=<last value of n>"
+}`,
 								},
 							},
 						},
@@ -1312,6 +1370,83 @@ var routeDescriptors = []RouteDescriptor{
 								Body: BodyDescriptor{
 									ContentType: "application/json; charset=utf-8",
 									Format:      errorsBody,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		Name:        RouteNameCatalog,
+		Path:        "/v2/_catalog",
+		Entity:      "Catalog",
+		Description: "List a set of available repositories in the local registry cluster. Does not provide any indication of what may be available upstream. Applications can only determine if a repository is available but not if it is not available.",
+		Methods: []MethodDescriptor{
+			{
+				Method:      "GET",
+				Description: "Retrieve a sorted, json list of repositories available in the registry.",
+				Requests: []RequestDescriptor{
+					{
+						Name:        "Catalog Fetch Complete",
+						Description: "Request an unabridged list of repositories available.",
+						Successes: []ResponseDescriptor{
+							{
+								Description: "Returns the unabridged list of repositories as a json response.",
+								StatusCode:  http.StatusOK,
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON response body.",
+										Format:      "<length>",
+									},
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format: `{
+	"repositories": [
+		<name>,
+		...
+	]
+}`,
+								},
+							},
+						},
+					},
+					{
+						Name:            "Catalog Fetch Paginated",
+						Description:     "Return the specified portion of repositories.",
+						QueryParameters: paginationParameters,
+						Successes: []ResponseDescriptor{
+							{
+								StatusCode: http.StatusOK,
+								Body: BodyDescriptor{
+									ContentType: "application/json; charset=utf-8",
+									Format: `{
+	"repositories": [
+		<name>,
+		...
+	]
+	"next": "<url>?last=<name>&n=<last value of n>"
+}`,
+								},
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON response body.",
+										Format:      "<length>",
+									},
+								},
+								Fields: []ParameterDescriptor{
+									{
+										Name:        "next",
+										Type:        "url",
+										Description: "Provides the URL to get the next set of results, if available.",
+										Format:      "<url>",
+									},
 								},
 							},
 						},

--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -11,6 +11,7 @@ const (
 	RouteNameBlob            = "blob"
 	RouteNameBlobUpload      = "blob-upload"
 	RouteNameBlobUploadChunk = "blob-upload-chunk"
+	RouteNameCatalog         = "catalog"
 )
 
 var allEndpoints = []string{


### PR DESCRIPTION
This contains a proposal for a catalog API, provided access to the internal
contents of a registry instance. The API endpoint is prefixed with an
underscore, which is illegal in images names, to prevent collisions with
repositories names. To avoid issues with large result sets, a paginated version
of the API is proposed. We make an addition to the tags API to support
pagination to ensure the specification is consistent.

Closes #441, #382.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @dmp42 @dmcgowan @ncdc @pdevine