### PR TITLE
Do not replace logger when adding hooks

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -298,7 +298,14 @@ func (app *App) configureRedis(configuration *configuration.Configuration) {
 
 // configureLogHook prepares logging hook parameters.
 func (app *App) configureLogHook(configuration *configuration.Configuration) {
-	logger := ctxu.GetLogger(app).(*log.Entry).Logger
+	entry, ok := ctxu.GetLogger(app).(*log.Entry)
+	if !ok {
+		// somehow, we are not using logrus
+		return
+	}
+
+	logger := entry.Logger
+
 	for _, configHook := range configuration.Log.Hooks {
 		if !configHook.Disabled {
 			switch configHook.Type {
@@ -318,7 +325,6 @@ func (app *App) configureLogHook(configuration *configuration.Configuration) {
 			}
 		}
 	}
-	app.Context = ctxu.WithLogger(app.Context, logger)
 }
 
 func (app *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Because the logger was incorrectly replaced while adding hooks, log output did
not include the version and instance ids. The main issue was the the
logrus.Entry was replaced with the logger, which included no context. Replacing
the logger on the context is not necessary when configuring hooks since we are
configuring the contexts logger directly.

The main problem was demonstrated by log output like this:

```
INFO[0000] listening on [::]:5000
```

When it should include the context information:

```
INFO[0000] listening on [::]:5000                        environment=development instance.id=a519e71f-4874-4738-b302-f4d0d1956733 service=registry version=v2.0.0-434-g984037f.m
```

Signed-off-by: Stephen J Day <stephen.day@docker.com>