### PR TITLE
Make Error.Error() return the post-arg-substitution Message

### DIFF
--- a/registry/api/errcode/errors.go
+++ b/registry/api/errcode/errors.go
@@ -106,7 +106,7 @@ func (e Error) ErrorCode() ErrorCode {
 func (e Error) Error() string {
 	return fmt.Sprintf("%s: %s",
 		strings.ToLower(strings.Replace(e.Code.String(), "_", " ", -1)),
-		e.Code.Message())
+		e.Message)
 }
 
 // WithDetail will return a new Error, based on the current one, but with

--- a/registry/api/errcode/errors_test.go
+++ b/registry/api/errcode/errors_test.go
@@ -126,6 +126,11 @@ func TestErrorsManagement(t *testing.T) {
 		t.Fatalf("Wrong msg, got:\n%q\n\nexpected:\n%q", e1.Message, exp1)
 	}
 
+	exp1 = "test3: " + exp1
+	if e1.Error() != exp1 {
+		t.Fatalf("Error() didn't return the right string, got:%s\nexpected:%s", e1.Error(), exp1)
+	}
+
 	// Test again with a single value this time
 	errs = Errors{ErrorCodeUnknown}
 	expectedJSON = "{\"errors\":[{\"code\":\"UNKNOWN\",\"message\":\"unknown error\"}]}"


### PR DESCRIPTION
Missed this during the removal of the args property

ping @stevvooe 

Signed-off-by: Doug Davis <dug@us.ibm.com>