### PR TITLE
Reduces log level of auth error lines from error->warn

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -359,7 +359,7 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 		context := app.context(w, r)
 
 		if err := app.authorized(w, r, context); err != nil {
-			ctxu.GetLogger(context).Errorf("error authorizing context: %v", err)
+			ctxu.GetLogger(context).Warnf("error authorizing context: %v", err)
 			return
 		}
 


### PR DESCRIPTION
An error level log is already produced within app.authorized() if an
actual unexpected error occurs during authorization, so this warning
level log remains for auditability purposes, but should not be
considered an error condition.

Addresses #704