### PR TITLE
registry/storage: use correct manifest link

### DIFF
--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -11,6 +11,10 @@ import (
 	"github.com/docker/distribution/uuid"
 )
 
+// linkPathFunc describes a function that can resolve a link based on the
+// repository name and digest.
+type linkPathFunc func(pm *pathMapper, name string, dgst digest.Digest) (string, error)
+
 // linkedBlobStore provides a full BlobService that namespaces the blobs to a
 // given repository. Effectively, it manages the links in a given repository
 // that grant access to the global blob store.
@@ -297,5 +301,5 @@ func blobLinkPath(pm *pathMapper, name string, dgst digest.Digest) (string, erro
 
 // manifestRevisionLinkPath provides the path to the manifest revision link.
 func manifestRevisionLinkPath(pm *pathMapper, name string, dgst digest.Digest) (string, error) {
-	return pm.path(layerLinkPathSpec{name: name, digest: dgst})
+	return pm.path(manifestRevisionLinkPathSpec{name: name, revision: dgst})
 }

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -362,3 +362,37 @@ func TestManifestStorage(t *testing.T) {
 		t.Errorf("Unexpected success deleting while disabled")
 	}
 }
+
+// TestLinkPathFuncs ensures that the link path functions behavior are locked
+// down and implemented as expected.
+func TestLinkPathFuncs(t *testing.T) {
+	for _, testcase := range []struct {
+		repo       string
+		digest     digest.Digest
+		linkPathFn linkPathFunc
+		expected   string
+	}{
+		{
+			repo:       "foo/bar",
+			digest:     "sha256:deadbeaf",
+			linkPathFn: blobLinkPath,
+			expected:   "/docker/registry/v2/repositories/foo/bar/_layers/sha256/deadbeaf/link",
+		},
+		{
+			repo:       "foo/bar",
+			digest:     "sha256:deadbeaf",
+			linkPathFn: manifestRevisionLinkPath,
+			expected:   "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/deadbeaf/link",
+		},
+	} {
+		p, err := testcase.linkPathFn(defaultPathMapper, testcase.repo, testcase.digest)
+		if err != nil {
+			t.Fatalf("unexpected error calling linkPathFn(pm, %q, %q): %v", testcase.repo, testcase.digest, err)
+		}
+
+		if p != testcase.expected {
+			t.Fatalf("incorrect path returned: %q != %q", p, testcase.expected)
+		}
+	}
+
+}

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -132,10 +132,10 @@ func (s *signatureStore) linkedBlobStore(ctx context.Context, revision digest.Di
 		repository: s.repository,
 		blobStore:  s.blobStore,
 		blobAccessController: &linkedBlobStatter{
-			blobStore:  s.blobStore,
-			repository: s.repository,
-			linkPath:   linkpath,
+			blobStore:   s.blobStore,
+			repository:  s.repository,
+			linkPathFns: []linkPathFunc{linkpath},
 		},
-		linkPath: linkpath,
+		linkPathFns: []linkPathFunc{linkpath},
 	}
 }

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -122,7 +122,7 @@ func (ts *tagStore) delete(tag string) error {
 	return ts.blobStore.driver.Delete(ts.ctx, tagPath)
 }
 
-// namedBlobStore returns the namedBlobStore for the named tag, allowing one
+// linkedBlobStore returns the linkedBlobStore for the named tag, allowing one
 // to index manifest blobs by tag name. While the tag store doesn't map
 // precisely to the linked blob store, using this ensures the links are
 // managed via the same code path.
@@ -131,13 +131,12 @@ func (ts *tagStore) linkedBlobStore(ctx context.Context, tag string) *linkedBlob
 		blobStore:  ts.blobStore,
 		repository: ts.repository,
 		ctx:        ctx,
-		linkPath: func(pm *pathMapper, name string, dgst digest.Digest) (string, error) {
+		linkPathFns: []linkPathFunc{func(pm *pathMapper, name string, dgst digest.Digest) (string, error) {
 			return pm.path(manifestTagIndexEntryLinkPathSpec{
 				name:     name,
 				tag:      tag,
 				revision: dgst,
 			})
-		},
+		}},
 	}
-
 }


### PR DESCRIPTION
- Use correct path for manifest revision path

    Unfortunately, the refactor used the incorrect path for manifest links within a
    repository. While this didn't stop the registry from working, it did break
    compatibility with 2.0 deployments for manifest fetches.

- Maintain manifest link compatibility

    Unfortunately, the 2.1 releease has written manfiest links into the wrong
    directory. This doesn't affect new 2.1 deployments but fixing this to be 2.0
    backwards compatible has broken 2.1.0 compatibility. To ensure we have
    compatibility between 2.0, 2.1.0 and future releases, we now check one of
    several locations to identify a manifest link.

    Tests were added to ensure these are locked down to the appropriate paths.

Signed-off-by: Stephen J Day <stephen.day@docker.com>