### PR TITLE
Provide simple storage driver health check

### DIFF
--- a/cmd/registry-api-descriptor-template/main.go
+++ b/cmd/registry-api-descriptor-template/main.go
@@ -50,7 +50,10 @@ func main() {
 		ErrorDescriptors []errcode.ErrorDescriptor
 	}{
 		RouteDescriptors: v2.APIDescriptor.RouteDescriptors,
-		ErrorDescriptors: errcode.GetErrorCodeGroup("registry.api.v2"),
+		ErrorDescriptors: append(errcode.GetErrorCodeGroup("registry.api.v2"),
+			// The following are part of the specification but provided by errcode default.
+			errcode.ErrorCodeUnauthorized.Descriptor(),
+			errcode.ErrorCodeUnsupported.Descriptor()),
 	}
 
 	if err := tmpl.Execute(os.Stdout, data); err != nil {

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/bugsnag/bugsnag-go"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
-	_ "github.com/docker/distribution/health"
+	"github.com/docker/distribution/health"
 	_ "github.com/docker/distribution/registry/auth/htpasswd"
 	_ "github.com/docker/distribution/registry/auth/silly"
 	_ "github.com/docker/distribution/registry/auth/token"
@@ -70,8 +70,10 @@ func main() {
 	uuid.Loggerf = context.GetLogger(ctx).Warnf
 
 	app := handlers.NewApp(ctx, *config)
+	app.RegisterHealthChecks()
 	handler := configureReporting(app)
 	handler = panicHandler(handler)
+	handler = health.Handler(handler)
 	handler = gorhandlers.CombinedLoggingHandler(os.Stdout, handler)
 
 	if config.HTTP.Debug.Addr != "" {

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -2249,7 +2249,7 @@ The following headers will be returned with the response:
 
 |Name|Description|
 |----|-----------|
-|`Content-Length`|Zero|
+|`Content-Length`|0|
 |`Docker-Content-Digest`|Digest of the targeted content for the request.|
 
 

--- a/health/health.go
+++ b/health/health.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/registry/api/errcode"
 )
 
 var (
@@ -214,7 +215,8 @@ func Handler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		checks := CheckStatus()
 		if len(checks) != 0 {
-			statusResponse(w, r, http.StatusServiceUnavailable, checks)
+			errcode.ServeJSON(w, errcode.ErrorCodeUnavailable.
+				WithDetail("health check failed: please see /debug/health"))
 			return
 		}
 

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,4 +45,63 @@ func TestReturns503IfThereAreErrorChecks(t *testing.T) {
 	if recorder.Code != 503 {
 		t.Errorf("Did not get a 503.")
 	}
+}
+
+// TestHealthHandler ensures that our handler implementation correct protects
+// the web application when things aren't so healthy.
+func TestHealthHandler(t *testing.T) {
+	// clear out existing checks.
+	registeredChecks = make(map[string]Checker)
+
+	// protect an http server
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	// wrap it in our health handler
+	handler = Handler(handler)
+
+	// use this swap check status
+	updater := NewStatusUpdater()
+	Register("test_check", updater)
+
+	// now, create a test server
+	server := httptest.NewServer(handler)
+
+	checkUp := func(t *testing.T, message string) {
+		resp, err := http.Get(server.URL)
+		if err != nil {
+			t.Fatalf("error getting success status: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("unexpected response code from server when %s: %d != %d", message, resp.StatusCode, http.StatusNoContent)
+		}
+		// NOTE(stevvooe): we really don't care about the body -- the format is
+		// not standardized or supported, yet.
+	}
+
+	checkDown := func(t *testing.T, message string) {
+		resp, err := http.Get(server.URL)
+		if err != nil {
+			t.Fatalf("error getting down status: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("unexpected response code from server when %s: %d != %d", message, resp.StatusCode, http.StatusServiceUnavailable)
+		}
+	}
+
+	// server should be up
+	checkUp(t, "initial health check")
+
+	// now, we fail the health check
+	updater.Update(fmt.Errorf("the server is now out of commission"))
+	checkDown(t, "server should be down") // should be down
+
+	// bring server back up
+	updater.Update(nil)
+	checkUp(t, "when server is back up") // now we should be back up.
 }

--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -13,15 +13,45 @@ var (
 	groupToDescriptors     = map[string][]ErrorDescriptor{}
 )
 
-// ErrorCodeUnknown is a generic error that can be used as a last
-// resort if there is no situation-specific error message that can be used
-var ErrorCodeUnknown = Register("errcode", ErrorDescriptor{
-	Value:   "UNKNOWN",
-	Message: "unknown error",
-	Description: `Generic error returned when the error does not have an
+var (
+	// ErrorCodeUnknown is a generic error that can be used as a last
+	// resort if there is no situation-specific error message that can be used
+	ErrorCodeUnknown = Register("errcode", ErrorDescriptor{
+		Value:   "UNKNOWN",
+		Message: "unknown error",
+		Description: `Generic error returned when the error does not have an
 			                                            API classification.`,
-	HTTPStatusCode: http.StatusInternalServerError,
-})
+		HTTPStatusCode: http.StatusInternalServerError,
+	})
+
+	// ErrorCodeUnsupported is returned when an operation is not supported.
+	ErrorCodeUnsupported = Register("errcode", ErrorDescriptor{
+		Value:   "UNSUPPORTED",
+		Message: "The operation is unsupported.",
+		Description: `The operation was unsupported due to a missing
+		implementation or invalid set of parameters.`,
+		HTTPStatusCode: http.StatusBadRequest,
+	})
+
+	// ErrorCodeUnauthorized is returned if a request is not authorized.
+	ErrorCodeUnauthorized = Register("errcode", ErrorDescriptor{
+		Value:   "UNAUTHORIZED",
+		Message: "access to the requested resource is not authorized",
+		Description: `The access controller denied access for the operation on
+		a resource. Often this will be accompanied by a 401 Unauthorized
+		response status.`,
+		HTTPStatusCode: http.StatusUnauthorized,
+	})
+
+	// ErrorCodeUnavailable provides a common error to report unavialability
+	// of a service or endpoint.
+	ErrorCodeUnavailable = Register("errcode", ErrorDescriptor{
+		Value:          "UNAVAILABLE",
+		Message:        "service unavailable",
+		Description:    "Returned when a service is not available",
+		HTTPStatusCode: http.StatusServiceUnavailable,
+	})
+)
 
 var nextCode = 1000
 var registerLock sync.Mutex

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -124,7 +124,7 @@ var (
 			},
 		},
 		ErrorCodes: []errcode.ErrorCode{
-			ErrorCodeUnauthorized,
+			errcode.ErrorCodeUnauthorized,
 		},
 		Body: BodyDescriptor{
 			ContentType: "application/json; charset=utf-8",
@@ -145,7 +145,7 @@ var (
 			},
 		},
 		ErrorCodes: []errcode.ErrorCode{
-			ErrorCodeUnauthorized,
+			errcode.ErrorCodeUnauthorized,
 		},
 		Body: BodyDescriptor{
 			ContentType: "application/json; charset=utf-8",
@@ -374,7 +374,7 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeUnauthorized,
+									errcode.ErrorCodeUnauthorized,
 								},
 							},
 							{
@@ -451,7 +451,7 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeUnauthorized,
+									errcode.ErrorCodeUnauthorized,
 								},
 							},
 						},
@@ -506,7 +506,7 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeUnauthorized,
+									errcode.ErrorCodeUnauthorized,
 								},
 							},
 						},
@@ -568,7 +568,7 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeUnauthorized,
+									errcode.ErrorCodeUnauthorized,
 								},
 							},
 							{
@@ -645,7 +645,7 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeUnauthorized,
+									errcode.ErrorCodeUnauthorized,
 								},
 							},
 							{
@@ -682,7 +682,7 @@ var routeDescriptors = []RouteDescriptor{
 									},
 								},
 								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeUnauthorized,
+									errcode.ErrorCodeUnauthorized,
 								},
 								Body: BodyDescriptor{
 									ContentType: "application/json; charset=utf-8",
@@ -737,7 +737,7 @@ var routeDescriptors = []RouteDescriptor{
 									},
 								},
 								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeUnauthorized,
+									errcode.ErrorCodeUnauthorized,
 								},
 								Body: BodyDescriptor{
 									ContentType: "application/json; charset=utf-8",
@@ -974,7 +974,7 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeUnsupported,
+									errcode.ErrorCodeUnsupported,
 								},
 							},
 						},

--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -9,24 +9,6 @@ import (
 const errGroup = "registry.api.v2"
 
 var (
-	// ErrorCodeUnsupported is returned when an operation is not supported.
-	ErrorCodeUnsupported = errcode.Register(errGroup, errcode.ErrorDescriptor{
-		Value:   "UNSUPPORTED",
-		Message: "The operation is unsupported.",
-		Description: `The operation was unsupported due to a missing
-		implementation or invalid set of parameters.`,
-	})
-
-	// ErrorCodeUnauthorized is returned if a request is not authorized.
-	ErrorCodeUnauthorized = errcode.Register(errGroup, errcode.ErrorDescriptor{
-		Value:   "UNAUTHORIZED",
-		Message: "access to the requested resource is not authorized",
-		Description: `The access controller denied access for the operation on
-		a resource. Often this will be accompanied by a 401 Unauthorized
-		response status.`,
-		HTTPStatusCode: http.StatusUnauthorized,
-	})
-
 	// ErrorCodeDigestInvalid is returned when uploading a blob if the
 	// provided digest does not match the blob contents.
 	ErrorCodeDigestInvalid = errcode.Register(errGroup, errcode.ErrorDescriptor{

--- a/registry/client/errors.go
+++ b/registry/client/errors.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/docker/distribution/registry/api/v2"
 )
 
 // UnexpectedHTTPStatusError is returned when an unexpected HTTP status is
@@ -52,7 +51,7 @@ func handleErrorResponse(resp *http.Response) error {
 	if resp.StatusCode == 401 {
 		err := parseHTTPErrorResponse(resp.Body)
 		if uErr, ok := err.(*UnexpectedHTTPResponseError); ok {
-			return v2.ErrorCodeUnauthorized.WithDetail(uErr.Response)
+			return errcode.ErrorCodeUnauthorized.WithDetail(uErr.Response)
 		}
 		return err
 	}

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/testutil"
 )
 
@@ -782,10 +781,10 @@ func TestManifestUnauthorized(t *testing.T) {
 	if !ok {
 		t.Fatalf("Unexpected error type: %#v", err)
 	}
-	if v2Err.Code != v2.ErrorCodeUnauthorized {
+	if v2Err.Code != errcode.ErrorCodeUnauthorized {
 		t.Fatalf("Unexpected error code: %s", v2Err.Code.String())
 	}
-	if expected := v2.ErrorCodeUnauthorized.Message(); v2Err.Message != expected {
+	if expected := errcode.ErrorCodeUnauthorized.Message(); v2Err.Message != expected {
 		t.Fatalf("Unexpected message value: %q, expected %q", v2Err.Message, expected)
 	}
 }

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -575,7 +575,7 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 			// base route is accessed. This section prevents us from making
 			// that mistake elsewhere in the code, allowing any operation to
 			// proceed.
-			if err := errcode.ServeJSON(w, v2.ErrorCodeUnauthorized); err != nil {
+			if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthorized); err != nil {
 				ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
 			}
 			return fmt.Errorf("forbidden: no repository name")
@@ -590,7 +590,7 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 			// Add the appropriate WWW-Auth header
 			err.SetHeaders(w)
 
-			if err := errcode.ServeJSON(w, v2.ErrorCodeUnauthorized.WithDetail(accessRecords)); err != nil {
+			if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthorized.WithDetail(accessRecords)); err != nil {
 				ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
 			}
 		default:

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -205,8 +205,8 @@ func TestNewApp(t *testing.T) {
 	if !ok {
 		t.Fatalf("not an ErrorCoder: %#v", errs[0])
 	}
-	if err2.ErrorCode() != v2.ErrorCodeUnauthorized {
-		t.Fatalf("unexpected error code: %v != %v", err2.ErrorCode(), v2.ErrorCodeUnauthorized)
+	if err2.ErrorCode() != errcode.ErrorCodeUnauthorized {
+		t.Fatalf("unexpected error code: %v != %v", err2.ErrorCode(), errcode.ErrorCodeUnauthorized)
 	}
 }
 

--- a/registry/handlers/blob.go
+++ b/registry/handlers/blob.go
@@ -81,7 +81,7 @@ func (bh *blobHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 			bh.Errors = append(bh.Errors, v2.ErrorCodeBlobUnknown)
 		case distribution.ErrUnsupported:
 			w.WriteHeader(http.StatusMethodNotAllowed)
-			bh.Errors = append(bh.Errors, v2.ErrorCodeUnsupported)
+			bh.Errors = append(bh.Errors, errcode.ErrorCodeUnsupported)
 		default:
 			bh.Errors = append(bh.Errors, errcode.ErrorCodeUnknown)
 		}

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -213,7 +213,7 @@ func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *h
 			w.WriteHeader(http.StatusNotFound)
 			return
 		case distribution.ErrUnsupported:
-			imh.Errors = append(imh.Errors, v2.ErrorCodeUnsupported)
+			imh.Errors = append(imh.Errors, errcode.ErrorCodeUnsupported)
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		default:
 			imh.Errors = append(imh.Errors, errcode.ErrorCodeUnknown)

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
-	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/proxy/scheduler"
 )
@@ -147,9 +147,9 @@ func manifestDigest(sm *manifest.SignedManifest) (digest.Digest, error) {
 }
 
 func (pms proxyManifestStore) Put(manifest *manifest.SignedManifest) error {
-	return v2.ErrorCodeUnsupported
+	return errcode.ErrorCodeUnsupported
 }
 
 func (pms proxyManifestStore) Delete(dgst digest.Digest) error {
-	return v2.ErrorCodeUnsupported
+	return errcode.ErrorCodeUnsupported
 }


### PR DESCRIPTION
To ensure the ensure the web application is properly operating, we've added a
periodic health check for the storage driver. If the health check fails three
times in a row, the registry will serve 503 response status for any request
until the condition is resolved. The condition is reported in the response body
and via the /debug/health endpoint.

To ensure that all drivers will properly operate with this health check, a
function has been added to the driver test suite.

Close #272.

Signed-off-by: Stephen J Day <stephen.day@docker.com>