### PR TITLE
add configuration file close after it is parsed.

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -152,6 +152,8 @@ func resolveConfiguration() (*configuration.Configuration, error) {
 		return nil, err
 	}
 
+	defer fp.Close()
+
 	config, err := configuration.Parse(fp)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing %s: %v", configurationPath, err)


### PR DESCRIPTION
Signed-off-by: yuzou <zouyu7@huawei.com>
after registry configuration is parsed, close its related file handle.