### PR TITLE
Fix link to token specification

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -701,7 +701,7 @@ public part of the certificates that is used to sign authentication tokens.
   </tr>
 </table>
 
-For more information about Token based authentication configuration, see the [specification.]
+For more information about Token based authentication configuration, see the [specification](spec/auth/token.md).
 
 ### htpasswd
 


### PR DESCRIPTION
Link was broken in [commit `cf9b4ab5e`](https://github.com/docker/distribution/commit/cf9b4ab5e9458eb4e542b8db487344a59657f4fe#diff-76e731333fb756df3bff5ddb3b731c46L245)