### PR TITLE
Adding a volume for the default 'registry-dev' location.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
 RUN make PREFIX=/go clean binaries
 
+VOLUME ["/tmp/registry-dev"]
 EXPOSE 5000
 ENTRYPOINT ["registry"]
 CMD ["cmd/registry/config.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
 RUN make PREFIX=/go clean binaries
 
-VOLUME ["/tmp/registry-dev"]
+VOLUME ["/var/lib/registry"]
 EXPOSE 5000
 ENTRYPOINT ["registry"]
 CMD ["cmd/registry/config.yml"]


### PR DESCRIPTION
I added a sensible default volume to support the default registry data location. In doing so, we can save users the effort of digging up the location and manually creating the volume. If the default configuration is overridden, the volume will remain unused and empty.

Signed-off-by: Jeff Nickoloff <jeff@allingeek.com>