### PR TITLE
Ensure that rados is disabled without build tag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -102,8 +102,7 @@ test:
     - echo "$CIRCLE_PAIN" > ~/goverage.report
     - gvm use stable; go list ./... | xargs -L 1 -I{} rm -f $GOPATH/src/{}/coverage.out:
         pwd: $BASE_STABLE
-
-    - gvm use stable; go list ./... | xargs -L 1 -I{} godep go test -tags "$DOCKER_BUILDTAGS" -test.short -coverprofile=$GOPATH/src/{}/coverage.out {}:
+    - gvm use stable; go list -tags "$DOCKER_BUILDTAGS" ./... | xargs -L 1 -I{} godep go test -tags "$DOCKER_BUILDTAGS" -test.short -coverprofile=$GOPATH/src/{}/coverage.out {}:
         timeout: 600
         pwd: $BASE_STABLE
 

--- a/registry/storage/driver/rados/doc.go
+++ b/registry/storage/driver/rados/doc.go
@@ -1,0 +1,3 @@
+// Package rados implements the rados storage driver backend. Support can be
+// enabled by including the "include_rados" build tag.
+package rados

--- a/registry/storage/driver/rados/rados.go
+++ b/registry/storage/driver/rados/rados.go
@@ -1,3 +1,5 @@
+// +build include_rados
+
 package rados
 
 import (

--- a/registry/storage/driver/rados/rados_test.go
+++ b/registry/storage/driver/rados/rados_test.go
@@ -1,3 +1,5 @@
+// +build include_rados
+
 package rados
 
 import (


### PR DESCRIPTION
This ensures that rados is not required when building the registry. This was
slightly tricky in that when the flags were applied, the rados package was
completely missing. This led to a problem where rados was basically unlistable
and untestable as a package. This was fixed by simply adding a doc.go file that
is included whether rados is built or not.

This carries #611.