### PR TITLE
Manifest and layer soft deletion

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -27,6 +27,9 @@ var (
 	// ErrBlobInvalidLength returned when the blob has an expected length on
 	// commit, meaning mismatched with the descriptor or an invalid value.
 	ErrBlobInvalidLength = errors.New("blob invalid length")
+
+	// ErrUnsupported returned when an unsupported operation is attempted
+	ErrUnsupported = errors.New("unsupported operation")
 )
 
 // ErrBlobInvalidDigest returned when digest check fails.
@@ -70,6 +73,11 @@ type BlobStatter interface {
 	Stat(ctx context.Context, dgst digest.Digest) (Descriptor, error)
 }
 
+// BlobDeleter enables deleting blobs from storage.
+type BlobDeleter interface {
+	Delete(ctx context.Context, dgst digest.Digest) error
+}
+
 // BlobDescriptorService manages metadata about a blob by digest. Most
 // implementations will not expose such an interface explicitly. Such mappings
 // should be maintained by interacting with the BlobIngester. Hence, this is
@@ -87,6 +95,9 @@ type BlobDescriptorService interface {
 	// the restriction that the algorithm of the descriptor must match the
 	// canonical algorithm (ie sha256) of the annotator.
 	SetDescriptor(ctx context.Context, dgst digest.Digest, desc Descriptor) error
+
+	// Clear enables descriptors to be unlinked
+	Clear(ctx context.Context, dgst digest.Digest) error
 }
 
 // ReadSeekCloser is the primary reader type for blob data, combining
@@ -183,8 +194,9 @@ type BlobService interface {
 }
 
 // BlobStore represent the entire suite of blob related operations. Such an
-// implementation can access, read, write and serve blobs.
+// implementation can access, read, write, delete and serve blobs.
 type BlobStore interface {
 	BlobService
 	BlobServer
+	BlobDeleter
 }

--- a/cmd/registry/config.yml
+++ b/cmd/registry/config.yml
@@ -19,6 +19,8 @@ log:
         to:
           - errors@example.com
 storage:
+    delete:
+      enabled: true
     cache:
         blobdescriptor: redis
     filesystem:

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -240,6 +240,8 @@ func (storage Storage) Type() string {
 			// allow configuration of maintenance
 		case "cache":
 			// allow configuration of caching
+		case "delete":
+			// allow configuration of delete
 		default:
 			return k
 		}
@@ -271,6 +273,9 @@ func (storage *Storage) UnmarshalYAML(unmarshal func(interface{}) error) error {
 					// allow for configuration of maintenance
 				case "cache":
 					// allow configuration of caching
+				case "delete":
+					// allow configuration of delete
+
 				default:
 					types = append(types, k)
 				}

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -125,6 +125,12 @@ reference and shouldn't be used outside the specification other than to
 identify a set of modifications.
 
 <dl>
+  <dt>f</dt>
+  <dd>
+    <ul>
+      <li>Specify the delete API for layers and manifests.</li>
+    </ul>
+  </dd>
 
   <dt>e</dt>
   <dd>
@@ -714,6 +720,22 @@ Note that the upload url will not be available forever. If the upload uuid is
 unknown to the registry, a `404 Not Found` response will be returned and the
 client must restart the upload process.
 
+### Deleting a Layer
+
+A layer may be deleted from the registry via its `name` and `digest`. A
+delete may be issued with the following request format:
+
+    DELETE /v2/<name>/blobs/<digest>
+
+If the blob exists and has been successfully deleted, the following response will be issued:
+
+    202 Accepted
+    Content-Length: None
+
+If the blob had already been deleted or did not exist, a `404 Not Found`
+response will be issued instead.
+
+
 #### Pushing an Image Manifest
 
 Once all of the layers for an image are uploaded, the client can upload the
@@ -1000,6 +1022,7 @@ A list of methods and URIs are covered in the table below:
 | PUT | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Complete the upload specified by `uuid`, optionally appending the body as the final chunk. |
 | DELETE | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Cancel outstanding upload processes, releasing associated resources. If this is not called, the unfinished uploads will eventually timeout. |
 | GET | `/v2/_catalog` | Catalog | Retrieve a sorted, json list of repositories available in the registry. |
+| DELETE | `/v2/<name>/blobs/<digest>` | Blob delete | Delete the blob identified by `name` and `digest`|
 
 
 The detail for each endpoint is covered in the following sections.
@@ -1645,6 +1668,7 @@ The error codes that may be included in the response body are enumerated below:
 
 
 #### DELETE Manifest
+
 
 Delete the manifest identified by `name` and `reference`. Note that a manifest can _only_ be deleted by `digest`.
 

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -125,6 +125,12 @@ reference and shouldn't be used outside the specification other than to
 identify a set of modifications.
 
 <dl>
+  <dt>f</dt>
+  <dd>
+    <ul>
+      <li>Specify the delete API for layers and manifests.</li>
+    </ul>
+  </dd>
 
   <dt>e</dt>
   <dd>
@@ -169,7 +175,6 @@ identify a set of modifications.
       <li>Added error code for unsupported operations.</li>
     </ul>
   </dd>
-
 </dl>
 
 ## Overview
@@ -713,6 +718,25 @@ action.
 Note that the upload url will not be available forever. If the upload uuid is
 unknown to the registry, a `404 Not Found` response will be returned and the
 client must restart the upload process.
+
+### Deleting a Layer
+
+A layer may be deleted from the registry via its `name` and `digest`. A
+delete may be issued with the following request format:
+
+    DELETE /v2/<name>/blobs/<digest>
+
+If the blob exists and has been successfully deleted, the following response
+will be issued:
+
+    202 Accepted
+    Content-Length: None
+
+If the blob had already been deleted or did not exist, a `404 Not Found`
+response will be issued instead.
+
+If a layer is deleted which is referenced by a manifest in the registry,
+then the complete images will not be resolvable.
 
 #### Pushing an Image Manifest
 

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestListener(t *testing.T) {
 	ctx := context.Background()
-	registry := storage.NewRegistryWithDriver(ctx, inmemory.New(), memory.NewInMemoryBlobDescriptorCacheProvider())
+	registry := storage.NewRegistryWithDriver(ctx, inmemory.New(), memory.NewInMemoryBlobDescriptorCacheProvider(), true)
 	tl := &testListener{
 		ops: make(map[string]int),
 	}

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -101,6 +101,39 @@ func addTestCatalog(route string, content []byte, link string, m *testutil.Reque
 	})
 }
 
+func TestBlobDelete(t *testing.T) {
+	dgst, _ := newRandomBlob(1024)
+	var m testutil.RequestResponseMap
+	repo := "test.example.com/repo1"
+	m = append(m, testutil.RequestResponseMapping{
+		Request: testutil.Request{
+			Method: "DELETE",
+			Route:  "/v2/" + repo + "/blobs/" + dgst.String(),
+		},
+		Response: testutil.Response{
+			StatusCode: http.StatusAccepted,
+			Headers: http.Header(map[string][]string{
+				"Content-Length": {"0"},
+			}),
+		},
+	})
+
+	e, c := testServer(m)
+	defer c()
+
+	ctx := context.Background()
+	r, err := NewRepository(ctx, repo, e, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := r.Blobs(ctx)
+	err = l.Delete(ctx, dgst)
+	if err != nil {
+		t.Errorf("Error deleting blob: %s", err.Error())
+	}
+
+}
+
 func TestBlobFetch(t *testing.T) {
 	d1, b1 := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
@@ -590,7 +623,7 @@ func TestManifestDelete(t *testing.T) {
 			Route:  "/v2/" + repo + "/manifests/" + dgst1.String(),
 		},
 		Response: testutil.Response{
-			StatusCode: http.StatusOK,
+			StatusCode: http.StatusAccepted,
 			Headers: http.Header(map[string][]string{
 				"Content-Length": {"0"},
 			}),

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -31,7 +31,7 @@ func TestAppDispatcher(t *testing.T) {
 		Context:  ctx,
 		router:   v2.Router(),
 		driver:   driver,
-		registry: storage.NewRegistryWithDriver(ctx, driver, memorycache.NewInMemoryBlobDescriptorCacheProvider()),
+		registry: storage.NewRegistryWithDriver(ctx, driver, memorycache.NewInMemoryBlobDescriptorCacheProvider(), true),
 	}
 	server := httptest.NewServer(app)
 	router := v2.Router()

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/distribution/registry/storage/driver"
 )
 
-// blobStore implements a the read side of the blob store interface over a
+// blobStore implements the read side of the blob store interface over a
 // driver without enforcing per-repository membership. This object is
 // intentionally a leaky abstraction, providing utility methods that support
 // creating and traversing backend links.
@@ -143,7 +143,7 @@ type blobStatter struct {
 	pm     *pathMapper
 }
 
-var _ distribution.BlobStatter = &blobStatter{}
+var _ distribution.BlobDescriptorService = &blobStatter{}
 
 // Stat implements BlobStatter.Stat by returning the descriptor for the blob
 // in the main blob store. If this method returns successfully, there is
@@ -187,4 +187,12 @@ func (bs *blobStatter) Stat(ctx context.Context, dgst digest.Digest) (distributi
 		MediaType: "application/octet-stream",
 		Digest:    dgst,
 	}, nil
+}
+
+func (bs *blobStatter) Clear(ctx context.Context, dgst digest.Digest) error {
+	return distribution.ErrUnsupported
+}
+
+func (bs *blobStatter) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
+	return distribution.ErrUnsupported
 }

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -70,6 +70,11 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 		return distribution.Descriptor{}, err
 	}
 
+	err = bw.blobStore.blobAccessController.SetDescriptor(ctx, canonical.Digest, canonical)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+
 	return canonical, nil
 }
 

--- a/registry/storage/cache/memory/memory.go
+++ b/registry/storage/cache/memory/memory.go
@@ -44,6 +44,10 @@ func (imbdcp *inMemoryBlobDescriptorCacheProvider) Stat(ctx context.Context, dgs
 	return imbdcp.global.Stat(ctx, dgst)
 }
 
+func (imbdcp *inMemoryBlobDescriptorCacheProvider) Clear(ctx context.Context, dgst digest.Digest) error {
+	return imbdcp.global.Clear(ctx, dgst)
+}
+
 func (imbdcp *inMemoryBlobDescriptorCacheProvider) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
 	_, err := imbdcp.Stat(ctx, dgst)
 	if err == distribution.ErrBlobUnknown {
@@ -78,6 +82,14 @@ func (rsimbdcp *repositoryScopedInMemoryBlobDescriptorCache) Stat(ctx context.Co
 	}
 
 	return rsimbdcp.repository.Stat(ctx, dgst)
+}
+
+func (rsimbdcp *repositoryScopedInMemoryBlobDescriptorCache) Clear(ctx context.Context, dgst digest.Digest) error {
+	if rsimbdcp.repository == nil {
+		return distribution.ErrBlobUnknown
+	}
+
+	return rsimbdcp.repository.Clear(ctx, dgst)
 }
 
 func (rsimbdcp *repositoryScopedInMemoryBlobDescriptorCache) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
@@ -131,6 +143,14 @@ func (mbdc *mapBlobDescriptorCache) Stat(ctx context.Context, dgst digest.Digest
 	}
 
 	return desc, nil
+}
+
+func (mbdc *mapBlobDescriptorCache) Clear(ctx context.Context, dgst digest.Digest) error {
+	mbdc.mu.Lock()
+	defer mbdc.mu.Unlock()
+
+	delete(mbdc.descriptors, dgst)
+	return nil
 }
 
 func (mbdc *mapBlobDescriptorCache) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {

--- a/registry/storage/cache/suite.go
+++ b/registry/storage/cache/suite.go
@@ -139,3 +139,40 @@ func checkBlobDescriptorCacheSetAndRead(t *testing.T, ctx context.Context, provi
 		t.Fatalf("unexpected descriptor: %#v != %#v", desc, expected)
 	}
 }
+
+func checkBlobDescriptorClear(t *testing.T, ctx context.Context, provider BlobDescriptorCacheProvider) {
+	localDigest := digest.Digest("sha384:abc")
+	expected := distribution.Descriptor{
+		Digest:    "sha256:abc",
+		Size:      10,
+		MediaType: "application/octet-stream"}
+
+	cache, err := provider.RepositoryScoped("foo/bar")
+	if err != nil {
+		t.Fatalf("unexpected error getting scoped cache: %v", err)
+	}
+
+	if err := cache.SetDescriptor(ctx, localDigest, expected); err != nil {
+		t.Fatalf("error setting descriptor: %v", err)
+	}
+
+	desc, err := cache.Stat(ctx, localDigest)
+	if err != nil {
+		t.Fatalf("unexpected error statting fake2:abc: %v", err)
+	}
+
+	if expected != desc {
+		t.Fatalf("unexpected descriptor: %#v != %#v", expected, desc)
+	}
+
+	err = cache.Clear(ctx, localDigest)
+	if err != nil {
+		t.Fatalf("unexpected error deleting descriptor")
+	}
+
+	nonExistantDigest := digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	err = cache.Clear(ctx, nonExistantDigest)
+	if err == nil {
+		t.Fatalf("expected error deleting unknown descriptor")
+	}
+}

--- a/registry/storage/catalog_test.go
+++ b/registry/storage/catalog_test.go
@@ -22,7 +22,7 @@ func setupFS(t *testing.T) *setupEnv {
 	d := inmemory.New()
 	c := []byte("")
 	ctx := context.Background()
-	registry := NewRegistryWithDriver(ctx, d, memory.NewInMemoryBlobDescriptorCacheProvider())
+	registry := NewRegistryWithDriver(ctx, d, memory.NewInMemoryBlobDescriptorCacheProvider(), false)
 	rootpath, _ := defaultPathMapper.path(repositoriesRootPathSpec{})
 
 	repos := []string{

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -69,8 +69,8 @@ func (ms *manifestStore) Put(manifest *manifest.SignedManifest) error {
 
 // Delete removes the revision of the specified manfiest.
 func (ms *manifestStore) Delete(dgst digest.Digest) error {
-	context.GetLogger(ms.ctx).Debug("(*manifestStore).Delete - unsupported")
-	return fmt.Errorf("deletion of manifests not supported")
+	context.GetLogger(ms.ctx).Debug("(*manifestStore).Delete")
+	return ms.revisionStore.delete(ms.ctx, dgst)
 }
 
 func (ms *manifestStore) Tags() ([]string, error) {

--- a/registry/storage/revisionstore.go
+++ b/registry/storage/revisionstore.go
@@ -17,19 +17,6 @@ type revisionStore struct {
 	ctx        context.Context
 }
 
-func newRevisionStore(ctx context.Context, repo *repository, blobStore *blobStore) *revisionStore {
-	return &revisionStore{
-		ctx:        ctx,
-		repository: repo,
-		blobStore: &linkedBlobStore{
-			blobStore:  blobStore,
-			repository: repo,
-			ctx:        ctx,
-			linkPath:   manifestRevisionLinkPath,
-		},
-	}
-}
-
 // get retrieves the manifest, keyed by revision digest.
 func (rs *revisionStore) get(ctx context.Context, revision digest.Digest) (*manifest.SignedManifest, error) {
 	// Ensure that this revision is available in this repository.
@@ -117,4 +104,8 @@ func (rs *revisionStore) put(ctx context.Context, sm *manifest.SignedManifest) (
 	}
 
 	return revision, nil
+}
+
+func (rs *revisionStore) delete(ctx context.Context, revision digest.Digest) error {
+	return rs.blobStore.Delete(ctx, revision)
 }

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -115,8 +115,8 @@ func (s *signatureStore) Put(dgst digest.Digest, signatures ...[]byte) error {
 	return nil
 }
 
-// namedBlobStore returns the namedBlobStore of the signatures for the
-// manifest with the given digest. Effectively, each singature link path
+// linkedBlobStore returns the namedBlobStore of the signatures for the
+// manifest with the given digest. Effectively, each signature link path
 // layout is a unique linked blob store.
 func (s *signatureStore) linkedBlobStore(ctx context.Context, revision digest.Digest) *linkedBlobStore {
 	linkpath := func(pm *pathMapper, name string, dgst digest.Digest) (string, error) {
@@ -131,7 +131,7 @@ func (s *signatureStore) linkedBlobStore(ctx context.Context, revision digest.Di
 		ctx:        ctx,
 		repository: s.repository,
 		blobStore:  s.blobStore,
-		statter: &linkedBlobStatter{
+		blobAccessController: &linkedBlobStatter{
 			blobStore:  s.blobStore,
 			repository: s.repository,
 			linkPath:   linkpath,


### PR DESCRIPTION
Implement the delete API by implementing soft delete for layers
and blobs by removing link files and updating the blob descriptor
cache.  Deletion is configurable - if it is disabled API calls
will return an unsupported error.

We invalidate the blob descriptor cache by changing the linkedBlobStore's
blobStatter to a blobDescriptorService and naming it a blobAccessController.

Delete() is added throughout the storage API to support this functionality.

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>

Closes #461 