### PR TITLE
Allow disabling of storage driver redirects

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -242,6 +242,8 @@ func (storage Storage) Type() string {
 			// allow configuration of caching
 		case "delete":
 			// allow configuration of delete
+		case "redirect":
+			// allow configuration of redirect
 		default:
 			return k
 		}
@@ -275,7 +277,8 @@ func (storage *Storage) UnmarshalYAML(unmarshal func(interface{}) error) error {
 					// allow configuration of caching
 				case "delete":
 					// allow configuration of delete
-
+				case "redirect":
+					// allow configuration of redirect
 				default:
 					types = append(types, k)
 				}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,8 @@ information about each option that appears later in this page.
         region: fr
         container: containername
         rootdirectory: /swift/object/name/prefix
+      redirect:
+        disable: false
       cache:
         blobdescriptor: redis
       maintenance:
@@ -328,6 +330,8 @@ Permitted values are `error`, `warn`, `info` and `debug`. The default is
           age: 168h
           interval: 24h
           dryrun: false
+      redirect:
+        disable: false
 
 The storage option is **required** and defines which storage backend is in use.
 You must configure one backend; if you configure more, the registry returns an error.
@@ -349,6 +353,21 @@ map.
 >**NOTE**: Formerly, `blobdescriptor` was known as `layerinfo`. While these
 >are equivalent, `layerinfo` has been deprecated, in favor or
 >`blobdescriptor`.
+
+### redirect
+
+The `redirect` subsection provides configuration for managing redirects from
+content backends. For backends that support it, redirecting is enabled by
+default. Certain deployment scenarios may prefer to route all data through the
+Registry, rather than redirecting to the backend. This may be more efficient
+when using a backend that is not colocated or when a registry instance is
+doing aggressive caching.
+
+Redirects can be disabled by adding a single flag `disable`, set to `true`
+under the `redirect` section:
+
+  redirect:
+    disable: true
 
 ### filesystem
 

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestListener(t *testing.T) {
 	ctx := context.Background()
-	registry := storage.NewRegistryWithDriver(ctx, inmemory.New(), memory.NewInMemoryBlobDescriptorCacheProvider(), true)
+	registry := storage.NewRegistryWithDriver(ctx, inmemory.New(), memory.NewInMemoryBlobDescriptorCacheProvider(), true, true)
 	tl := &testListener{
 		ops: make(map[string]int),
 	}

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -31,7 +31,7 @@ func TestAppDispatcher(t *testing.T) {
 		Context:  ctx,
 		router:   v2.Router(),
 		driver:   driver,
-		registry: storage.NewRegistryWithDriver(ctx, driver, memorycache.NewInMemoryBlobDescriptorCacheProvider(), true),
+		registry: storage.NewRegistryWithDriver(ctx, driver, memorycache.NewInMemoryBlobDescriptorCacheProvider(), true, true),
 	}
 	server := httptest.NewServer(app)
 	router := v2.Router()

--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -33,7 +33,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 	ctx := context.Background()
 	imageName := "foo/bar"
 	driver := inmemory.New()
-	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), true)
+	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), true, true)
 	repository, err := registry.Repository(ctx, imageName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -193,7 +193,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 	}
 
 	// Reuse state to test delete with a delete-disabled registry
-	registry = NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), false)
+	registry = NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), false, true)
 	repository, err = registry.Repository(ctx, imageName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -212,7 +212,7 @@ func TestSimpleBlobRead(t *testing.T) {
 	ctx := context.Background()
 	imageName := "foo/bar"
 	driver := inmemory.New()
-	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), true)
+	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), true, true)
 	repository, err := registry.Repository(ctx, imageName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -316,7 +316,7 @@ func TestLayerUploadZeroLength(t *testing.T) {
 	ctx := context.Background()
 	imageName := "foo/bar"
 	driver := inmemory.New()
-	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), true)
+	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), true, true)
 	repository, err := registry.Repository(ctx, imageName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)

--- a/registry/storage/catalog_test.go
+++ b/registry/storage/catalog_test.go
@@ -22,7 +22,7 @@ func setupFS(t *testing.T) *setupEnv {
 	d := inmemory.New()
 	c := []byte("")
 	ctx := context.Background()
-	registry := NewRegistryWithDriver(ctx, d, memory.NewInMemoryBlobDescriptorCacheProvider(), false)
+	registry := NewRegistryWithDriver(ctx, d, memory.NewInMemoryBlobDescriptorCacheProvider(), false, true)
 	rootpath, _ := defaultPathMapper.path(repositoriesRootPathSpec{})
 
 	repos := []string{

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -29,7 +29,8 @@ type manifestStoreTestEnv struct {
 func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestEnv {
 	ctx := context.Background()
 	driver := inmemory.New()
-	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), true)
+	registry := NewRegistryWithDriver(ctx, driver, memory.NewInMemoryBlobDescriptorCacheProvider(), true, true)
+
 	repo, err := registry.Repository(ctx, name)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -347,7 +348,7 @@ func TestManifestStorage(t *testing.T) {
 		t.Errorf("Deleted manifest get returned non-nil")
 	}
 
-	r := NewRegistryWithDriver(ctx, env.driver, memory.NewInMemoryBlobDescriptorCacheProvider(), false)
+	r := NewRegistryWithDriver(ctx, env.driver, memory.NewInMemoryBlobDescriptorCacheProvider(), false, true)
 	repo, err := r.Repository(ctx, env.name)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)


### PR DESCRIPTION
Storage drivers can implement a method called URLFor which can return a direct url for a given path. The functionality allows the registry to direct clients to download content directly from the backend storage. This is commonly used with s3 and cloudfront. Under certain conditions, such as when the registry is not local to the backend, these redirects can hurt performance and waste incoming bandwidth on pulls. This feature addition allows one to disable this feature, if required.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #432. #739 must be merged before this PR.