### PR TITLE
Fix broken link to deploying.md

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -34,7 +34,7 @@ Below is a simple example of secured basic authentication (using TLS), using ngi
 
 ### Requirements
 
-You should have followed entirely the basic [deployment guide](deployement.md).
+You should have followed entirely the basic [deployment guide](deploying.md).
 
 If you have not, please take the time to do so.
 


### PR DESCRIPTION
The link was pointing to deployement.md, while the file is deploying.md

Note: 
Currently the problem is not visible on https://docs.docker.com/registry/authentication/
The issue is visible on https://github.com/docker/distribution/blob/master/docs/authentication.md