### PR TITLE
Correctly generate URL examples specifications

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1241,7 +1241,7 @@ The error codes that may be included in the response body are enumerated below:
 ##### Tags Paginated
 
 ```
-GET /v2/<name>/tags/list?n=<integer>last=<integer>
+GET /v2/<name>/tags/list?n=<integer>&last=<integer>
 ```
 
 Return a portion of the tags for the specified repository.
@@ -3249,7 +3249,7 @@ The following headers will be returned with the response:
 ##### Catalog Fetch Paginated
 
 ```
-GET /v2/_catalog?n=<integer>last=<integer>
+GET /v2/_catalog?n=<integer>&last=<integer>
 ```
 
 Return the specified portion of repositories.

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -1017,7 +1017,7 @@ The error codes encountered via the API are enumerated in the following table:
 ##### {{.Name}}{{end}}
 
 ```
-{{$method.Method}} {{$route.Path|prettygorilla}}{{if .QueryParameters}}?{{range .QueryParameters}}{{.Name}}={{.Format}}{{end}}{{end}}{{range .Headers}}
+{{$method.Method}} {{$route.Path|prettygorilla}}{{range $i, $param := .QueryParameters}}{{if eq $i 0}}?{{else}}&{{end}}{{$param.Name}}={{$param.Format}}{{end}}{{range .Headers}}
 {{.Name}}: {{.Format}}{{end}}{{if .Body.ContentType}}
 Content-Type: {{.Body.ContentType}}{{end}}{{if .Body.Format}}
 


### PR DESCRIPTION
This is the correct fix for #737.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @tsing 