### PR TITLE
Increase timeout of http.Client for Docker Registry V2 client

### DIFF
--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -34,7 +34,6 @@ func NewRepository(ctx context.Context, name, baseURL string, transport http.Rou
 
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   1 * time.Minute,
 		// TODO(dmcgowan): create cookie jar
 	}
 


### PR DESCRIPTION
The one minute timeout was too short and caused errors due to reading on a closed connection when downloading blobs.