### PR TITLE
Rev base version to 2.1.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,4 +8,4 @@ var Package = "github.com/docker/distribution"
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "v2.0.0+unknown"
+var Version = "v2.1.0+unknown"


### PR DESCRIPTION
Now that we've tagged a release candidate, we can now say all builds are
"2.1.0+unknown" if the makefile is not used.

cc @RichardScothern 

Signed-off-by: Stephen J Day <stephen.day@docker.com>