### PR TITLE
Ship htpasswd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.4
 
 RUN apt-get update && \
-    apt-get install -y librados-dev && \
+    apt-get install -y librados-dev apache2-utils && \
     rm -rf /var/lib/apt/lists/*
 
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution


### PR DESCRIPTION
Following native basic auth and while reviewing the doc, I would suggest to ship htpasswd.

Benefits are:

 * controlled version: does support bcrypt
 * self-contained: no separate installation required to operate
 * straight-forward doc (to come): `docker run --entrypoint htpasswd registry -Bbn batman robin > batcave`