### PR TITLE
Documentation work

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,8 +63,11 @@ Simple as that? Yes. Now, please read the...
 ### Reference and advanced topics
 
  - [Glossary](glossary.md)
- - [Authentication](authentication.md)
  - [Working with notifications](notifications.md)
+
+### Miscellanee
+ - [Nginx as a proxy](nginx.md)
+ - [Insecure registry](insecure.md)
 
 ### Development resources
 

--- a/docs/insecure.md
+++ b/docs/insecure.md
@@ -1,0 +1,68 @@
+<!--GITHUB
+page_title: Deploying an insecure registry
+page_description: Explains how to deploy an insecure registry
+page_keywords: registry, service, images, repository, deploy, insecure
+IGNORES-->
+
+# Insecure Registry
+
+While it's highly recommended to secure your registry using a TLS certificate issued by a known CA, you may alternatively decide to use self-signed certificates, or even use your registry over plain http.
+
+You have to understand the downsides in doing so, and the extra burden in configuration.
+
+## Plain HTTP registry
+
+> :warning: it's not possible to use an insecure registry with basic authentication
+
+This basically tells Docker to entirely disregard security for your registry.
+
+1. edit the file `/etc/default/docker` so that there is a line that reads: `DOCKER_OPTS="--insecure-registry myregistrydomain.com:5000"` (or add that to existing `DOCKER_OPTS`)
+2. restart your Docker daemon: on ubuntu, this is usually `service docker stop && service docker start`
+
+**Pros:**
+
+ - easy to configure
+ 
+**Cons:**
+ 
+ - very insecure
+ - you have to configure every docker daemon that wants to access your registry 
+  
+## Self-signed certificate
+
+> :warning: using this along with basic authentication requires to **also** trust the certificate into the OS cert store
+
+Generate your own certificate:
+
+```
+mkdir -p certs && openssl req \
+  -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key \
+  -x509 -days 365 -out certs/domain.crt
+```
+
+Be sure to use the name `myregistrydomain.com` as a CN.
+
+Now go to solution 1 above and stop and restart your registry.
+
+Then you have to instruct every docker daemon to trust that certificate. This is done by copying the `domain.crt` file to `/etc/docker/certs.d/myregistrydomain.com:5000/ca.crt` (don't forget to restart docker after doing so).
+
+**Pros:**
+
+ - more secure than the insecure registry solution
+
+**Cons:**
+
+ - you have to configure every docker daemon that wants to access your registry
+
+## Failing...
+
+Failing to configure docker and trying to pull from a registry that is not using TLS will result in the following message:
+
+```
+FATA[0000] Error response from daemon: v1 ping attempt failed with error:
+Get https://myregistrydomain.com:5000/v1/_ping: tls: oversized record received with length 20527. 
+If this private registry supports only HTTP or HTTPS with an unknown CA certificate,please add 
+`--insecure-registry myregistrydomain.com:5000` to the daemon's arguments.
+In the case of HTTPS, if you have access to the registry's CA certificate, no need for the flag;
+simply place the CA certificate at /etc/docker/certs.d/myregistrydomain.com:5000/ca.crt
+```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -12,9 +12,9 @@ Users interact with a registry by using docker push and pull commands. For examp
 
 Storage itself is delegated to drivers. The default storage driver is the local posix filesystem, which is suitable for development or small deployments. Additional cloud-based storage driver like S3, Microsoft Azure and Ceph are also supported. People looking into using other storage backends may do so by writing their own driver implementing the [Storage API](storagedrivers.md).
 
-Since securing access to your hosted images is paramount, the Registry natively supports TLS. You can also enforce basic authentication through a proxy like Nginx.
+Since securing access to your hosted images is paramount, the Registry natively supports TLS and basic authentication.
 
-The Registry GitHub repository includes reference implementations for additional authentication and authorization methods. Only very large or public deployments are expected to extend the Registry in this way.
+The Registry GitHub repository includes information about advanced authentication and authorization methods. Only very large or public deployments are expected to extend the Registry in this way.
 
 Finally, the Registry includes a robust [notification system](notifications.md), calling webhooks in response to activity, and both extensive logging and reporting. Reporting is mostly useful for large installations that want to collect metrics. Currently, New Relic and Bugsnag are supported.
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -1,31 +1,16 @@
 <!--GITHUB
-page_title: Authentication for the Registry
-page_description: Restricting access to your registry
-page_keywords: registry, service, images, repository, authentication
+page_title: Authenticating proxy with nginx for the Registry
+page_description: Restricting access to your registry using nginx
+page_keywords: registry, service, images, repository, authentication, nginx
 IGNORES-->
 
-# Authentication
-
-While running an unrestricted registry is certainly ok for development, secured local networks, or test setups, you should probably implement access restriction if you plan on making your registry available to a wider audience or through public internet.
-
-The Registry supports two different authentication methods to get your there:
-
- * direct authentication, through the use of a proxy
- * delegated authentication, redirecting to a trusted token server
-
-The first method is recommended for most people as the most straight-forward solution.
-
-The second method requires significantly more investment, and only make sense if you want to fully configure ACLs and more control over the Registry integration into your global authorization and authentication systems.
-
-## Direct authentication through a proxy
+# Authenticating proxy with nginx
 
 With this method, you implement basic authentication in a reverse proxy that sits in front of your registry.
 
-Since the Docker engine uses basic authentication to negotiate access to the Registry, securing communication between docker engines and your proxy is absolutely paramount. 
-
 While this model gives you the ability to use whatever authentication backend you want through a secondary authentication mechanism implemented inside your proxy, it also requires that you move TLS termination from the Registry to the proxy itself.
 
-Below is a simple example of secured basic authentication (using TLS), using nginx as a proxy.
+Furthermore, introducing an extra http layer in your communication pipeline will make it more complex to deploy, maintain, and debug, and will possibly create issues (typically, nginx does buffer client requests to disk, opening the door to a host of problems if you are dealing with huge images and a lot of traffic).
 
 ### Requirements
 
@@ -37,9 +22,8 @@ At this point, it's assumed that:
 
  * you understand Docker security requirements, and how to configure your docker engines properly
  * you have installed Docker Compose
- * you have a `domain.crt` and `domain.key` files, for the CN `myregistrydomain.com` (or whatever domain name you want to use)
- * these files are located inside the current directory, and there is nothing else in that directory
  * it's HIGHLY recommended that you get a certificate from a known CA instead of self-signed certificates
+ * inside the current directory, you have a X509 `domain.crt` and `domain.key`, for the CN `myregistrydomain.com` (or whatever domain name you want to use)
  * be sure you have stopped and removed any previously running registry (typically `docker stop registry && docker rm registry`)
 
 
@@ -52,8 +36,8 @@ Ready?
 Run the following:
 
 ```
-mkdir auth
-mkdir data
+mkdir -p auth
+mkdir -p data
 
 # This is the main nginx configuration you will use
 cat <<EOF > auth/registry.conf
@@ -83,8 +67,8 @@ server {
     }
 
     # To add basic authentication to v2 use auth_basic setting plus add_header
-    auth_basic "registry.localhost";
-    auth_basic_user_file /etc/nginx/conf.d/registry.password;
+    auth_basic "Registry realm";
+    auth_basic_user_file /etc/nginx/conf.d/htpasswd;
     add_header 'Docker-Distribution-Api-Version' 'registry/2.0' always;
 
     proxy_pass                          http://docker-registry;
@@ -98,10 +82,7 @@ server {
 EOF
 
 # Now, create a password file for "testuser" and "testpassword"
-echo 'testuser:$2y$05$.nIfPAEgpWCh.rpts/XHX.UOfCRNtvMmYjh6sY/AZBmeg/dQyN62q' > auth/registry.password
-
-# Alternatively you could have achieved the same thing with htpasswd
-# htpasswd -Bbc auth/registry.password testuser testpassword
+htpasswd -Bbn testuser testpassword > auth/htpasswd
 
 # Copy over your certificate files
 cp domain.crt auth
@@ -162,10 +143,3 @@ Now:
  * `service docker stop && service docker start` (or any other way you use to restart docker)
  * `docker-compose up -d` to bring your registry up
 
-## Token-based delegated authentication
-
-This is **advanced**.
-
-You will find [background information here](spec/auth/token.md), [configuration information here](configuration.md#auth).
-
-Beware that you will have to implement your own authentication service for this to work (though there exist third-party open-source implementations).

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,7 +1,7 @@
 <!--GITHUB
 page_title: Work with Notifications
-page_description: Explains how to deploy a registry server
-page_keywords: registry, service, images, repository
+page_description: Work with Notifications
+page_keywords: registry, service, images, repository, notifications
 IGNORES-->
 
 


### PR DESCRIPTION
Moving forward in the same spirit as the previous doc PR.
- move away insecure & self-signed into their own separate document
- emphasize proper certs use
- introduce native basic auth
- move away nginx based authentication
- overall shortening / smoothing of "deploying" documentation: the narrative feels better now, and cover all aspects that most users expect

Once we release 2.1, some stuff can be cut out (explicit storage paths for eg).

For some reason, I couldn't test native basic auth, so, the snippet has not been fireproofed.

cc @thaJeztah @stevvooe 