### PR TITLE
fix json parse error on Godeps

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -81,7 +81,8 @@
 		{
 			"ImportPath": "github.com/stevvooe/resumable",
 			"Rev": "51ad44105773cafcbe91927f70ac68e1bf78f8b4"
-                },
+		},
+		{
 			"ImportPath": "github.com/mitchellh/mapstructure",
 			"Rev": "482a9fd5fa83e8c4e7817413b80f3eb8feec03ef"
 		},


### PR DESCRIPTION
Deleted brace was causing an error on master.  Fixed tabs/spaces at the same time.

Test:
```
jq . Godeps/Godeps.json
parse error: ':' not as part of an object at line 85, column 16
```