### PR TITLE
Change mode of unix socket file to 777

### DIFF
--- a/registry/listener/listener.go
+++ b/registry/listener/listener.go
@@ -57,7 +57,17 @@ func newUnixListener(laddr string) (net.Listener, error) {
 		return nil, err
 	}
 
-	return net.Listen("unix", laddr)
+	ln, err := net.Listen("unix", laddr)
+	if err != nil {
+		return nil, err
+	}
+
+	// make sock file writable for other user
+	if err := os.Chmod(laddr, 0777); err != nil {
+		return nil, err
+	}
+
+	return ln, nil
 }
 
 func isSocket(m os.FileMode) bool {


### PR DESCRIPTION
Make sock file writable for other user

eg. I have distribution run by user `registry` and nginx run by user `nginx`. nginx will report 'Permission denied' if sock is not writable.

Signed-off-by: Huayi Zhang <irachex@gmail.com>