### PR TITLE
Fix vet issue

### DIFF
--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -146,7 +146,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 
 	d, err := bs.Stat(ctx, desc.Digest)
 	if err == nil {
-		t.Fatalf("unexpected non-error stating deleted blob: %s", d)
+		t.Fatalf("unexpected non-error stating deleted blob: %v", d)
 	}
 
 	switch err {


### PR DESCRIPTION
registry/storage/blob_test.go:149: arg d for printf verb %s of wrong type: github.com/docker/distribution.Descriptor

Signed-off-by: Doug Davis <dug@us.ibm.com>