### PR TITLE
Change confusing enpoint name

### DIFF
--- a/cmd/registry/config.yml
+++ b/cmd/registry/config.yml
@@ -42,7 +42,7 @@ redis:
   writetimeout: 10ms
 notifications:
     endpoints:
-        - name: local-8082
+        - name: local-5003
           url: http://localhost:5003/callback
           headers:
              Authorization: [Bearer <an example token>]

--- a/docs/building.md
+++ b/docs/building.md
@@ -46,7 +46,7 @@ incantantation:
 
 ```
 $ $GOPATH/bin/registry $GOPATH/src/github.com/docker/distribution/cmd/registry/config.yml
-INFO[0000] endpoint local-8082 disabled, skipping        app.id=34bbec38-a91a-494a-9a3f-b72f9010081f version=v2.0.0-alpha.1+unknown
+INFO[0000] endpoint local-5003 disabled, skipping        app.id=34bbec38-a91a-494a-9a3f-b72f9010081f version=v2.0.0-alpha.1+unknown
 INFO[0000] endpoint local-8083 disabled, skipping        app.id=34bbec38-a91a-494a-9a3f-b72f9010081f version=v2.0.0-alpha.1+unknown
 INFO[0000] listening on :5000                            app.id=34bbec38-a91a-494a-9a3f-b72f9010081f version=v2.0.0-alpha.1+unknown
 INFO[0000] debug server listening localhost:5001

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -243,7 +243,7 @@ several failures and have since recovered:
 "notifications":{
    "endpoints":[
       {
-         "name":"local-8082",
+         "name":"local-5003",
          "url":"http://localhost:5003/callback",
          "Headers":{
             "Authorization":[


### PR DESCRIPTION
Since the actual port is 5003, it would make sense to name it local-5003 instead of local-8082