### PR TITLE
driver/rados: Create OMAP for root directory

### DIFF
--- a/registry/storage/driver/rados/rados.go
+++ b/registry/storage/driver/rados/rados.go
@@ -409,7 +409,9 @@ func (d *driver) List(ctx context.Context, dirPath string) ([]string, error) {
 
 	keys := make([]string, 0, len(files))
 	for k := range files {
-		keys = append(keys, path.Join(dirPath, k))
+		if k != dirPath {
+			keys = append(keys, path.Join(dirPath, k))
+		}
 	}
 
 	return keys, nil
@@ -528,7 +530,7 @@ func (d *driver) putOid(objectPath string, oid string) error {
 	}
 
 	// Esure parent virtual directories
-	if createParentReference && directory != "/" {
+	if createParentReference {
 		return d.putOid(directory, "")
 	}
 
@@ -581,7 +583,7 @@ func (d *driver) deleteOid(objectPath string) error {
 		}
 
 		// Remove reference on parent omaps
-		if directory != "/" {
+		if directory != "" {
 			return d.deleteOid(directory)
 		}
 	}

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -87,6 +87,14 @@ func (suite *DriverSuite) TearDownTest(c *check.C) {
 	}
 }
 
+// TestRootExists ensures that all storage drivers have a root path by default.
+func (suite *DriverSuite) TestRootExists(c *check.C) {
+	_, err := suite.StorageDriver.List(suite.ctx, "/")
+	if err != nil {
+		c.Fatalf(`the root path "/" should always exist: %v`, err)
+	}
+}
+
 // TestValidPaths checks that various valid file paths are accepted by the
 // storage driver.
 func (suite *DriverSuite) TestValidPaths(c *check.C) {


### PR DESCRIPTION
When using the RADOS driver, the hierarchy of the files is stored
in OMAPs, but the root OMAP was not created and a call to List("/")
was returning an error instead of returned the first level files
stored. This patches creates an OMAP for "/" and excludes the listed
directory from the list of files returned.

Fixes: #832
Related: #831