### PR TITLE
Revert "Fix typo"

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1264,7 +1264,7 @@ The error codes that may be included in the response body are enumerated below:
 ##### Tags Paginated
 
 ```
-GET /v2/<name>/tags/list?n=<integer>&last=<integer>
+GET /v2/<name>/tags/list?n=<integer>last=<integer>
 ```
 
 Return a portion of the tags for the specified repository.


### PR DESCRIPTION
Reverts docker/distribution#737

This incorrectly fixed the type.