### PR TITLE
Run integration tests with multiple Docker engine versions

### DIFF
--- a/contrib/docker-integration/run_multiversion.sh
+++ b/contrib/docker-integration/run_multiversion.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Run the integration tests with multiple versions of the Docker engine
+
+set -e
+
+# Don't use /tmp because this isn't available in boot2docker
+tmpdir_template="`pwd`/docker-versions.XXXXX"
+tmpdir=`mktemp -d "$tmpdir_template"`
+trap "rm -rf $tmpdir" EXIT
+
+# If DOCKER_VOLUME is unset, create a temporary directory to cache containers
+# between runs
+# Only do this on Linux, because using /var/lib/docker from a host volume seems
+# problematic with boot2docker.
+if [ "$DOCKER_VOLUME" = "" -a `uname` = "Linux" ]; then
+	volumes_template="`pwd`/docker-versions.XXXXX"
+	volume=`mktemp -d "$volumes_template"`
+	trap "rm -rf $tmpdir $volume" EXIT
+else
+	volume="$DOCKER_VOLUME"
+fi
+
+# Released versions
+
+versions="1.6.0 1.7.0"
+
+for v in $versions; do
+	echo "Downloading Docker $v"
+	binpath="$tmpdir/docker-$v"
+	curl -L -o "$binpath" "https://test.docker.com/builds/Linux/x86_64/docker-$v"
+	chmod +x "$binpath"
+	echo "Running tests with Docker $v"
+	DOCKER_BINARY="$binpath" DOCKER_VOLUME="$volume" ./run.sh
+done
+
+# Latest experimental version
+
+# Extract URI from https://experimental.docker.com/builds/
+experimental=`curl -sSL https://experimental.docker.com/builds/ | tr " " "\n" | grep 'https://experimental.docker.com/builds/Linux/'`
+echo "Downloading Docker experimental"
+binpath="$tmpdir/docker-experimental"
+curl -L -o "$binpath" "$experimental"
+chmod +x "$binpath"
+echo "Running tests with Docker experimental"
+DOCKER_BINARY="$binpath" DOCKER_VOLUME="$volume" ./run.sh

--- a/contrib/docker-integration/tls.bats
+++ b/contrib/docker-integration/tls.bats
@@ -16,9 +16,9 @@ function setup() {
 # skip basic auth tests with Docker 1.6, where they don't pass due to
 # certificate issues
 function basic_auth_version_check() {
-	run sh -c 'docker version | fgrep -q "Client version: 1.6.0"'
+	run sh -c 'docker version | fgrep -q "Client version: 1.6."'
 	if [ "$status" -eq 0 ]; then
-		skip "Basic auth tests don't support 1.6.0"
+		skip "Basic auth tests don't support 1.6.x"
 	fi
 }
 

--- a/contrib/docker-integration/tls.bats
+++ b/contrib/docker-integration/tls.bats
@@ -13,6 +13,15 @@ function setup() {
 	docker pull $image
 }
 
+# skip basic auth tests with Docker 1.6, where they don't pass due to
+# certificate issues
+function basic_auth_version_check() {
+	run sh -c 'docker version | fgrep -q "Client version: 1.6.0"'
+	if [ "$status" -eq 0 ]; then
+		skip "Basic auth tests don't support 1.6.0"
+	fi
+}
+
 # has_digest enforces the last output line is "Digest: sha256:..."
 # the input is the name of the array containing the output lines
 function has_digest() {
@@ -35,6 +44,7 @@ function login() {
 }
 
 @test "Test basic auth" {
+	basic_auth_version_check
 	login $hostname:5441
 	docker tag -f $image $hostname:5441/$image
 	run docker push $hostname:5441/$image
@@ -56,6 +66,7 @@ function login() {
 }
 
 @test "Test basic auth with TLS client auth" {
+	basic_auth_version_check
 	login $hostname:5444
 	docker tag -f $image $hostname:5444/$image
 	run docker push $hostname:5444/$image


### PR DESCRIPTION
Add a run_multiversion.sh script that downloads a variety of Docker
engines and runs the integration tests against each of them.

Skip some of the tests when running with Docker 1.6.0. It has a bug that
prevents these tests from completing successfully.

Fixes #751

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>