### PR TITLE
In the build container, change the config file location to /etc/docker/registry/config.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ ENV DOCKER_BUILDTAGS include_rados
 
 WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
-COPY cmd/registry/config-dev.yml $DISTRIBUTION_DIR/cmd/registry/config.yml
+COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
 RUN make PREFIX=/go clean binaries
 
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000
 ENTRYPOINT ["registry"]
-CMD ["cmd/registry/config.yml"]
+CMD ["/etc/docker/registry/config.yml"]


### PR DESCRIPTION
This makes it consistent with the new official image.

Paths in the docs were updated in
34067d7d43f282a67528764ba36527b800da25fa.

Fixes #843.