### PR TITLE
Export ServeJSON for serving error codes

### DIFF
--- a/registry/api/errcode/errors.go
+++ b/registry/api/errcode/errors.go
@@ -16,6 +16,8 @@ type ErrorCoder interface {
 // and the integer format may change and should *never* be exported.
 type ErrorCode int
 
+var _ error = ErrorCode(0)
+
 // ErrorCode just returns itself
 func (ec ErrorCode) ErrorCode() ErrorCode {
 	return ec
@@ -93,6 +95,8 @@ type Error struct {
 	// variable substitution right before showing the message to the user
 }
 
+var _ error = Error{}
+
 // ErrorCode returns the ID/Value of this Error
 func (e Error) ErrorCode() ErrorCode {
 	return e.Code
@@ -162,6 +166,8 @@ func ParseErrorCode(value string) ErrorCode {
 // Errors provides the envelope for multiple errors and a few sugar methods
 // for use within the application.
 type Errors []error
+
+var _ error = Errors{}
 
 func (errs Errors) Error() string {
 	switch len(errs) {

--- a/registry/api/errcode/handler.go
+++ b/registry/api/errcode/handler.go
@@ -1,0 +1,44 @@
+package errcode
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ServeJSON attempts to serve the errcode in a JSON envelope. It marshals err
+// and sets the content-type header to 'application/json'. It will handle
+// ErrorCoder and Errors, and if necessary will create an envelope.
+func ServeJSON(w http.ResponseWriter, err error) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	var sc int
+
+	switch errs := err.(type) {
+	case Errors:
+		if len(errs) < 1 {
+			break
+		}
+
+		if err, ok := errs[0].(ErrorCoder); ok {
+			sc = err.ErrorCode().Descriptor().HTTPStatusCode
+		}
+	case ErrorCoder:
+		sc = errs.ErrorCode().Descriptor().HTTPStatusCode
+		err = Errors{err} // create an envelope.
+	default:
+		// We just have an unhandled error type, so just place in an envelope
+		// and move along.
+		err = Errors{err}
+	}
+
+	if sc == 0 {
+		sc = http.StatusInternalServerError
+	}
+
+	w.WriteHeader(sc)
+
+	if err := json.NewEncoder(w).Encode(err); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -1,42 +1,9 @@
 package handlers
 
 import (
-	"encoding/json"
 	"io"
 	"net/http"
-
-	"github.com/docker/distribution/registry/api/errcode"
 )
-
-// serveJSON marshals v and sets the content-type header to
-// 'application/json'. If a different status code is required, call
-// ResponseWriter.WriteHeader before this function.
-func serveJSON(w http.ResponseWriter, v interface{}) error {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	sc := http.StatusInternalServerError
-
-	if errs, ok := v.(errcode.Errors); ok && len(errs) > 0 {
-		if err, ok := errs[0].(errcode.ErrorCoder); ok {
-			if sc2 := err.ErrorCode().Descriptor().HTTPStatusCode; sc2 != 0 {
-				sc = sc2
-			}
-		}
-	} else if err, ok := v.(errcode.ErrorCoder); ok {
-		if sc2 := err.ErrorCode().Descriptor().HTTPStatusCode; sc2 != 0 {
-			sc = sc2
-		}
-	}
-
-	w.WriteHeader(sc)
-
-	enc := json.NewEncoder(w)
-
-	if err := enc.Encode(v); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 // closeResources closes all the provided resources after running the target
 // handler.


### PR DESCRIPTION
This changeset provides a common http handler for serving errcodes. This should
unify http responses across webservices in the face of errors.

Several type assertions have been added, as well, to ensure the error interface
is implemented.

This supports some work in notary.

CC @duglin @endophage @NathanMcCauley @diogomonica 

Signed-off-by: Stephen J Day <stephen.day@docker.com>