### PR TITLE
Misc tweaks based on using errcode in Docker engine

### DIFF
--- a/registry/api/errcode/errors_test.go
+++ b/registry/api/errcode/errors_test.go
@@ -122,11 +122,10 @@ func TestErrorsManagement(t *testing.T) {
 	// Test the arg substitution stuff
 	e1 := unmarshaled[3].(Error)
 	exp1 := `Sorry "BOOGIE" isn't valid`
-	if e1.Message != exp1 {
-		t.Fatalf("Wrong msg, got:\n%q\n\nexpected:\n%q", e1.Message, exp1)
+	if e1.Message() != exp1 {
+		t.Fatalf("Wrong msg, got:\n%q\n\nexpected:\n%q", e1.Message(), exp1)
 	}
 
-	exp1 = "test3: " + exp1
 	if e1.Error() != exp1 {
 		t.Fatalf("Error() didn't return the right string, got:%s\nexpected:%s", e1.Error(), exp1)
 	}
@@ -161,8 +160,8 @@ func TestErrorsManagement(t *testing.T) {
 	if &e1 == &e2 {
 		t.Fatalf("args: e2 and e1 should not be the same, but they are")
 	}
-	if e2.Message != `Sorry "test2" isn't valid` {
-		t.Fatalf("e2 had wrong message: %q", e2.Message)
+	if e2.Message() != `Sorry "test2" isn't valid` {
+		t.Fatalf("e2 had wrong message: %q", e2.Message())
 	}
 
 	// Verify that calling WithDetail() more than once does the right thing.

--- a/registry/client/blob_writer_test.go
+++ b/registry/client/blob_writer_test.go
@@ -174,8 +174,8 @@ func TestUploadReadFrom(t *testing.T) {
 		if v2Err.Code != v2.ErrorCodeBlobUploadInvalid {
 			t.Fatalf("Unexpected error code: %s, expected %d", v2Err.Code.String(), v2.ErrorCodeBlobUploadInvalid)
 		}
-		if expected := "blob upload invalid"; v2Err.Message != expected {
-			t.Fatalf("Unexpected error message: %q, expected %q", v2Err.Message, expected)
+		if expected := "blob upload invalid"; v2Err.Message() != expected {
+			t.Fatalf("Unexpected error message: %q, expected %q", v2Err.Message(), expected)
 		}
 		if expected := "more detail"; v2Err.Detail.(string) != expected {
 			t.Fatalf("Unexpected error message: %q, expected %q", v2Err.Detail.(string), expected)

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -785,8 +785,8 @@ func TestManifestUnauthorized(t *testing.T) {
 	if v2Err.Code != v2.ErrorCodeUnauthorized {
 		t.Fatalf("Unexpected error code: %s", v2Err.Code.String())
 	}
-	if expected := v2.ErrorCodeUnauthorized.Message(); v2Err.Message != expected {
-		t.Fatalf("Unexpected message value: %q, expected %q", v2Err.Message, expected)
+	if expected := v2.ErrorCodeUnauthorized.Message(); v2Err.Message() != expected {
+		t.Fatalf("Unexpected message value: %q, expected %q", v2Err.Message(), expected)
 	}
 }
 

--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -146,7 +146,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 
 	d, err := bs.Stat(ctx, desc.Digest)
 	if err == nil {
-		t.Fatalf("unexpected non-error stating deleted blob: %s", d)
+		t.Fatalf("unexpected non-error stating deleted blob: %v", d)
 	}
 
 	switch err {


### PR DESCRIPTION
This PR does a couple of things:
1 - it adds an Error.Message() func (and renamed 'Message' property to 'Msg')
    so that people are forced to use the func to acccess the human readable
	version for the error.  This future proofs things so that if/when we
	need to dynamically generate the text existing users of the code won't
	need to change because they're no longer access a property (which should
	be internal anyway).

2 - Made ErrCode.Error() return Message() instead of ID.
    There are lots and lots of places where people are just going to
	do stuff like fmt.Printf("there's an error: %s", err.Error())
	and if "err" is an ErrCode then all they'll see if some single-word ID
	instead of the human readable text, which means its almost useless in
	these cases.  So, I added an ID() func to get the ID if we really want it,
	but otherwise Error() really needs to be more useable.  This was a problem
	in "docker build" because the output of the build, in some cases, would
	just show the ID and nothing human readable.

3 - Changed Error.Error() to NOT include the ID in the start of the text.
    Like case 2 above, there are lots of places where people will just call
	Error() and expect human readable text.  However, including some
	word that's really only means something to Docker devs isn't useful and
	in some cases confusing.  For example, in the builder output (without
	adding special logic to deal with it I would see):
```
$ docker build tmp
Sending build context to Docker daemon 40.06 MB
Step 0 : FROM ubuntu
 ---> 07f8e8c5e660
Step 1 : ONBUILD onbuild
chainonbuild: Chaining ONBUILD via `ONBUILD ONBUILD` isn't allowed
```
Having the 'chainonbuild:' in the start of that text isn't meaningful
to the end user.  If we really want a version of the text to include it
then we can add a new func to do that, but Error() should return the more
human readable version.

Signed-off-by: Doug Davis <dug@us.ibm.com>