### PR TITLE
Add a storage-driver for speedy

### DIFF
--- a/cmd/registry/speedy.go
+++ b/cmd/registry/speedy.go
@@ -1,0 +1,3 @@
+package main
+
+import _ "github.com/docker/distribution/registry/storage/driver/speedy"

--- a/docs/storage-drivers/speedy.md
+++ b/docs/storage-drivers/speedy.md
@@ -15,8 +15,8 @@ The following parameters must be used to configure the storage driver
 (case-sensitive):
 
 * `storageurl`: The speedy(imageserver) address (e.g. http://127.0.0.1:6788 or http://127.0.0.1:6788;http://127.0.0.1:6789). 
-* `chunksize`: Size of the written objects(e.g. 4 means 4MB).
-* `heartbeatinterval`: The interval of heartbeat (e.g. 2 means 2 seconds) 
+* `chunksize`: Size of the written objects(units is MB, e.g. 4 is 4MB).
+* `heartbeatinterval`: The interval of heartbeat (units is seconds, e.g. 2 is 2 seconds) 
 
 
 [speedy]: https://github.com/jcloudpub/speedy

--- a/docs/storage-drivers/speedy.md
+++ b/docs/storage-drivers/speedy.md
@@ -1,0 +1,22 @@
+<!--GITHUB
+page_title: Speedy storage driver
+page_description: Explains how to use the Speedy storage driver
+page_keywords: registry, service, driver, images, storage, speedy
+IGNORES-->
+
+# Speedy storage driver
+
+An implementation of the `storagedriver.StorageDriver` interface which uses
+[Speedy][speedy] for storage backend.
+
+## Parameters
+
+The following parameters must be used to configure the storage driver
+(case-sensitive):
+
+* `storageurl`: The speedy(imageserver) address (e.g. http://127.0.0.1:6788 or http://127.0.0.1:6788;http://127.0.0.1:6789). 
+* `chunksize`: Size of the written objects(e.g. 4 means 4MB).
+* `heartbeatinterval`: The interval of heartbeat (e.g. 2 means 2 seconds) 
+
+
+[speedy]: https://github.com/jcloudpub/speedy

--- a/registry/storage/driver/speedy/speedy.go
+++ b/registry/storage/driver/speedy/speedy.go
@@ -445,7 +445,7 @@ func (d *driver) writeStreamToSpeedy(path string, currentOffset uint64, reader i
 }
 
 // Stat retrieves the FileInfo for the given path, including the current
-// size in bytes and the creation time.
+// size in bytes and the modification time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
 	url, err := d.getUrl()
 	if err != nil {

--- a/registry/storage/driver/speedy/speedy.go
+++ b/registry/storage/driver/speedy/speedy.go
@@ -28,7 +28,7 @@ type driver struct {
 	healthURLArr      []string
 	chunkSize         uint64
 	heartBeatInterval int
-	client            *SpeedyClient
+	client            *Client
 	rwlock            sync.RWMutex
 }
 
@@ -110,7 +110,7 @@ func New(params DriverParameters) (*Driver, error) {
 		return nil, fmt.Errorf("The storageURL parameter may be error")
 	}
 
-	client := &SpeedyClient{}
+	client := &Client{}
 
 	d := &driver{
 		storageURLArr:     storageURLArr,

--- a/registry/storage/driver/speedy/speedy.go
+++ b/registry/storage/driver/speedy/speedy.go
@@ -311,7 +311,7 @@ func (d *driver) initReadStream(path string, offset uint64, infoArr []*MetaInfoV
 	}
 
 	var index int
-	var readOffset uint64 = 0
+	var readOffset uint64
 	for index < len(infoArr) {
 		nextReadOffset := readOffset + (infoArr[index].End - infoArr[index].Start)
 		if nextReadOffset >= uint64(offset) {
@@ -354,7 +354,7 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 
 	var totalRead int64
 	var index int
-	var currentSize uint64 = 0
+	var currentSize uint64
 
 	//Align to chunk size, skip already exist chunk
 	if len(infoArr) != 0 {
@@ -370,13 +370,13 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 		//read 1MB every time
 		var tempSize uint64 = 1 << 20
 		tempBuf := make([]byte, tempSize)
-		var distance uint64 
+		var distance uint64
 		if currentSize > uint64(offset) {
 			distance = currentSize - uint64(offset)
 		}
 
 		for distance > 0 {
-			var readSize uint64 = 0
+			var readSize uint64
 			if distance > tempSize {
 				readSize = tempSize
 			} else {

--- a/registry/storage/driver/speedy/speedy.go
+++ b/registry/storage/driver/speedy/speedy.go
@@ -1,0 +1,568 @@
+package speedy
+
+import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/context"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+	"github.com/docker/distribution/registry/storage/driver/base"
+	"github.com/docker/distribution/registry/storage/driver/factory"
+	"io"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+)
+
+const driverName = "speedy"
+
+type DriverParameters struct {
+	storageUrls       string
+	chunkSize         uint64
+	heartBeatInterval int
+}
+
+type driver struct {
+	storageUrlArr     []string
+	healthUrlArr      []string
+	chunkSize         uint64
+	heartBeatInterval int
+	client            *SpeedyClient
+	rwlock            sync.RWMutex
+}
+
+type basedEmbed struct {
+	base.Base
+}
+
+type Driver struct {
+	basedEmbed
+}
+
+//ReadStream retrieves an io.ReadCloser for the content stored at "path" with a
+//given byte offset.
+type readStreamReader struct {
+	driver       *driver
+	path         string
+	index        int
+	infoArr      []*MetaInfoValue
+	remain       []byte
+	remainOffset uint64 //read from remain buffer at index of remainOffset
+	size         uint64 //total size
+	offset       uint64 //global offset
+}
+
+func init() {
+	factory.Register(driverName, &speedyDriverFactory{})
+}
+
+type speedyDriverFactory struct{}
+
+func (factory *speedyDriverFactory) Create(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+	return FromParameters(parameters)
+}
+
+// FromParameters constructs a new Driver with a given paramters map.
+func FromParameters(parameters map[string]interface{}) (*Driver, error) {
+	storageUrl, ok := parameters["storageurl"]
+	if !ok {
+		return nil, fmt.Errorf("No storageurl parameter provided")
+	}
+
+	chunkSizeParam, ok := parameters["chunksize"]
+	if !ok {
+		return nil, fmt.Errorf("No chunksize parameter provided")
+	}
+
+	chunkSizeMB, ok := chunkSizeParam.(int)
+	if !ok {
+		return nil, fmt.Errorf("The chunksize parameter should be a number")
+	}
+
+	//change MB to B
+	chunkSize := chunkSizeMB << 20
+
+	heartBeatIntervalParam, ok := parameters["heartbeatinterval"]
+	if !ok {
+		return nil, fmt.Errorf("No heartbeatinterval parameter provided")
+	}
+
+	heartBeatInterval, ok := heartBeatIntervalParam.(int)
+	if !ok {
+		return nil, fmt.Errorf("The heartbeatinterval parameter should be a number")
+	}
+
+	params := DriverParameters{
+		storageUrls:       fmt.Sprint(storageUrl),
+		chunkSize:         uint64(chunkSize),
+		heartBeatInterval: heartBeatInterval,
+	}
+
+	return New(params)
+}
+
+//New constructs a new Driver with the speedy param.
+func New(params DriverParameters) (*Driver, error) {
+	storageUrlArr := strings.Split(params.storageUrls, ";")
+	if len(storageUrlArr) < 1 {
+		return nil, fmt.Errorf("The storageUrl parameter may be error")
+	}
+
+	client := &SpeedyClient{}
+
+	d := &driver{
+		storageUrlArr:     storageUrlArr,
+		healthUrlArr:      make([]string, 0),
+		chunkSize:         params.chunkSize,
+		heartBeatInterval: params.heartBeatInterval,
+		client:            client,
+	}
+
+	finalDriver := &Driver{
+		basedEmbed: basedEmbed{
+			Base: base.Base{
+				StorageDriver: d,
+			},
+		},
+	}
+
+	go d.healthCheck(d.heartBeatInterval)
+	return finalDriver, nil
+}
+
+func (d *driver) Name() string {
+	return driverName
+}
+
+func (d *driver) updateHealthUrlArr() {
+	healthUrlArr := make([]string, 0)
+	for i, _ := range d.storageUrlArr {
+		err := d.client.Ping(d.storageUrlArr[i])
+		if err != nil {
+			log.Errorf("speedy driver ping error: %v", err)
+			continue
+		}
+		healthUrlArr = append(healthUrlArr, d.storageUrlArr[i])
+	}
+	d.rwlock.Lock()
+	d.healthUrlArr = healthUrlArr
+	d.rwlock.Unlock()
+}
+
+func (d *driver) healthCheck(seconds int) {
+	timer := time.NewTicker(time.Duration(seconds) * time.Second)
+	for {
+		select {
+		case <-timer.C:
+			d.updateHealthUrlArr()
+		}
+	}
+}
+
+//GetContent retrives the content stored at the "path" as a []byte.
+func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
+	url, err := d.getUrl()
+	if err != nil {
+		return nil, err
+	}
+
+	infoArr, err := d.client.GetFileInfo(url, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if infoArr == nil && err == nil {
+		return nil, storagedriver.PathNotFoundError{Path: path}
+	}
+
+	if len(infoArr) == 0 {
+		return nil, fmt.Errorf("There is not file info, path: %v", path)
+	}
+
+	if len(infoArr) != 1 {
+		return nil, fmt.Errorf("metainfo maybe error, path: %v, metainfo: %v", path, infoArr)
+	}
+
+	data, err := d.client.DownloadFile(url, path, infoArr[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+//PutContent stores the []byte content at a location designated by "path".
+func (d *driver) PutContent(ctx context.Context, path string, contents []byte) error {
+	url, err := d.getUrl()
+	if err != nil {
+		return err
+	}
+
+	info := &MetaInfoValue{
+		Index:  0,
+		Start:  0,
+		End:    uint64(len(contents)),
+		IsLast: true,
+	}
+
+	err = d.client.UploadFile(url, path, info, contents)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *readStreamReader) Read(b []byte) (n int, err error) {
+	bufferOffset := uint64(0)
+	bufferSize := uint64(len(b))
+
+	if bufferSize > r.size-r.offset {
+		bufferSize = r.size - r.offset
+	}
+
+	// Fill b
+	for bufferOffset < bufferSize {
+		unreadRemainSize := uint64(len(r.remain)) - r.remainOffset
+		fillSize := bufferSize - bufferOffset
+
+		if unreadRemainSize >= fillSize {
+			copy(b[bufferOffset:bufferSize], r.remain[r.remainOffset:r.remainOffset+fillSize])
+			r.remainOffset += fillSize
+			r.offset += fillSize
+			return int(bufferSize), nil
+		}
+
+		if unreadRemainSize > 0 && unreadRemainSize <= fillSize {
+			copy(b[bufferOffset:], r.remain[r.remainOffset:len(r.remain)])
+			readSize := uint64(len(r.remain)) - r.remainOffset
+			bufferOffset += readSize
+			r.remainOffset = uint64(len(r.remain))
+			r.offset += readSize
+		}
+
+		url, err := r.driver.getUrl()
+		if err != nil {
+			return int(bufferOffset), err
+		}
+
+		r.remain, err = r.driver.client.DownloadFile(url, r.path, r.infoArr[r.index])
+		if err != nil {
+			return int(bufferOffset), err
+		}
+		r.remainOffset = 0
+		r.index++
+	}
+
+	return 0, fmt.Errorf("The capacity of buffer is empty")
+}
+
+func (r *readStreamReader) Close() error {
+	r.remain = nil
+	r.index = 0
+	r.remainOffset = 0
+	r.infoArr = nil
+	return nil
+}
+
+// ReadStream retrieves an io.ReadCloser for the content stored at "path"
+// with a given byte offset.
+// May be used to resume reading a stream by providing a nonzero offset.
+func (d *driver) ReadStream(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
+	//get all metainfos
+	url, err := d.getUrl()
+	if err != nil {
+		return nil, err
+	}
+
+	infoArr, err := d.client.GetFileInfo(url, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(infoArr) == 0 {
+		return nil, fmt.Errorf("There is not file info, path: %v", path)
+	}
+
+	return d.initReadStream(path, uint64(offset), infoArr)
+}
+
+func (d *driver) initReadStream(path string, offset uint64, infoArr []*MetaInfoValue) (io.ReadCloser, error) {
+	var size uint64
+	for index, _ := range infoArr {
+		size += infoArr[index].End - infoArr[index].Start
+	}
+
+	if uint64(offset) > size {
+		return nil, storagedriver.InvalidOffsetError{Path: path, Offset: int64(offset)}
+	}
+
+	readCloser := &readStreamReader{
+		driver:       d,
+		path:         path,
+		index:        0,
+		infoArr:      infoArr,
+		remain:       nil,
+		remainOffset: 0,
+		size:         size,
+		offset:       0,
+	}
+
+	index := 0
+	var readOffset uint64 = 0
+	for index < len(infoArr) {
+		nextReadOffset := readOffset + (infoArr[index].End - infoArr[index].Start)
+		if nextReadOffset >= uint64(offset) {
+			break
+		}
+		readOffset = nextReadOffset
+		index++
+		continue
+	}
+
+	url, err := d.getUrl()
+	if err != nil {
+		return nil, err
+	}
+
+	readCloser.remain, err = d.client.DownloadFile(url, path, infoArr[index])
+	if err != nil {
+		return nil, err
+	}
+	readCloser.index = index + 1
+	readCloser.remainOffset = offset - readOffset
+	readCloser.offset = offset
+	return readCloser, nil
+}
+
+// WriteStream stores the contents of the provided io.ReadCloser at a
+// location designated by the given path.
+// May be used to resume writing a stream by providing a nonzero offset.
+// The offset must be no larger than the CurrentSize for this path.
+func (d *driver) WriteStream(ctx context.Context, path string, offset int64, reader io.Reader) (int64, error) {
+	url, err := d.getUrl()
+	if err != nil {
+		return 0, err
+	}
+
+	infoArr, err := d.client.GetFileInfo(url, path)
+	if err != nil {
+		return 0, err
+	}
+
+	var totalRead int64
+	totalRead = 0
+	index := 0
+	var currentSize uint64 = 0
+
+	//Align to chunk size, skip already exist chunk
+	if len(infoArr) != 0 {
+		for _, info := range infoArr {
+			currentSize += info.End - info.Start
+			index++
+		}
+
+		if currentSize < uint64(offset) {
+			return 0, fmt.Errorf("speedy driver currentSize: %d < offset: %d", currentSize, offset)
+		}
+
+		//read 1MB every time
+		var tempSize uint64 = 1 << 20
+		tempBuf := make([]byte, tempSize)
+		var distance uint64 = 0
+		if currentSize > uint64(offset) {
+			distance = currentSize - uint64(offset)
+		}
+
+		for distance > 0 {
+			var readSize uint64 = 0
+			if distance > tempSize {
+				readSize = tempSize
+			} else {
+				readSize = distance
+			}
+
+			n, err := reader.Read(tempBuf[0:readSize])
+			if err != nil {
+				return totalRead, err
+			}
+
+			totalRead += int64(n)
+			offset += int64(n)
+
+			distance = currentSize - uint64(offset)
+		}
+	}
+
+	readSize, err := d.writeStreamToSpeedy(path, currentSize, reader, index)
+	totalRead += readSize
+	if err != nil {
+		return totalRead, err
+	}
+
+	return totalRead, nil
+}
+
+func (d *driver) writeStreamToSpeedy(path string, currentOffset uint64, reader io.Reader, index int) (totalRead int64, err error) {
+	totalRead = 0
+	buf := make([]byte, d.chunkSize)
+	isLast := false
+
+	for {
+		n, err := reader.Read(buf)
+		if err != nil {
+			if err != io.EOF {
+				log.Errorf("speedy driver writeStreamToSpeedy error: %v", err)
+				return totalRead, err
+			}
+			isLast = true
+		}
+
+		info := &MetaInfoValue{
+			Index:  uint64(index),
+			Start:  currentOffset,
+			End:    currentOffset + uint64(n),
+			IsLast: isLast,
+		}
+
+		url, err := d.getUrl()
+		if err != nil {
+			return totalRead, err
+		}
+
+		err = d.client.UploadFile(url, path, info, buf[0:n])
+		if err != nil {
+			return totalRead, err
+		}
+
+		currentOffset = currentOffset + uint64(n)
+		totalRead += int64(n)
+		index++
+		if isLast {
+			return totalRead, nil
+		}
+	}
+}
+
+// Stat retrieves the FileInfo for the given path, including the current
+// size in bytes and the creation time.
+func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
+	url, err := d.getUrl()
+	if err != nil {
+		return nil, err
+	}
+
+	infoArr, err := d.client.GetFileInfo(url, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err == nil && infoArr == nil {
+		descendants, err := d.client.GetDirectDescendantPath(url, path)
+		if err == nil && len(descendants) != 0 {
+			return storagedriver.FileInfoInternal{
+				FileInfoFields: storagedriver.FileInfoFields{
+					Path:  path,
+					Size:  0,
+					IsDir: true,
+				},
+			}, nil
+		}
+		return nil, storagedriver.PathNotFoundError{Path: path}
+	}
+
+	if len(infoArr) == 0 {
+		return nil, fmt.Errorf("There is not file info, path: %v", path)
+	}
+
+	var totalSize uint64
+	modTime := infoArr[0].ModTime
+	for index, _ := range infoArr {
+		totalSize += infoArr[index].End - infoArr[index].Start
+		if infoArr[index].ModTime.After(modTime) {
+			modTime = infoArr[index].ModTime
+		}
+	}
+
+	return storagedriver.FileInfoInternal{
+		FileInfoFields: storagedriver.FileInfoFields{
+			Path:    path,
+			Size:    int64(totalSize),
+			ModTime: modTime,
+		},
+	}, nil
+}
+
+// List returns a list of the objects that are direct descendants of the
+//given path.
+func (d *driver) List(ctx context.Context, path string) ([]string, error) {
+	url, err := d.getUrl()
+	if err != nil {
+		return nil, err
+	}
+
+	descendants, err := d.client.GetDirectDescendantPath(url, path)
+	if err != nil {
+		log.Errorf("speedy driver List error: %v", err)
+		return nil, err
+	}
+
+	if err == nil && descendants == nil {
+		return make([]string, 0), nil
+	}
+
+	return descendants, nil
+}
+
+// Move moves an object stored at sourcePath to destPath, removing the
+// original object.
+// Note: This may be no more efficient than a copy followed by a delete for
+// many implementations.
+func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) error {
+	url, err := d.getUrl()
+	if err != nil {
+		return err
+	}
+
+	return d.client.MoveFile(url, sourcePath, destPath)
+}
+
+// Delete recursively deletes all objects stored at "path" and its subpaths.
+func (d *driver) Delete(ctx context.Context, path string) error {
+	url, err := d.getUrl()
+	if err != nil {
+		return err
+	}
+
+	return d.client.DeleteFile(url, path)
+}
+
+// URLFor returns a URL which may be used to retrieve the content stored at
+// the given path, possibly using the given options.
+// May return an ErrUnsupportedMethod in certain StorageDriver
+// implementations.
+func (d *driver) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+	return "", storagedriver.ErrUnsupportedMethod
+}
+
+func (d *driver) getUrl() (string, error) {
+	d.rwlock.RLock()
+	healthUrlArr := d.healthUrlArr
+	d.rwlock.RUnlock()
+	//try to get url from healthUrlArr
+	healthSize := len(healthUrlArr)
+	if healthSize != 0 {
+		index := rand.Int() % healthSize
+		url := healthUrlArr[index]
+		return url, nil
+	}
+
+	//try to get url from storageUrlArr
+	totalSize := len(d.storageUrlArr)
+	if totalSize == 0 {
+		return "", fmt.Errorf("The storageUrlArr is empty")
+	}
+	index := rand.Int() % totalSize
+	url := d.storageUrlArr[index]
+	return url, nil
+}

--- a/registry/storage/driver/speedy/speedy_test.go
+++ b/registry/storage/driver/speedy/speedy_test.go
@@ -19,11 +19,11 @@ func init() {
 	var heartBeatInterval int //seconds
 
 	if chunkSizeStr != "" {
-		chunkSize, _ := strconv.Atoi(chunkSizeStr)
+		chunkSize, _ = strconv.Atoi(chunkSizeStr)
 	}
 
 	if heartBeatIntervalStr != "" {
-		heartBeatInterval, _ := strconv.Atoi(heartBeatIntervalStr)
+		heartBeatInterval, _ = strconv.Atoi(heartBeatIntervalStr)
 	}
 
 	driverConstructor := func() (storagedriver.StorageDriver, error) {

--- a/registry/storage/driver/speedy/speedy_test.go
+++ b/registry/storage/driver/speedy/speedy_test.go
@@ -12,7 +12,7 @@ import (
 func Test(t *testing.T) { check.TestingT(t) }
 
 func init() {
-	storageUrls := os.Getenv("SPEEDY_STORAGE_URL")
+	storageURLs := os.Getenv("SPEEDY_STORAGE_URL")
 	chunkSizeStr := os.Getenv("SPEEDY_CHUNKSIZE")
 	heartBeatIntervalStr := os.Getenv("SPEEDY_HEART_BEAT")
 	var chunkSize int         //MB
@@ -28,7 +28,7 @@ func init() {
 
 	driverConstructor := func() (storagedriver.StorageDriver, error) {
 		parameters := DriverParameters{
-			storageUrls:       storageUrls,
+			storageURLs:       storageURLs,
 			chunkSize:         uint64(chunkSize),
 			heartBeatInterval: heartBeatInterval,
 		}
@@ -37,7 +37,7 @@ func init() {
 	}
 
 	skipCheck := func() string {
-		if storageUrls == "" || chunkSize == 0 || heartBeatInterval == 0 {
+		if storageURLs == "" || chunkSize == 0 || heartBeatInterval == 0 {
 			return "Must set SPEEDY_STORAGE_URL, SPEEDY_CHUNKSIZE and SPEEDY_HEART_BEAT to run speedy test"
 		}
 		return ""

--- a/registry/storage/driver/speedy/speedy_test.go
+++ b/registry/storage/driver/speedy/speedy_test.go
@@ -1,0 +1,47 @@
+package speedy
+
+import (
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+	"github.com/docker/distribution/registry/storage/driver/testsuites"
+	"gopkg.in/check.v1"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+func init() {
+	storageUrls := os.Getenv("SPEEDY_STORAGE_URL")
+	chunkSizeStr := os.Getenv("SPEEDY_CHUNKSIZE")
+	heartBeatIntervalStr := os.Getenv("SPEEDY_HEART_BEAT")
+	var chunkSize int         //MB
+	var heartBeatInterval int //seconds
+
+	if chunkSizeStr != "" {
+		chunkSize, _ := strconv.Atoi(chunkSizeStr)
+	}
+
+	if heartBeatIntervalStr != "" {
+		heartBeatInterval, _ := strconv.Atoi(heartBeatIntervalStr)
+	}
+
+	driverConstructor := func() (storagedriver.StorageDriver, error) {
+		parameters := DriverParameters{
+			storageUrls:       storageUrls,
+			chunkSize:         uint64(chunkSize),
+			heartBeatInterval: heartBeatInterval,
+		}
+
+		return New(parameters)
+	}
+
+	skipCheck := func() string {
+		if storageUrls == "" || chunkSize == 0 || heartBeatInterval == 0 {
+			return "Must set SPEEDY_STORAGE_URL, SPEEDY_CHUNKSIZE and SPEEDY_HEART_BEAT to run speedy test"
+		}
+		return ""
+	}
+
+	testsuites.RegisterSuite(driverConstructor, skipCheck)
+}

--- a/registry/storage/driver/speedy/speedyclient.go
+++ b/registry/storage/driver/speedy/speedyclient.go
@@ -15,7 +15,7 @@ import (
 type Client struct {
 }
 
-//MetaInfoValue is meta info format of speedy. 
+//MetaInfoValue is meta info format of speedy.
 type MetaInfoValue struct {
 	Index   uint64
 	Start   uint64
@@ -233,7 +233,7 @@ func (c *Client) GetDirectoryInfo(url string, path string) ([]string, error) {
 	return nil, fmt.Errorf("GetDirectoryInfo failed, statusCode: %d, err: %v", statusCode, err)
 }
 
-//GetDirectDescendantPath is used to get direct descendants path from speedy by path. 
+//GetDirectDescendantPath is used to get direct descendants path from speedy by path.
 func (c *Client) GetDirectDescendantPath(url string, path string) ([]string, error) {
 	req, err := http.NewRequest("GET", url+"/v1/list_descendant", nil)
 	if err != nil {

--- a/registry/storage/driver/speedy/speedyclient.go
+++ b/registry/storage/driver/speedy/speedyclient.go
@@ -1,0 +1,366 @@
+package speedy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+type SpeedyClient struct {
+}
+
+type MetaInfoValue struct {
+	Index   uint64
+	Start   uint64
+	End     uint64
+	IsLast  bool
+	IsDir   bool `json:",omitempty"`
+	ModTime time.Time
+}
+
+type OrderByIndex []*MetaInfoValue
+
+const (
+	headerSourcePath = "Source-Path"
+	headerDestPath   = "Dest-Path"
+	headerPath       = "Path"
+	headerIndex      = "Fragment-Index"
+	headerRange      = "Bytes-Range"
+	headerIsLast     = "Is-Last"
+	headerVersion    = "Registry-Version"
+	fragmentInfo     = "fragment-info"
+	fileList         = "file-list"
+	pathDescendant   = "path-descendant"
+)
+
+func (a OrderByIndex) Len() int {
+	return len(a)
+}
+
+func (a OrderByIndex) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a OrderByIndex) Less(i, j int) bool {
+	return a[i].Index < a[j].Index
+}
+
+func (c *SpeedyClient) DoRequest(req *http.Request) ([]byte, int, error) {
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		if resp != nil {
+			return nil, resp.StatusCode, err
+		}
+		return nil, http.StatusNotFound, err
+	}
+
+	dataBody, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return dataBody, resp.StatusCode, nil
+}
+
+func (c *SpeedyClient) getMetaInfoValueFromJson(data []byte) ([]*MetaInfoValue, error) {
+	var mapResult map[string]interface{}
+	err := json.Unmarshal(data, &mapResult)
+	if err != nil {
+		return nil, err
+	}
+
+	fragmentInfoValue, ok := mapResult[fragmentInfo]
+	if !ok {
+		return nil, fmt.Errorf("Response format maybe error: %v", mapResult)
+	}
+
+	infoArr, ok := fragmentInfoValue.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Response format maybe error, value is not a array: %v", fragmentInfoValue)
+	}
+
+	result := make([]*MetaInfoValue, 0)
+	for _, info := range infoArr {
+		m, ok := info.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("Response format maybe error, infoArr: %v", infoArr)
+		}
+
+		miv := new(MetaInfoValue)
+		index, ok := m["Index"].(float64)
+		if !ok {
+			return nil, fmt.Errorf("Response format maybe error, MetaInfoValue: %v", m)
+		}
+		miv.Index = uint64(index)
+
+		start, ok := m["Start"].(float64)
+		if !ok {
+			return nil, fmt.Errorf("Response format maybe error, MetaInfoValue: %v", m)
+		}
+		miv.Start = uint64(start)
+
+		end, ok := m["End"].(float64)
+		if !ok {
+			return nil, fmt.Errorf("Response format maybe error, MetaInfoValue: %v", m)
+		}
+		miv.End = uint64(end)
+
+		isLast, ok := m["IsLast"].(bool)
+		if !ok {
+			return nil, fmt.Errorf("Response format maybe error, MetaInfoValue: %v", m)
+		}
+		miv.IsLast = isLast
+
+		isDirTemp, ok := m["IsDir"]
+		if ok {
+			isDir, ok := isDirTemp.(bool)
+			if !ok {
+				return nil, fmt.Errorf("Response format maybe error, MetaInfoValue: %v", m)
+			}
+			miv.IsDir = isDir
+		}
+
+		modTimeStr, ok := m["ModTime"].(string)
+		if !ok {
+			return nil, fmt.Errorf("Response format maybe error, MetaInfoValue: %v", m)
+		}
+		modTime, err := time.Parse(time.RFC3339Nano, modTimeStr)
+		if err != nil {
+			return nil, fmt.Errorf("Response format maybe error, MetaInfoValue: %v, error: %v", m, err)
+		}
+		miv.ModTime = modTime
+
+		result = append(result, miv)
+	}
+	return result, nil
+}
+
+func (c *SpeedyClient) sortMetaInfoValue(origin []*MetaInfoValue) ([]*MetaInfoValue, error) {
+	sort.Sort(OrderByIndex(origin))
+	return origin, nil
+}
+
+func (c *SpeedyClient) GetFileInfo(url string, path string) ([]*MetaInfoValue, error) {
+	req, err := http.NewRequest("GET", url+"/v1/fileinfo", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	header := make(http.Header)
+	header.Set(headerPath, path)
+	req.Header = header
+	dataBody, statusCode, err := c.DoRequest(req)
+	if err == nil && statusCode == http.StatusOK {
+		infoArr, err := c.getMetaInfoValueFromJson(dataBody)
+		if err != nil {
+			return nil, err
+		}
+		infoArr, err = c.sortMetaInfoValue(infoArr)
+		if err != nil {
+			return nil, err
+		}
+		return infoArr, nil
+	}
+
+	if err == nil && statusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("GetFileInfo failed, statusCode: %d, err: %v", statusCode, err)
+}
+
+func (c *SpeedyClient) DownloadFile(url string, path string, info *MetaInfoValue) ([]byte, error) {
+	req, err := http.NewRequest("GET", url+"/v1/file", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	header := make(http.Header)
+	header.Set(headerPath, path)
+	header.Set(headerIndex, fmt.Sprintf("%d", info.Index))
+	header.Set(headerRange, fmt.Sprintf("%d-%d", info.Start, info.End))
+	header.Set(headerIsLast, fmt.Sprintf("%v", info.IsLast))
+	req.Header = header
+	dataBody, statusCode, err := c.DoRequest(req)
+	if err == nil && statusCode == http.StatusOK {
+		return dataBody, nil
+	}
+	return nil, fmt.Errorf("DownloadFile failed, statusCode: %d, err: %v", statusCode, err)
+}
+
+func (c *SpeedyClient) GetDirectoryInfo(url string, path string) ([]string, error) {
+	req, err := http.NewRequest("GET", url+"/v1/list_directory", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	header := make(http.Header)
+	header.Set(headerPath, path)
+	req.Header = header
+	dataBody, statusCode, err := c.DoRequest(req)
+	if err == nil && statusCode == http.StatusOK {
+		var mapResult map[string][]string
+		err := json.Unmarshal(dataBody, &mapResult)
+		if err != nil {
+			return nil, err
+		}
+
+		result, ok := mapResult[fileList]
+		if !ok {
+			return nil, fmt.Errorf("Response format maybe error: %v", mapResult)
+		}
+
+		return result, nil
+	}
+
+	if err == nil && statusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("GetDirectoryInfo failed, statusCode: %d, err: %v", statusCode, err)
+}
+
+func (c *SpeedyClient) GetDirectDescendantPath(url string, path string) ([]string, error) {
+	req, err := http.NewRequest("GET", url+"/v1/list_descendant", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	header := make(http.Header)
+	header.Set(headerPath, path)
+	req.Header = header
+	dataBody, statusCode, err := c.DoRequest(req)
+	if err == nil && statusCode == http.StatusOK {
+		var mapResult map[string][]string
+		err := json.Unmarshal(dataBody, &mapResult)
+		if err != nil {
+			return nil, err
+		}
+
+		tempResult, ok := mapResult[pathDescendant]
+		if !ok {
+			return nil, fmt.Errorf("Response format maybe error: %v", mapResult)
+		}
+
+		result, err := c.directDescendPath(path, tempResult)
+		if err != nil {
+			return nil, err
+		}
+
+		return result, nil
+	}
+
+	if err != nil && statusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("GetDescendantPath failed, statusCode: %d, err: %v", statusCode, err)
+}
+
+// directDescendPath will find direct descendants of the prefix and will return their full paths.
+// Example: direct descendants of "/" in {"/foo", "/bar/1", "/bar/2"} is
+// {"/foo", "/bar"} and direct descendants of "bar" is {"/bar/1", "/bar/2"}
+func (c *SpeedyClient) directDescendPath(prefix string, descendants []string) ([]string, error) {
+	if descendants == nil || len(descendants) == 0 {
+		return nil, fmt.Errorf("descendants is empty")
+	}
+
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	out := make(map[string]bool)
+	for _, path := range descendants {
+		if strings.HasPrefix(path, prefix) {
+			rel := path[len(prefix):]
+			c := strings.Count(rel, "/")
+			if c == 0 {
+				out[path] = true
+			} else {
+				out[prefix+rel[:strings.Index(rel, "/")]] = true
+			}
+		}
+	}
+
+	var keys []string
+	for k := range out {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+func (c *SpeedyClient) UploadFile(url string, path string, info *MetaInfoValue, data []byte) error {
+	req, err := http.NewRequest("POST", url+"/v1/file", bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+
+	header := make(http.Header)
+	header.Set(headerPath, path)
+	header.Set(headerIndex, fmt.Sprintf("%d", info.Index))
+	header.Set(headerRange, fmt.Sprintf("%d-%d", info.Start, info.End))
+	header.Set(headerIsLast, fmt.Sprintf("%v", info.IsLast))
+	req.Header = header
+	_, statusCode, err := c.DoRequest(req)
+	if statusCode == http.StatusOK {
+		return nil
+	}
+	return fmt.Errorf("UploadFile failed, statusCode: %d, error: %v", statusCode, err)
+}
+
+func (c *SpeedyClient) Ping(url string) error {
+	req, err := http.NewRequest("POST", url+"/v1/_ping", nil)
+	if err != nil {
+		return err
+	}
+
+	_, statusCode, err := c.DoRequest(req)
+	if statusCode == http.StatusOK {
+		return nil
+	}
+	return fmt.Errorf("Ping failed, statusCode: %d, error: %v", statusCode, err)
+}
+
+func (c *SpeedyClient) DeleteFile(url string, path string) error {
+	req, err := http.NewRequest("DELETE", url+"/v1/file", nil)
+	if err != nil {
+		return err
+	}
+
+	header := make(http.Header)
+	header.Set(headerPath, path)
+	req.Header = header
+	_, statusCode, err := c.DoRequest(req)
+	if statusCode == http.StatusNoContent {
+		return nil
+	}
+
+	return fmt.Errorf("DeleteFile failed, statusCode: %d, error: %v", statusCode, err)
+}
+
+func (c *SpeedyClient) MoveFile(url string, sourcePath string, destPath string) error {
+	req, err := http.NewRequest("POST", url+"/v1/move", nil)
+	if err != nil {
+		return err
+	}
+
+	header := make(http.Header)
+	header.Set(headerSourcePath, sourcePath)
+	header.Set(headerDestPath, destPath)
+	req.Header = header
+	_, statusCode, err := c.DoRequest(req)
+	if statusCode == http.StatusOK {
+		return nil
+	}
+
+	return fmt.Errorf("MoveFile failed, statusCode: %d, error: %v", statusCode, err)
+}

--- a/registry/storage/driver/speedy/speedyclient.go
+++ b/registry/storage/driver/speedy/speedyclient.go
@@ -11,11 +11,11 @@ import (
 	"time"
 )
 
-//Client for speedy.
+//SpeedyClient is client for speedy.
 type SpeedyClient struct {
 }
 
-//The metainfo format of speedy. 
+//MetaInfoValue is meta info format of speedy. 
 type MetaInfoValue struct {
 	Index   uint64
 	Start   uint64
@@ -25,7 +25,7 @@ type MetaInfoValue struct {
 	ModTime time.Time
 }
 
-//Used to sort metainfo by index.
+//OrderByIndex is Used to sort metainfo by index
 //E.g. we may get a metainfo array for a special path, so we need to sort this metainfo array.
 type OrderByIndex []*MetaInfoValue
 
@@ -150,7 +150,7 @@ func (c *SpeedyClient) sortMetaInfoValue(origin []*MetaInfoValue) ([]*MetaInfoVa
 	return origin, nil
 }
 
-//Get meta info from speedy by path.
+//GetFileInfo is used to get meta info from speedy by path.
 func (c *SpeedyClient) GetFileInfo(url string, path string) ([]*MetaInfoValue, error) {
 	req, err := http.NewRequest("GET", url+"/v1/fileinfo", nil)
 	if err != nil {
@@ -180,7 +180,7 @@ func (c *SpeedyClient) GetFileInfo(url string, path string) ([]*MetaInfoValue, e
 	return nil, fmt.Errorf("GetFileInfo failed, statusCode: %d, err: %v", statusCode, err)
 }
 
-//Download file from speedy by path and meta info.
+//DownloadFile is used to download file from speedy by path and meta info.
 func (c *SpeedyClient) DownloadFile(url string, path string, info *MetaInfoValue) ([]byte, error) {
 	req, err := http.NewRequest("GET", url+"/v1/file", nil)
 	if err != nil {
@@ -200,7 +200,7 @@ func (c *SpeedyClient) DownloadFile(url string, path string, info *MetaInfoValue
 	return nil, fmt.Errorf("DownloadFile failed, statusCode: %d, err: %v", statusCode, err)
 }
 
-//Get directory info from speedy by path.
+//GetDirectoryInfo is used to get directory info from speedy by path.
 func (c *SpeedyClient) GetDirectoryInfo(url string, path string) ([]string, error) {
 	req, err := http.NewRequest("GET", url+"/v1/list_directory", nil)
 	if err != nil {
@@ -233,7 +233,7 @@ func (c *SpeedyClient) GetDirectoryInfo(url string, path string) ([]string, erro
 	return nil, fmt.Errorf("GetDirectoryInfo failed, statusCode: %d, err: %v", statusCode, err)
 }
 
-//Get direct descendants path from speedy by path. 
+//GetDirectDescendantPath is used to get direct descendants path from speedy by path. 
 func (c *SpeedyClient) GetDirectDescendantPath(url string, path string) ([]string, error) {
 	req, err := http.NewRequest("GET", url+"/v1/list_descendant", nil)
 	if err != nil {
@@ -306,7 +306,7 @@ func (c *SpeedyClient) directDescendPath(prefix string, descendants []string) ([
 	return keys, nil
 }
 
-//Upload file to speedy by path and meta info.
+//UploadFile is used to get file to speedy by path and meta info.
 func (c *SpeedyClient) UploadFile(url string, path string, info *MetaInfoValue, data []byte) error {
 	req, err := http.NewRequest("POST", url+"/v1/file", bytes.NewBuffer(data))
 	if err != nil {
@@ -340,7 +340,7 @@ func (c *SpeedyClient) Ping(url string) error {
 	return fmt.Errorf("Ping failed, statusCode: %d, error: %v", statusCode, err)
 }
 
-//Delete file from speedy by path.
+//DeleteFile is used to delete file from speedy by path.
 func (c *SpeedyClient) DeleteFile(url string, path string) error {
 	req, err := http.NewRequest("DELETE", url+"/v1/file", nil)
 	if err != nil {
@@ -358,7 +358,7 @@ func (c *SpeedyClient) DeleteFile(url string, path string) error {
 	return fmt.Errorf("DeleteFile failed, statusCode: %d, error: %v", statusCode, err)
 }
 
-//Move file in speedy from source path to destination path.
+//MoveFile is used to move file in speedy from source path to destination path.
 func (c *SpeedyClient) MoveFile(url string, sourcePath string, destPath string) error {
 	req, err := http.NewRequest("POST", url+"/v1/move", nil)
 	if err != nil {

--- a/registry/storage/driver/speedy/speedyclient.go
+++ b/registry/storage/driver/speedy/speedyclient.go
@@ -11,8 +11,8 @@ import (
 	"time"
 )
 
-//SpeedyClient is client for speedy.
-type SpeedyClient struct {
+//Client is the client for speedy.
+type Client struct {
 }
 
 //MetaInfoValue is meta info format of speedy. 
@@ -54,7 +54,7 @@ func (a OrderByIndex) Less(i, j int) bool {
 	return a[i].Index < a[j].Index
 }
 
-func (c *SpeedyClient) doRequest(req *http.Request) ([]byte, int, error) {
+func (c *Client) doRequest(req *http.Request) ([]byte, int, error) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -72,7 +72,7 @@ func (c *SpeedyClient) doRequest(req *http.Request) ([]byte, int, error) {
 	return dataBody, resp.StatusCode, nil
 }
 
-func (c *SpeedyClient) getMetaInfoValueFromJSON(data []byte) ([]*MetaInfoValue, error) {
+func (c *Client) getMetaInfoValueFromJSON(data []byte) ([]*MetaInfoValue, error) {
 	var mapResult map[string]interface{}
 	err := json.Unmarshal(data, &mapResult)
 	if err != nil {
@@ -145,13 +145,13 @@ func (c *SpeedyClient) getMetaInfoValueFromJSON(data []byte) ([]*MetaInfoValue, 
 	return result, nil
 }
 
-func (c *SpeedyClient) sortMetaInfoValue(origin []*MetaInfoValue) ([]*MetaInfoValue, error) {
+func (c *Client) sortMetaInfoValue(origin []*MetaInfoValue) ([]*MetaInfoValue, error) {
 	sort.Sort(OrderByIndex(origin))
 	return origin, nil
 }
 
 //GetFileInfo is used to get meta info from speedy by path.
-func (c *SpeedyClient) GetFileInfo(url string, path string) ([]*MetaInfoValue, error) {
+func (c *Client) GetFileInfo(url string, path string) ([]*MetaInfoValue, error) {
 	req, err := http.NewRequest("GET", url+"/v1/fileinfo", nil)
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ func (c *SpeedyClient) GetFileInfo(url string, path string) ([]*MetaInfoValue, e
 }
 
 //DownloadFile is used to download file from speedy by path and meta info.
-func (c *SpeedyClient) DownloadFile(url string, path string, info *MetaInfoValue) ([]byte, error) {
+func (c *Client) DownloadFile(url string, path string, info *MetaInfoValue) ([]byte, error) {
 	req, err := http.NewRequest("GET", url+"/v1/file", nil)
 	if err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func (c *SpeedyClient) DownloadFile(url string, path string, info *MetaInfoValue
 }
 
 //GetDirectoryInfo is used to get directory info from speedy by path.
-func (c *SpeedyClient) GetDirectoryInfo(url string, path string) ([]string, error) {
+func (c *Client) GetDirectoryInfo(url string, path string) ([]string, error) {
 	req, err := http.NewRequest("GET", url+"/v1/list_directory", nil)
 	if err != nil {
 		return nil, err
@@ -234,7 +234,7 @@ func (c *SpeedyClient) GetDirectoryInfo(url string, path string) ([]string, erro
 }
 
 //GetDirectDescendantPath is used to get direct descendants path from speedy by path. 
-func (c *SpeedyClient) GetDirectDescendantPath(url string, path string) ([]string, error) {
+func (c *Client) GetDirectDescendantPath(url string, path string) ([]string, error) {
 	req, err := http.NewRequest("GET", url+"/v1/list_descendant", nil)
 	if err != nil {
 		return nil, err
@@ -274,7 +274,7 @@ func (c *SpeedyClient) GetDirectDescendantPath(url string, path string) ([]strin
 // directDescendPath will find direct descendants of the prefix and will return their full paths.
 // Example: direct descendants of "/" in {"/foo", "/bar/1", "/bar/2"} is
 // {"/foo", "/bar"} and direct descendants of "bar" is {"/bar/1", "/bar/2"}
-func (c *SpeedyClient) directDescendPath(prefix string, descendants []string) ([]string, error) {
+func (c *Client) directDescendPath(prefix string, descendants []string) ([]string, error) {
 	if descendants == nil || len(descendants) == 0 {
 		return nil, fmt.Errorf("descendants is empty")
 	}
@@ -307,7 +307,7 @@ func (c *SpeedyClient) directDescendPath(prefix string, descendants []string) ([
 }
 
 //UploadFile is used to get file to speedy by path and meta info.
-func (c *SpeedyClient) UploadFile(url string, path string, info *MetaInfoValue, data []byte) error {
+func (c *Client) UploadFile(url string, path string, info *MetaInfoValue, data []byte) error {
 	req, err := http.NewRequest("POST", url+"/v1/file", bytes.NewBuffer(data))
 	if err != nil {
 		return err
@@ -327,7 +327,7 @@ func (c *SpeedyClient) UploadFile(url string, path string, info *MetaInfoValue, 
 }
 
 //Ping with speedy used to check the health of speedy.
-func (c *SpeedyClient) Ping(url string) error {
+func (c *Client) Ping(url string) error {
 	req, err := http.NewRequest("POST", url+"/v1/_ping", nil)
 	if err != nil {
 		return err
@@ -341,7 +341,7 @@ func (c *SpeedyClient) Ping(url string) error {
 }
 
 //DeleteFile is used to delete file from speedy by path.
-func (c *SpeedyClient) DeleteFile(url string, path string) error {
+func (c *Client) DeleteFile(url string, path string) error {
 	req, err := http.NewRequest("DELETE", url+"/v1/file", nil)
 	if err != nil {
 		return err
@@ -359,7 +359,7 @@ func (c *SpeedyClient) DeleteFile(url string, path string) error {
 }
 
 //MoveFile is used to move file in speedy from source path to destination path.
-func (c *SpeedyClient) MoveFile(url string, sourcePath string, destPath string) error {
+func (c *Client) MoveFile(url string, sourcePath string, destPath string) error {
 	req, err := http.NewRequest("POST", url+"/v1/move", nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add a storage-driver for speedy.
Speedy(https://github.com/jcloudpub/speedy) is a high performance distributed docker image storage solution written by go/c.  
After testing, this driver works well with docker-1.6, distribution and speedy.
