### PR TITLE
Prevent the ErrUnsupportedMethod error from being returned up the stack.

### DIFF
--- a/registry/storage/blobserver.go
+++ b/registry/storage/blobserver.go
@@ -65,6 +65,7 @@ func (bs *blobServer) ServeBlob(ctx context.Context, w http.ResponseWriter, r *h
 		}
 
 		http.ServeContent(w, r, desc.Digest.String(), time.Time{}, br)
+		return nil
 	}
 
 	// Some unexpected error.


### PR DESCRIPTION
Prevent the ErrUnsupportedMethod error from being returned up the stack,
it is not an error here. It eventually causes the go http library to do a double 
WriteHeader() which is an error.

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>