### PR TITLE
Include configuration explanation for intermediate TLS certificates

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -89,6 +89,8 @@ docker run -d -p 5000:5000 \
 	registry:2
 ```
 
+If the certificate issuer supplies you with an 'intermediate' certificate, such as Gandi, you need to combine your certificate with the intermediates to form a 'certificate bundle'. You can do this using the cat command: ```cat server.crt GandiStandardSSLCA2.pem > server.with-intermediate.crt```. You can then configure the registry to use your certificate bundle with the ```REGISTRY_HTTP_TLS_CERTIFICATE``` environment variable.
+
 **Pros:**
 
  - best solution

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -89,7 +89,7 @@ docker run -d -p 5000:5000 \
 	registry:2
 ```
 
-If the certificate issuer supplies you with an 'intermediate' certificate, such as Gandi, you need to combine your certificate with the intermediates to form a 'certificate bundle'. You can do this using the cat command: ```cat server.crt GandiStandardSSLCA2.pem > server.with-intermediate.crt```. You can then configure the registry to use your certificate bundle with the ```REGISTRY_HTTP_TLS_CERTIFICATE``` environment variable.
+If the certificate issuer supplies you with an 'intermediate' certificate, you need to combine your certificate with the intermediates to form a 'certificate bundle'. You can do this using the cat command: ```cat server.crt intermediate-certificates.pem > server.with-intermediate.crt```. You can then configure the registry to use your certificate bundle with the ```REGISTRY_HTTP_TLS_CERTIFICATE``` environment variable.
 
 **Pros:**
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -89,7 +89,13 @@ docker run -d -p 5000:5000 \
 	registry:2
 ```
 
-If the certificate issuer supplies you with an 'intermediate' certificate, you need to combine your certificate with the intermediates to form a 'certificate bundle'. You can do this using the cat command: ```cat server.crt intermediate-certificates.pem > server.with-intermediate.crt```. You can then configure the registry to use your certificate bundle with the ```REGISTRY_HTTP_TLS_CERTIFICATE``` environment variable.
+A certificate issuer may supply you with an *intermediate* certificate. In this case, you must combine your certificate with the intermediate's to form a *certificate bundle*. You can do this using the `cat` command: 
+
+```
+$ cat server.crt intermediate-certificates.pem > server.with-intermediate.crt
+```
+
+You then configure the registry to use your certificate bundle by providing the `REGISTRY_HTTP_TLS_CERTIFICATE` environment variable.
 
 **Pros:**
 


### PR DESCRIPTION
Intermediate certificates are issued by TLS providers who themselves are
an intermediate of a certificate in the trust store. Therefore, to prove
the chain of trust is valid, you need to include their certificate as
well as yours when you send your certificate to the client.

Contrary to what I said in issue #683, distribution can handle these
certificate bundles like nginx. As discussed in #docker-distribution,
I have updated the deployment documentation (which recommends the use of
a TLS certificate from a provider) to include instructions on how to
handle the intermediate certificate when a user is configuring
distribution.

Closes #683.