### PR TITLE
Fix lack of styling on Aliyun OSS documentation page

### DIFF
--- a/docs/storage-drivers/oss.md
+++ b/docs/storage-drivers/oss.md
@@ -1,8 +1,10 @@
-<!--GITHUB
-page_title: Aliyun OSS storage driver
-page_description: Explains how to use the Aliyun OSS storage drivers
-page_keywords: registry, service, driver, images, storage, OSS, aliyun
-IGNORES-->
+<!--[metadata]>
++++
+title = "Aliyun OSS storage driver"
+description = "Explains how to use the Aliyun OSS storage driver"
+keywords = ["registry, service, driver, images, storage, OSS, aliyun"]
++++
+<![end-metadata]-->
 
 # Aliyun OSS storage driver
 


### PR DESCRIPTION
This page was missing styling once exported to HTML. Adding a
<!--[metadata]> block similar to the ones the other *.md files have
appears to solve the problem.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>