### PR TITLE
Change server TLS config to tighten security

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -83,9 +83,21 @@ func main() {
 
 	if config.HTTP.TLS.Certificate != "" {
 		tlsConf := &tls.Config{
-			ClientAuth:   tls.NoClientCert,
-			NextProtos:   []string{"http/1.1"},
-			Certificates: make([]tls.Certificate, 1),
+			ClientAuth:               tls.NoClientCert,
+			NextProtos:               []string{"http/1.1"},
+			Certificates:             make([]tls.Certificate, 1),
+			MinVersion:               tls.VersionTLS10,
+			PreferServerCipherSuites: true,
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+			},
 		}
 
 		tlsConf.Certificates[0], err = tls.LoadX509KeyPair(config.HTTP.TLS.Certificate, config.HTTP.TLS.Key)


### PR DESCRIPTION
Change the minimum TLS version to TLS 1.0, and add a custom list of
ciphersuites which are thought to be the most secure options.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>