### PR TITLE
Make testResponseWriter's CloseNotify return an actual channel instead of nil

### DIFF
--- a/context/http_test.go
+++ b/context/http_test.go
@@ -114,7 +114,7 @@ func (trw *testResponseWriter) Header() http.Header {
 // http.CloseNotifier interface, which WithResponseWriter expects to be
 // implemented.
 func (trw *testResponseWriter) CloseNotify() <-chan bool {
-	return nil
+	return make(chan bool)
 }
 
 func (trw *testResponseWriter) Write(p []byte) (n int, err error) {


### PR DESCRIPTION
This channel never gets written to, but this only means that the mock
ResponseWriter will never signal a premature disconnect.

Based on feedback from #763.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>