### PR TITLE
UUID package improvements

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/docker/distribution/registry/storage/driver/middleware/cloudfront"
 	_ "github.com/docker/distribution/registry/storage/driver/s3"
 	_ "github.com/docker/distribution/registry/storage/driver/swift"
+	"github.com/docker/distribution/uuid"
 	"github.com/docker/distribution/version"
 	gorhandlers "github.com/gorilla/handlers"
 	"github.com/yvasiyarov/gorelic"
@@ -61,6 +62,10 @@ func main() {
 	if err != nil {
 		fatalf("error configuring logger: %v", err)
 	}
+
+	// inject a logger into the uuid library. warns us if there is a problem
+	// with uuid generation under low entropy.
+	uuid.Loggerf = context.GetLogger(ctx).Warnf
 
 	app := handlers.NewApp(ctx, *config)
 	handler := configureReporting(app)

--- a/context/context.go
+++ b/context/context.go
@@ -7,10 +7,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-var (
-	once sync.Once
-)
-
 // Context is a copy of Context from the golang.org/x/net/context package.
 type Context interface {
 	context.Context
@@ -20,12 +16,13 @@ type Context interface {
 // provided as the main background context.
 type instanceContext struct {
 	Context
-	id string // id of context, logged as "instance.id"
+	id   string    // id of context, logged as "instance.id"
+	once sync.Once // once protect generation of the id
 }
 
 func (ic *instanceContext) Value(key interface{}) interface{} {
 	if key == "instance.id" {
-		once.Do(func() {
+		ic.once.Do(func() {
 			// We want to lazy initialize the UUID such that we don't
 			// call a random generator from the package initialization
 			// code. For various reasons random could not be available

--- a/context/context.go
+++ b/context/context.go
@@ -1,8 +1,14 @@
 package context
 
 import (
+	"sync"
+
 	"github.com/docker/distribution/uuid"
 	"golang.org/x/net/context"
+)
+
+var (
+	once sync.Once
 )
 
 // Context is a copy of Context from the golang.org/x/net/context package.
@@ -19,6 +25,13 @@ type instanceContext struct {
 
 func (ic *instanceContext) Value(key interface{}) interface{} {
 	if key == "instance.id" {
+		once.Do(func() {
+			// We want to lazy initialize the UUID such that we don't
+			// call a random generator from the package initialization
+			// code. For various reasons random could not be available
+			// https://github.com/docker/distribution/issues/782
+			ic.id = uuid.Generate().String()
+		})
 		return ic.id
 	}
 
@@ -27,7 +40,6 @@ func (ic *instanceContext) Value(key interface{}) interface{} {
 
 var background = &instanceContext{
 	Context: context.Background(),
-	id:      uuid.Generate().String(),
 }
 
 // Background returns a non-nil, empty Context. The background context

--- a/context/logger.go
+++ b/context/logger.go
@@ -3,8 +3,6 @@ package context
 import (
 	"fmt"
 
-	"github.com/docker/distribution/uuid"
-
 	"github.com/Sirupsen/logrus"
 )
 
@@ -100,9 +98,4 @@ func getLogrusLogger(ctx Context, keys ...interface{}) *logrus.Entry {
 	}
 
 	return logger.WithFields(fields)
-}
-
-func init() {
-	// inject a logger into the uuid library.
-	uuid.Loggerf = GetLogger(Background()).Warnf
 }

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"syscall"
 	"time"
@@ -30,7 +29,7 @@ var (
 
 	// Loggerf can be used to override the default logging destination. Such
 	// log messages in this library should be logged at warning or higher.
-	Loggerf = log.Printf
+	Loggerf = func(format string, args ...interface{}) {}
 )
 
 // UUID represents a UUID value. UUIDs can be compared and set to other values


### PR DESCRIPTION
To avoid errant log messages, we've disabled logging by default when uuid is having trouble accessing `/dev/urandom`. This also takes the work from #786 and incorporates the feedback.

This carries #784 and #786.

cc @jfrazelle @tiborvass @ibuildthecloud
