### PR TITLE
Two fixes for Docker integration tests

### DIFF
--- a/contrib/docker-integration/Dockerfile
+++ b/contrib/docker-integration/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Docker
-ENV VERSION 1.7.0-rc1
+ENV VERSION 1.7.1
 RUN curl -L -o /usr/local/bin/docker https://test.docker.com/builds/Linux/x86_64/docker-${VERSION} \
     && chmod +x /usr/local/bin/docker
 

--- a/contrib/docker-integration/run_multiversion.sh
+++ b/contrib/docker-integration/run_multiversion.sh
@@ -10,6 +10,29 @@ tmpdir_template="`pwd`/docker-versions.XXXXX"
 tmpdir=`mktemp -d "$tmpdir_template"`
 trap "rm -rf $tmpdir" EXIT
 
+if [ "$1" == "-d" ]; then
+	# Start docker daemon
+
+	# Drivers to use for Docker engines the tests are going to create.
+	STORAGE_DRIVER=${STORAGE_DRIVER:-overlay}
+	EXEC_DRIVER=${EXEC_DRIVER:-native}
+
+	docker --daemon --log-level=panic \
+		--storage-driver="$STORAGE_DRIVER" --exec-driver="$EXEC_DRIVER" &
+	DOCKER_PID=$!
+
+	# Wait for it to become reachable.
+	tries=10
+	until docker version &> /dev/null; do
+		(( tries-- ))
+		if [ $tries -le 0 ]; then
+			echo >&2 "error: daemon failed to start"
+			exit 1
+		fi
+		sleep 1
+	done
+fi
+
 # If DOCKER_VOLUME is unset, create a temporary directory to cache containers
 # between runs
 # Only do this on Linux, because using /var/lib/docker from a host volume seems


### PR DESCRIPTION
- Add a command line argument to run_multiversion.sh which has it start
  a docker daemon. This allows it to run directly inside an outermost
  docker-integration container instead of running outside all containers.

- Install Docker 1.7.1 intead of 1.7.0-rc1 in the docker-integration
  container. 1.7.0 has a bug that prevents "docker cp" from working
  properly.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>