### PR TITLE
Add a section to the config file for HTTP headers to add to responses

### DIFF
--- a/cmd/registry/config-cache.yml
+++ b/cmd/registry/config-cache.yml
@@ -17,6 +17,8 @@ http:
     secret: asecretforlocaldevelopment
     debug:
         addr: localhost:5001
+    headers:
+        X-Content-Type-Options: [nosniff]
 redis:
   addr: localhost:6379
   pool:

--- a/cmd/registry/config-dev.yml
+++ b/cmd/registry/config-dev.yml
@@ -32,6 +32,8 @@ http:
     addr: :5000
     debug:
         addr: localhost:5001
+    headers:
+        X-Content-Type-Options: [nosniff]
 redis:
   addr: localhost:6379
   pool:

--- a/cmd/registry/config-example.yml
+++ b/cmd/registry/config-example.yml
@@ -9,3 +9,5 @@ storage:
         rootdirectory: /var/lib/registry
 http:
     addr: :5000
+    headers:
+        X-Content-Type-Options: [nosniff]

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -86,6 +86,12 @@ type Configuration struct {
 			ClientCAs []string `yaml:"clientcas,omitempty"`
 		} `yaml:"tls,omitempty"`
 
+		// Headers is a set of headers to include in HTTP responses. A common
+		// use case for this would be security headers such as
+		// Strict-Transport-Security. The map keys are the header names, and
+		// the values are the associated header payloads.
+		Headers http.Header `yaml:"headers,omitempty"`
+
 		// Debug configures the http debug interface, if specified. This can
 		// include services such as pprof, expvar and other data that should
 		// not be exposed externally. Left disabled by default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,6 +163,8 @@ information about each option that appears later in this page.
           - /path/to/another/ca.pem
       debug:
         addr: localhost:5001
+      headers:
+        X-Content-Type-Options: [nosniff]
     notifications:
       endpoints:
         - name: alistener
@@ -1147,6 +1149,8 @@ configuration may contain both.
           - /path/to/another/ca.pem
       debug:
         addr: localhost:5001
+      headers:
+        X-Content-Type-Options: [nosniff]
 
 The `http` option details the configuration for the HTTP server that hosts the registry.
 
@@ -1273,6 +1277,21 @@ access to the debug endpoint is locked down in a production environment.
 
 The `debug` section takes a single, required `addr` parameter. This parameter
 specifies the `HOST:PORT` on which the debug server should accept connections.
+
+
+### headers
+
+The `headers` option is **optional** . Use it to specify headers that the HTTP
+server should include in responses. This can be used for security headers such
+as `Strict-Transport-Security`.
+
+The `headers` option should contain an option for each header to include, where
+the parameter name is the header's name, and the parameter value a list of the
+header's payload values.
+
+Including `X-Content-Type-Options: [nosniff]` is recommended, so that browsers
+will not interpret content as HTML if they are directed to load a page from the
+registry. This header is included in the example configuration files.
 
 
 ## notifications

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -428,6 +428,12 @@ type dispatchFunc func(ctx *Context, r *http.Request) http.Handler
 // handler, using the dispatch factory function.
 func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for headerName, headerValues := range app.Config.HTTP.Headers {
+			for _, value := range headerValues {
+				w.Header().Add(headerName, value)
+			}
+		}
+
 		context := app.context(w, r)
 
 		if err := app.authorized(w, r, context); err != nil {


### PR DESCRIPTION
The example configuration files add X-Content-Type-Options: nosniff.

Add coverage in existing registry/handlers unit tests.

Fixes #265.