### PR TITLE
Reduce consumption of entropy source

### DIFF
--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -49,6 +49,7 @@ func Generate() (u UUID) {
 
 	var (
 		totalBackoff time.Duration
+		count        int
 		retries      int
 	)
 
@@ -60,9 +61,10 @@ func Generate() (u UUID) {
 		time.Sleep(b)
 		totalBackoff += b
 
-		_, err := io.ReadFull(rand.Reader, u[:])
+		n, err := io.ReadFull(rand.Reader, u[count:])
 		if err != nil {
 			if retryOnError(err) && retries < maxretries {
+				count += n
 				retries++
 				Loggerf("error generating version 4 uuid, retrying: %v", err)
 				continue


### PR DESCRIPTION
The whole CI infrastructure on docker/docker is suffering from entropy exhaustion. As pointed out by @ewindisch, the UUID generation code here is wasting some entropy bytes. That may not be a sufficient fix, but still seems like an improvement.

The UUID generation retries multiple times to read a full UUID, but preserves any bytes of entropy he successfully managed to read between retries.

Ping @jfrazelle @crosbymichael @calavera.