### PR TITLE
Two more Docker integration test fixes

### DIFF
--- a/contrib/docker-integration/Dockerfile
+++ b/contrib/docker-integration/Dockerfile
@@ -35,7 +35,7 @@ RUN cd /usr/local/src/ \
     && ./install.sh /usr/local
 
 # Install docker-compose
-RUN curl -L https://github.com/docker/compose/releases/download/1.2.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose \
+RUN curl -L https://github.com/docker/compose/releases/download/1.3.3/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose
 
 RUN mkdir -p /go/src/github.com/docker/distribution

--- a/contrib/docker-integration/run.sh
+++ b/contrib/docker-integration/run.sh
@@ -23,14 +23,9 @@ INTEGRATION_IMAGE=${INTEGRATION_IMAGE:-distribution/docker-integration}
 docker pull $INTEGRATION_IMAGE
 
 # Start the integration tests in a Docker container.
-ID=$(docker run -d -t --privileged $volumeMount $dockerMount \
+docker run --rm -t --privileged $volumeMount $dockerMount \
 	-v ${DISTRIBUTION_ROOT}:/go/src/github.com/docker/distribution \
 	-e "STORAGE_DRIVER=$DOCKER_GRAPHDRIVER" \
 	-e "EXEC_DRIVER=$EXEC_DRIVER" \
 	${INTEGRATION_IMAGE} \
-	./test_runner.sh "$@")
-
-# Clean it up when we exit.
-trap "docker rm -f -v $ID > /dev/null" EXIT
-
-docker logs -f $ID
+	./test_runner.sh "$@"


### PR DESCRIPTION
- Upgrade docker-compose to 1.3.3 to work around
  https://github.com/docker/compose/issues/1314

- Change run.sh to run the Docker container in the foreground so that
  the exit code is propagated.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>