### PR TITLE
Automatically generate a HTTP secret if none is provided

### DIFF
--- a/cmd/registry/config.yml
+++ b/cmd/registry/config.yml
@@ -30,7 +30,6 @@ storage:
             enabled: false
 http:
     addr: :5000
-    secret: asecretforlocaldevelopment
     debug:
         addr: localhost:5001
 redis:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1184,7 +1184,12 @@ should have both preceding and trailing slashes, for example <code>/path/</code>
     <td>
 A random piece of data. This is used to sign state that may be stored with the
 client to protect against tampering. For production environments you should generate a
-random piece of data using a cryptographically secure random generator.
+random piece of data using a cryptographically secure random generator. This
+configuration parameter may be omitted, in which case the registry will automatically
+generate a secret at launch.
+<p />
+<b>WARNING: If you are building a cluster of registries behind a load balancer, you MUST
+ensure the secret is the same for all registries.</b>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
Log a warning if the registry generates its own secret.

Update configuration doc, and remove the default secret from the
development config file.

@stevvooe PTAL