### PR TITLE
Apply earlier typo fixes to source files instead of their output

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -175,7 +175,6 @@ identify a set of modifications.
       <li>Added error code for unsupported operations.</li>
     </ul>
   </dd>
-
 </dl>
 
 ## Overview
@@ -727,7 +726,8 @@ delete may be issued with the following request format:
 
     DELETE /v2/<name>/blobs/<digest>
 
-If the blob exists and has been successfully deleted, the following response will be issued:
+If the blob exists and has been successfully deleted, the following response
+will be issued:
 
     202 Accepted
     Content-Length: None
@@ -735,6 +735,8 @@ If the blob exists and has been successfully deleted, the following response wil
 If the blob had already been deleted or did not exist, a `404 Not Found`
 response will be issued instead.
 
+If a layer is deleted which is referenced by a manifest in the registry,
+then the complete images will not be resolvable.
 
 #### Pushing an Image Manifest
 
@@ -1022,7 +1024,6 @@ A list of methods and URIs are covered in the table below:
 | PUT | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Complete the upload specified by `uuid`, optionally appending the body as the final chunk. |
 | DELETE | `/v2/<name>/blobs/uploads/<uuid>` | Blob Upload | Cancel outstanding upload processes, releasing associated resources. If this is not called, the unfinished uploads will eventually timeout. |
 | GET | `/v2/_catalog` | Catalog | Retrieve a sorted, json list of repositories available in the registry. |
-| DELETE | `/v2/<name>/blobs/<digest>` | Blob delete | Delete the blob identified by `name` and `digest`|
 
 
 The detail for each endpoint is covered in the following sections.
@@ -1731,7 +1732,6 @@ The error codes that may be included in the response body are enumerated below:
 
 
 #### DELETE Manifest
-
 
 Delete the manifest identified by `name` and `reference`. Note that a manifest can _only_ be deleted by `digest`.
 

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -277,7 +277,7 @@ API. When this header is omitted, clients may fallback to an older API version.
 
 This API design is driven heavily by [content addressability](http://en.wikipedia.org/wiki/Content-addressable_storage).
 The core of this design is the concept of a content addressable identifier. It
-uniquely identifies content by taking a collision-resistent hash of the bytes.
+uniquely identifies content by taking a collision-resistant hash of the bytes.
 Such an identifier can be independently calculated and verified by selection
 of a common _algorithm_. If such an identifier can be communicated in a secure
 manner, one can retrieve the content from an insecure source, calculate it
@@ -791,7 +791,7 @@ Images are stored in collections, known as a _repository_, which is keyed by a
 contain several repositories. The list of available repositories is made
 available through the _catalog_.
 
-The catalog for a given registry can be retrived with the following request:
+The catalog for a given registry can be retrieved with the following request:
 
 ```
 GET /v2/_catalog
@@ -875,7 +875,7 @@ To get the next result set, a client would issue the request as follows, using
 the URL encoded in the described `Link` header:
 
 ```
-GET /v2/_catalog?n=<n from the request>&last=<last repostory value from previous response>
+GET /v2/_catalog?n=<n from the request>&last=<last repository value from previous response>
 ```
 
 The above process should then be repeated until the `Link` header is no longer

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -536,7 +536,7 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						Successes: []ResponseDescriptor{
 							{
-								Description: "The manifest idenfied by `name` and `reference`. The contents can be used to identify and resolve resources required to run the specified image.",
+								Description: "The manifest identified by `name` and `reference`. The contents can be used to identify and resolve resources required to run the specified image.",
 								StatusCode:  http.StatusOK,
 								Headers: []ParameterDescriptor{
 									digestHeader,
@@ -928,7 +928,7 @@ var routeDescriptors = []RouteDescriptor{
 	{
 		Name:        RouteNameBlobUpload,
 		Path:        "/v2/{name:" + RepositoryNameRegexp.String() + "}/blobs/uploads/",
-		Entity:      "Intiate Blob Upload",
+		Entity:      "Initiate Blob Upload",
 		Description: "Initiate a blob upload. This endpoint can be used to create resumable uploads or monolithic uploads.",
 		Methods: []MethodDescriptor{
 			{


### PR DESCRIPTION
Regenerate api.md. This seems to result in a few unrelated changes.

Fixes #804

@stevvooe @RichardScothern