### PR TITLE
registry/storage (2.0): validate manifest parent-child relationships

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -74,6 +74,16 @@ func (ErrManifestUnverified) Error() string {
 	return fmt.Sprintf("unverified manifest")
 }
 
+// ErrManifestValidation is returned during manifest verification if a common
+// validation error is encountered.
+type ErrManifestValidation struct {
+	Reason string
+}
+
+func (err ErrManifestValidation) Error() string {
+	return fmt.Sprintf("invalid manifest: %s", err.Reason)
+}
+
 // ErrManifestVerification provides a type to collect errors encountered
 // during manifest verification. Currently, it accepts errors of all types,
 // but it may be narrowed to those involving manifest verification.

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -140,6 +140,8 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 					imh.Errors.Push(v2.ErrorCodeBlobUnknown, verificationError.FSLayer)
 				case distribution.ErrManifestUnverified:
 					imh.Errors.Push(v2.ErrorCodeManifestUnverified)
+				case distribution.ErrManifestValidation:
+					imh.Errors.Push(v2.ErrorCodeManifestInvalid, verificationError.Error())
 				default:
 					if verificationError == digest.ErrDigestInvalidFormat {
 						// TODO(stevvooe): We need to really need to move all


### PR DESCRIPTION
Since 1.8 may push bad manifests, we've added some validation to ensure that
the parent-child relationships represented by image json are correct. If the
relationship is not correct, we reject the push.

Signed-off-by: Stephen J Day <stephen.day@docker.com>