### PR TITLE
Fix go vet in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ ${PREFIX}/bin/dist: version/version.go $(shell find . -type f -name '*.go')
 docs/spec/api.md: docs/spec/api.md.tmpl ${PREFIX}/bin/registry-api-descriptor-template
 	./bin/registry-api-descriptor-template $< > $@
 
-vet:
+# Depends on binaries because vet will silently fail if it can't load compiled
+# imports
+vet: binaries
 	@echo "+ $@"
 	@go vet ./...
 
@@ -70,5 +72,3 @@ binaries: ${PREFIX}/bin/registry ${PREFIX}/bin/registry-api-descriptor-template 
 clean:
 	@echo "+ $@"
 	@rm -rf "${PREFIX}/bin/registry" "${PREFIX}/bin/registry-api-descriptor-template"
-
-	

--- a/circle.yml
+++ b/circle.yml
@@ -75,6 +75,11 @@ test:
     - gvm use stable && go version
     # - gvm use bleed && go version
 
+  # First thing: build everything. This will catch compile errors, and it's
+  # also necessary for go vet to work properly (see #807).
+    - gvm use stable && godep go install ./...:
+        pwd: $BASE_STABLE
+
   # FMT
     - gvm use stable && test -z "$(gofmt -s -l . | grep -v Godeps/_workspace/src/ | tee /dev/stderr)":
         pwd: $BASE_STABLE


### PR DESCRIPTION
It's necessary to compile the code first; otherwise go vet silently
fails to load imports.

Fixes #807.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>