### PR TITLE
Fix earlier commit to enable upload purging in example config file

### DIFF
--- a/cmd/registry/config-example.yml
+++ b/cmd/registry/config-example.yml
@@ -7,8 +7,5 @@ storage:
         layerinfo: inmemory
     filesystem:
         rootdirectory: /var/lib/registry
-    maintenance:
-        uploadpurging:
-            enabled: true
 http:
     addr: :5000


### PR DESCRIPTION
Rather than setting this to "true", the whole section should be removed.

@stevvooe 