### PR TITLE
Fix broken specification link in docs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -171,6 +171,6 @@ Now:
 
 This is **advanced**.
 
-You will find [background information here](spec/auth/token.md), [configuration information here](configuration.md#auth).
+You will find [background information here](./spec/auth/token.md), [configuration information here](configuration.md#auth).
 
 Beware that you will have to implement your own authentication service for this to work (though there exist third-party open-source implementations).


### PR DESCRIPTION
This should make the link work in both github and the docs site.

We may need to fix the sed calls in the docs build process and see if we can address this in hugo.

Signed-off-by: Stephen J Day <stephen.day@docker.com>