### PR TITLE
Close reader after the test is finished.

### DIFF
--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -258,6 +258,7 @@ func (suite *DriverSuite) TestWriteReadLargeStreams(c *check.C) {
 
 	reader, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 	c.Assert(err, check.IsNil)
+	defer reader.Close()
 
 	writtenChecksum := sha1.New()
 	io.Copy(writtenChecksum, reader)


### PR DESCRIPTION
Signed-off-by: yuzou <zouyu7@huawei.com>

After TestWriteReadLargeStreams is finished, close the reader created by ReadStream to free the underlying resources used by drivers.