### PR TITLE
External manifest verification

### DIFF
--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -51,11 +51,15 @@ func Listen(repo distribution.Repository, listener Listener) distribution.Reposi
 	}
 }
 
-func (rl *repositoryListener) Manifests() distribution.ManifestService {
-	return &manifestServiceListener{
-		ManifestService: rl.Repository.Manifests(),
-		parent:          rl,
+func (rl *repositoryListener) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
+	manifests, err := rl.Repository.Manifests(ctx, options...)
+	if err != nil {
+		return nil, err
 	}
+	return &manifestServiceListener{
+		ManifestService: manifests,
+		parent:          rl,
+	}, nil
 }
 
 func (rl *repositoryListener) Blobs(ctx context.Context) distribution.BlobStore {

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -146,9 +146,12 @@ func checkExerciseRepository(t *testing.T, repository distribution.Repository) {
 		t.Fatalf("unexpected error signing manifest: %v", err)
 	}
 
-	manifests := repository.Manifests()
+	manifests, err := repository.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 
-	if err := manifests.Put(sm); err != nil {
+	if err = manifests.Put(sm); err != nil {
 		t.Fatalf("unexpected error putting the manifest: %v", err)
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -46,7 +46,8 @@ type Repository interface {
 	Name() string
 
 	// Manifests returns a reference to this repository's manifest service.
-	Manifests() ManifestService
+	// with the supplied options applied.
+	Manifests(ctx context.Context, options ...ManifestServiceOption) (ManifestService, error)
 
 	// Blobs returns a reference to this repository's blob service.
 	Blobs(ctx context.Context) BlobStore

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -70,18 +70,20 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 	}
 }
 
-func (r *repository) Manifests() distribution.ManifestService {
+func (r *repository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
+	// todo(richardscothern): options should be sent over the wire
 	return &manifests{
 		name:   r.Name(),
 		ub:     r.ub,
 		client: r.client,
 		etags:  make(map[string]string),
-	}
+	}, nil
 }
 
 func (r *repository) Signatures() distribution.SignatureService {
+	ms, _ := r.Manifests(r.context)
 	return &signatures{
-		manifests: r.Manifests(),
+		manifests: ms,
 	}
 }
 
@@ -235,6 +237,8 @@ func (ms *manifests) Put(m *manifest.SignedManifest) error {
 	if err != nil {
 		return err
 	}
+
+	// todo(richardscothern): do something with options here when they become applicable
 
 	putRequest, err := http.NewRequest("PUT", manifestURL, bytes.NewReader(m.Raw))
 	if err != nil {

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -492,6 +492,7 @@ func checkEqualManifest(m1, m2 *manifest.SignedManifest) error {
 }
 
 func TestManifestFetch(t *testing.T) {
+	ctx := context.Background()
 	repo := "test.example.com/repo"
 	m1, dgst := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
@@ -504,7 +505,10 @@ func TestManifestFetch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ms := r.Manifests()
+	ms, err := r.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ok, err := ms.Exists(dgst)
 	if err != nil {
@@ -536,8 +540,12 @@ func TestManifestFetchWithEtag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := context.Background()
+	ms, err := r.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	ms := r.Manifests()
 	m2, err := ms.GetByTag("latest", AddEtagToTag("latest", d1.String()))
 	if err != nil {
 		t.Fatal(err)
@@ -572,8 +580,12 @@ func TestManifestDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := context.Background()
+	ms, err := r.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	ms := r.Manifests()
 	if err := ms.Delete(dgst1); err != nil {
 		t.Fatal(err)
 	}
@@ -609,8 +621,12 @@ func TestManifestPut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := context.Background()
+	ms, err := r.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	ms := r.Manifests()
 	if err := ms.Put(m1); err != nil {
 		t.Fatal(err)
 	}
@@ -653,8 +669,12 @@ func TestManifestTags(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := context.Background()
+	ms, err := r.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	ms := r.Manifests()
 	tags, err := ms.Tags()
 	if err != nil {
 		t.Fatal(err)
@@ -691,7 +711,11 @@ func TestManifestUnauthorized(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ms := r.Manifests()
+	ctx := context.Background()
+	ms, err := r.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = ms.Get(dgst)
 	if err == nil {

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -34,7 +34,11 @@ type tagsAPIResponse struct {
 // GetTags returns a json list of tags for a specific image name.
 func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	manifests := th.Repository.Manifests()
+	manifests, err := th.Repository.Manifests(th)
+	if err != nil {
+		th.Errors = append(th.Errors, err)
+		return
+	}
 
 	tags, err := manifests.Tags()
 	if err != nil {

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -48,7 +48,11 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 
 func TestManifestStorage(t *testing.T) {
 	env := newManifestStoreTestEnv(t, "foo/bar", "thetag")
-	ms := env.repository.Manifests()
+	ctx := context.Background()
+	ms, err := env.repository.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exists, err := ms.ExistsByTag(env.tag)
 	if err != nil {
@@ -97,14 +101,14 @@ func TestManifestStorage(t *testing.T) {
 		t.Fatalf("unexpected error generating private key: %v", err)
 	}
 
-	sm, err := manifest.Sign(&m, pk)
-	if err != nil {
+	sm, merr := manifest.Sign(&m, pk)
+	if merr != nil {
 		t.Fatalf("error signing manifest: %v", err)
 	}
 
 	err = ms.Put(sm)
 	if err == nil {
-		t.Fatalf("expected errors putting manifest")
+		t.Fatalf("expected errors putting manifest with full verification")
 	}
 
 	switch err := err.(type) {


### PR DESCRIPTION
Enable manifest verification to be specified external to the Manifest 
interface and be passed in to the Put function.

I would have preferred VerifyManifest to live in the manifest package
but it would result in an import cycle