### PR TITLE
Add back in the "errors" wrapper in the Errors serialization

### DIFF
--- a/registry/api/errcode/errors.go
+++ b/registry/api/errcode/errors.go
@@ -172,7 +172,9 @@ type jsonError struct {
 // MarshalJSON converts slice of error, ErrorCode or Error into a
 // slice of Error - then serializes
 func (errs Errors) MarshalJSON() ([]byte, error) {
-	var tmpErrs []jsonError
+	var tmpErrs struct {
+		Errors []jsonError `json:"errors,omitempty"`
+	}
 
 	for _, daErr := range errs {
 		var err Error
@@ -187,7 +189,7 @@ func (errs Errors) MarshalJSON() ([]byte, error) {
 
 		}
 
-		tmpErrs = append(tmpErrs, jsonError{
+		tmpErrs.Errors = append(tmpErrs.Errors, jsonError{
 			Code:    err.Code,
 			Message: err.Message(),
 			Detail:  err.Detail,
@@ -200,14 +202,16 @@ func (errs Errors) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes []Error and then converts it into slice of
 // Error or ErrorCode
 func (errs *Errors) UnmarshalJSON(data []byte) error {
-	var tmpErrs []jsonError
+	var tmpErrs struct {
+		Errors []jsonError
+	}
 
 	if err := json.Unmarshal(data, &tmpErrs); err != nil {
 		return err
 	}
 
 	var newErrs Errors
-	for _, daErr := range tmpErrs {
+	for _, daErr := range tmpErrs.Errors {
 		if daErr.Detail == nil {
 			// Error's w/o details get converted to ErrorCode
 			newErrs = append(newErrs, daErr.Code)

--- a/registry/api/errcode/errors_test.go
+++ b/registry/api/errcode/errors_test.go
@@ -89,7 +89,7 @@ func TestErrorsManagement(t *testing.T) {
 		t.Fatalf("error marashaling errors: %v", err)
 	}
 
-	expectedJSON := "[{\"code\":\"TEST1\",\"message\":\"test error 1\"},{\"code\":\"TEST2\",\"message\":\"test error 2\",\"detail\":{\"digest\":\"sometestblobsumdoesntmatter\"}}]"
+	expectedJSON := "{\"errors\":[{\"code\":\"TEST1\",\"message\":\"test error 1\"},{\"code\":\"TEST2\",\"message\":\"test error 2\",\"detail\":{\"digest\":\"sometestblobsumdoesntmatter\"}}]}"
 
 	if string(p) != expectedJSON {
 		t.Fatalf("unexpected json:\ngot:\n%q\n\nexpected:\n%q", string(p), expectedJSON)
@@ -107,7 +107,7 @@ func TestErrorsManagement(t *testing.T) {
 
 	// Test again with a single value this time
 	errs = Errors{ErrorCodeUnknown}
-	expectedJSON = "[{\"code\":\"UNKNOWN\",\"message\":\"unknown error\"}]"
+	expectedJSON = "{\"errors\":[{\"code\":\"UNKNOWN\",\"message\":\"unknown error\"}]}"
 	p, err = json.Marshal(errs)
 
 	if err != nil {

--- a/registry/client/blob_writer_test.go
+++ b/registry/client/blob_writer_test.go
@@ -86,12 +86,14 @@ func TestUploadReadFrom(t *testing.T) {
 			Response: testutil.Response{
 				StatusCode: http.StatusBadRequest,
 				Body: []byte(`
-					[
-						{
-							"code": "BLOB_UPLOAD_INVALID",
-							"detail": "more detail"
-						}
-					] `),
+					{ "errors":
+						[
+							{
+								"code": "BLOB_UPLOAD_INVALID",
+								"detail": "more detail"
+							}
+						]
+					} `),
 			},
 		},
 		// Test 400 invalid json


### PR DESCRIPTION
See: https://github.com/docker/distribution/pull/548/files#r32794064

Signed-off-by: Doug Davis <dug@us.ibm.com>