### PR TITLE
Removing Nginx Authorization header unset because it breaks with a user defined index endpoint

### DIFF
--- a/contrib/compose/nginx/docker-registry.conf
+++ b/contrib/compose/nginx/docker-registry.conf
@@ -3,5 +3,5 @@ proxy_set_header  Host              $http_host;   # required for docker client's
 proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
 proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
 proxy_set_header  X-Forwarded-Proto $scheme;
-proxy_set_header  Authorization     ""; # see https://github.com/docker/docker-registry/issues/170
+proxy_set_header  Authorization     ""; # For basic auth through nginx in v1 to work, please comment this line
 proxy_read_timeout                  900;


### PR DESCRIPTION
When using the private registry with a user defined index endpoint I was getting the following error .....

FATA[0017] HTTP code 401 while uploading metadata: {"error": "Requires authorization"}

The cause of this was the Authorization header being unset by Nginx. I followed the issue reported as a comment on the .conf but it seems like that issue was closed and listed as resolved but it seems like this is a breaking change for people running their own index. 