### PR TITLE
Added generic S3 compatible APIs support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,8 @@ information about each option that appears later in this page.
         accesskey: awsaccesskey
         secretkey: awssecretkey
         region: us-west-1
+        regionendpoint: http://myobjects.local
+        regionsupportshead: true
         bucket: bucketname
         encrypt: true
         secure: true
@@ -329,6 +331,8 @@ Permitted values are `error`, `warn`, `info` and `debug`. The default is
         accesskey: awsaccesskey
         secretkey: awssecretkey
         region: us-west-1
+        regionendpoint: http://myobjects.local
+        regionsupportshead: true
         bucket: bucketname
         encrypt: true
         secure: true
@@ -526,7 +530,7 @@ This storage backend uses [Ceph Object Storage](http://ceph.com/docs/master/rado
 
 ### S3
 
-This storage backend uses Amazon's Simple Storage Service (S3).
+This storage backend uses Amazon's Simple Storage Service (S3) and compatible APIs.
 
 <table>
   <tr>
@@ -566,6 +570,29 @@ This storage backend uses Amazon's Simple Storage Service (S3).
     <td>
       The AWS region in which your bucket exists. For the moment, the Go AWS
       library in use does not use the newer DNS based bucket routing.
+    </td>
+  </tr>
+    <tr>
+    <td>
+      <code>regionendpoint</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+	Endpoint for S3 compatible APIs (Ceph Rados Gateway, Riak CS, etc)
+    </td>
+  </tr>
+    <tr>
+    <td>
+      <code>regionsupportshead</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      For S3 compatible APIs, indicates whether to use HEAD for object info.
+      A boolean value. The default is true. For old APIs, use false.
     </td>
   </tr>
     <tr>

--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -9,7 +9,7 @@ keywords = ["registry, service, driver, images, storage,  S3"]
 
 # S3 storage driver
 
-An implementation of the `storagedriver.StorageDriver` interface which uses Amazon S3 for object storage.
+An implementation of the `storagedriver.StorageDriver` interface which uses Amazon S3 for object storage or generic S3 APIs.
 
 ## Parameters
 
@@ -19,7 +19,11 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
 
 **Note** You can provide empty strings for your access and secret keys if you plan on running the driver on an ec2 instance and will handle authentication with the instance's credentials.
 
-`region`: The name of the aws region in which you would like to store objects (for example `us-east-1`). For a list of regions, you can look at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
+`region`: The name of the aws region in which you would like to store objects (for example `us-east-1`) or `generic` for S3 compatible APIs. For a list of regions, you can look at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html 
+
+`regionendpoint`: empty for Amazon S3 or url for S3 compatible APIs.
+
+`regionsupportshead`: empty or true for Amazon S3, false for old APIs that does not implement HEAD for objects info.
 
 `bucket`: The name of your s3 bucket where you wish to store objects (needs to already be created prior to driver initialization).
 

--- a/registry/storage/driver/s3/s3_test.go
+++ b/registry/storage/driver/s3/s3_test.go
@@ -35,6 +35,8 @@ func init() {
 	defer os.Remove(root)
 
 	s3DriverConstructor = func(rootDirectory string) (*Driver, error) {
+		regionSupportHead := true
+
 		encryptBool := false
 		if encrypt != "" {
 			encryptBool, err = strconv.ParseBool(encrypt)
@@ -64,6 +66,7 @@ func init() {
 			secretKey,
 			bucket,
 			aws.GetRegion(region),
+			regionSupportHead,
 			encryptBool,
 			secureBool,
 			v4AuthBool,


### PR DESCRIPTION
Support for Ceph Rados Gateway (not librados) and perhaps Riak CS.

Extra configurations:

* regionendpoint: api url
* regionsupportshead: old RadosGw versions does not support HEAD for object info

Requirements:

* region must be set as **generic**

How I tested it:

```
docker run -d -p 5000:5000 -e "REGISTRY_STORAGE=s3" \
-e "REGISTRY_STORAGE_S3_REGION=generic" \
-e "REGISTRY_STORAGE_S3_REGIONENDPOINT=http://myradosgw.mydomain.com" \
-e "REGISTRY_STORAGE_S3_BUCKET=registry" \
-e "REGISTRY_STORAGE_S3_ACCESSKEY=XXXXXXX" \
-e "REGISTRY_STORAGE_S3_SECRETKEY=XXXXXXX" \
-e "REGISTRY_STORAGE_S3_SECURE=false" \
-e "REGISTRY_STORAGE_S3_ENCRYPT=false" \
-e "REGISTRY_STORAGE_S3_REGIONSUPPORTSHEAD=false" \
test-registry
```