### PR TITLE
Do not call uuid.Generate() on package-level var initialization

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -27,13 +27,15 @@ func (ic *instanceContext) Value(key interface{}) interface{} {
 
 var background = &instanceContext{
 	Context: context.Background(),
-	id:      uuid.Generate().String(),
 }
 
 // Background returns a non-nil, empty Context. The background context
 // provides a single key, "instance.id" that is globally unique to the
 // process.
 func Background() Context {
+	if len(background.id) == 0 {
+		background.id = uuid.Generate().String()
+	}
 	return background
 }
 

--- a/context/logger.go
+++ b/context/logger.go
@@ -3,8 +3,6 @@ package context
 import (
 	"fmt"
 
-	"github.com/docker/distribution/uuid"
-
 	"github.com/Sirupsen/logrus"
 )
 
@@ -100,9 +98,4 @@ func getLogrusLogger(ctx Context, keys ...interface{}) *logrus.Entry {
 	}
 
 	return logger.WithFields(fields)
-}
-
-func init() {
-	// inject a logger into the uuid library.
-	uuid.Loggerf = GetLogger(Background()).Warnf
 }

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"syscall"
 	"time"
@@ -30,7 +29,7 @@ var (
 
 	// Loggerf can be used to override the default logging destination. Such
 	// log messages in this library should be logged at warning or higher.
-	Loggerf = log.Printf
+	Loggerf func(string, ...interface{})
 )
 
 // UUID represents a UUID value. UUIDs can be compared and set to other values
@@ -66,7 +65,9 @@ func Generate() (u UUID) {
 			if retryOnError(err) && retries < maxretries {
 				count += n
 				retries++
-				Loggerf("error generating version 4 uuid, retrying: %v", err)
+				if Loggerf != nil {
+					Loggerf("error generating version 4 uuid, retrying: %v", err)
+				}
 				continue
 			}
 


### PR DESCRIPTION
This prevents clients of the different packages to overwrite
uuid.Loggerf before uuid.Generate() is called.

Signed-off-by: Tibor Vass <tibor@docker.com>

Closes #784 