### PR TITLE
Don't panic when a http.ResponseWriter does not implement CloseNotifier

### DIFF
--- a/context/http_test.go
+++ b/context/http_test.go
@@ -110,13 +110,6 @@ func (trw *testResponseWriter) Header() http.Header {
 	return trw.header
 }
 
-// CloseNotify is only here to make the testResponseWriter implement the
-// http.CloseNotifier interface, which WithResponseWriter expects to be
-// implemented.
-func (trw *testResponseWriter) CloseNotify() <-chan bool {
-	return make(chan bool)
-}
-
 func (trw *testResponseWriter) Write(p []byte) (n int, err error) {
 	if trw.status == 0 {
 		trw.status = http.StatusOK

--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -29,7 +29,7 @@ func copyFullPayload(responseWriter http.ResponseWriter, r *http.Request, destWr
 	if notifier, ok := responseWriter.(http.CloseNotifier); ok {
 		clientClosed = notifier.CloseNotify()
 	} else {
-		panic("the ResponseWriter does not implement CloseNotifier")
+		ctxu.GetLogger(context).Warn("the ResponseWriter does not implement CloseNotifier")
 	}
 
 	// Read in the data, if any.


### PR DESCRIPTION
Instead, provide a variant of instrumentedResponseWriter that does not
implement CloseNotifier, and use that when necessary. In
copyFullPayload, log instead of panicing when we encounter something
that doesn't implement CloseNotifier.

This is more complicated than I'd like, but it's necessary because
instrumentedResponseWriter must not embed CloseNotifier unless there's
really a CloseNotifier to embed.

Closes #828