### PR TITLE
Make the registry client more tolerant about HTTP status codes

### DIFF
--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/transport"
 )
 
@@ -209,7 +210,7 @@ func (th *tokenHandler) fetchToken(params map[string]string) (token string, err 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if !client.SuccessStatus(resp.StatusCode) {
 		return "", fmt.Errorf("token auth attempt for registry: %s request failed with status: %d %s", req.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 

--- a/registry/client/blob_writer.go
+++ b/registry/client/blob_writer.go
@@ -44,7 +44,7 @@ func (hbu *httpBlobUpload) ReadFrom(r io.Reader) (n int64, err error) {
 		return 0, err
 	}
 
-	if resp.StatusCode != http.StatusAccepted {
+	if !SuccessStatus(resp.StatusCode) {
 		return 0, hbu.handleErrorResponse(resp)
 	}
 
@@ -79,7 +79,7 @@ func (hbu *httpBlobUpload) Write(p []byte) (n int, err error) {
 		return 0, err
 	}
 
-	if resp.StatusCode != http.StatusAccepted {
+	if !SuccessStatus(resp.StatusCode) {
 		return 0, hbu.handleErrorResponse(resp)
 	}
 
@@ -142,7 +142,7 @@ func (hbu *httpBlobUpload) Commit(ctx context.Context, desc distribution.Descrip
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusCreated {
+	if !SuccessStatus(resp.StatusCode) {
 		return distribution.Descriptor{}, hbu.handleErrorResponse(resp)
 	}
 
@@ -160,12 +160,10 @@ func (hbu *httpBlobUpload) Cancel(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 
-	switch resp.StatusCode {
-	case http.StatusNoContent, http.StatusNotFound:
+	if resp.StatusCode == http.StatusNotFound || SuccessStatus(resp.StatusCode) {
 		return nil
-	default:
-		return hbu.handleErrorResponse(resp)
 	}
+	return hbu.handleErrorResponse(resp)
 }
 
 func (hbu *httpBlobUpload) Close() error {

--- a/registry/client/errors.go
+++ b/registry/client/errors.go
@@ -61,3 +61,9 @@ func handleErrorResponse(resp *http.Response) error {
 	}
 	return &UnexpectedHTTPStatusError{Status: resp.Status}
 }
+
+// SuccessStatus returns true if the argument is a successful HTTP response
+// code (in the range 200 - 399 inclusive).
+func SuccessStatus(status int) bool {
+	return status >= 200 && status <= 399
+}

--- a/registry/client/transport/http_reader.go
+++ b/registry/client/transport/http_reader.go
@@ -154,10 +154,11 @@ func (hrs *httpReadSeeker) reader() (io.Reader, error) {
 		return nil, err
 	}
 
-	switch {
-	case resp.StatusCode == 200:
+	// Normally would use client.SuccessStatus, but that would be a cyclic
+	// import
+	if resp.StatusCode >= 200 && resp.StatusCode <= 399 {
 		hrs.rc = resp.Body
-	default:
+	} else {
 		defer resp.Body.Close()
 		return nil, fmt.Errorf("unexpected status resolving reader: %v", resp.Status)
 	}


### PR DESCRIPTION
Generally, all 2xx and 3xx codes should be treated as success.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>