### PR TITLE
Fix for api_test.go

### DIFF
--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -963,7 +963,7 @@ func testManifestDelete(t *testing.T, env *testEnv, args manifestArgs) {
 	// --------------------
 	// Re-upload manifest by digest
 	resp = putManifest(t, "putting signed manifest", manifestDigestURL, signedManifest)
-	checkResponse(t, "putting signed manifest", resp, http.StatusAccepted)
+	checkResponse(t, "putting signed manifest", resp, http.StatusCreated)
 	checkHeaders(t, resp, http.Header{
 		"Location":              []string{manifestDigestURL},
 		"Docker-Content-Digest": []string{dgst.String()},
@@ -1372,7 +1372,7 @@ func createRepository(env *testEnv, t *testing.T, imageName string, tag string) 
 	checkErr(t, err, "building manifest url")
 
 	resp := putManifest(t, "putting signed manifest", manifestDigestURL, signedManifest)
-	checkResponse(t, "putting signed manifest", resp, http.StatusAccepted)
+	checkResponse(t, "putting signed manifest", resp, http.StatusCreated)
 	checkHeaders(t, resp, http.Header{
 		"Location":              []string{manifestDigestURL},
 		"Docker-Content-Digest": []string{dgst.String()},


### PR DESCRIPTION
This passed in the #744 before merge, but apparently the test changed
since the PR was created in ways that led to a new failures.

@dmcgowan 