### PR TITLE
Fix mismatched version error on integration tests

### DIFF
--- a/contrib/docker-integration/install_certs.sh
+++ b/contrib/docker-integration/install_certs.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -e
 
-# Set IP address in /etc/hosts for localregistry
-IP=$(ifconfig eth0|grep "inet addr:"| cut -d: -f2 | awk '{ print $1}')
-echo "$IP localregistry" >> /etc/hosts
-
 hostname=$1
 if [ "$hostname" = "" ]; then
 	hostname="localhost"

--- a/contrib/docker-integration/run.sh
+++ b/contrib/docker-integration/run.sh
@@ -2,18 +2,12 @@
 set -e
 set -x
 
-source helpers.bash
-
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
-# Port used by engine under test
-ENGINE_PORT=5216
+source helpers.bash
 
 # Root directory of Distribution
 DISTRIBUTION_ROOT=$(cd ../..; pwd -P)
-
-DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-overlay}
-EXEC_DRIVER=${EXEC_DRIVER:-native}
 
 volumeMount=""
 if [ "$DOCKER_VOLUME" != "" ]; then
@@ -41,17 +35,19 @@ TESTS=${@:-.}
 docker pull $INTEGRATION_IMAGE
 
 # Start a Docker engine inside a docker container
-ID=$(docker run -d -it -p $ENGINE_PORT:$ENGINE_PORT --privileged $volumeMount $dockerMount \
+ID=$(docker run -d -it --privileged $volumeMount $dockerMount \
 	-v ${DISTRIBUTION_ROOT}:/go/src/github.com/docker/distribution \
-	-e "ENGINE_PORT=$ENGINE_PORT" \
 	-e "DOCKER_GRAPHDRIVER=$DOCKER_GRAPHDRIVER" \
 	-e "EXEC_DRIVER=$EXEC_DRIVER" \
 	${INTEGRATION_IMAGE} \
 	./run_engine.sh)
 
+# Stop container on exit
+trap "docker rm -f -v $ID" EXIT
+
 # Wait for it to become reachable.
 tries=10
-until "$DOCKER_BINARY" -H "127.0.0.1:$ENGINE_PORT" version &> /dev/null; do
+until docker exec "$ID" docker version &> /dev/null; do
 	(( tries-- ))
 	if [ $tries -le 0 ]; then
 		echo >&2 "error: daemon failed to start"
@@ -60,21 +56,20 @@ until "$DOCKER_BINARY" -H "127.0.0.1:$ENGINE_PORT" version &> /dev/null; do
 	sleep 1
 done
 
-# Make sure we have images outside the container, to transfer to the container.
-# Not much will happen here if the images are already present.
-docker-compose pull
-docker-compose build
+# If no volume is specified, transfer images into the container from
+# the outer docker instance
+if [ "$DOCKER_VOLUME" == "" ]; then
+	# Make sure we have images outside the container, to transfer to the container.
+	# Not much will happen here if the images are already present.
+	docker-compose pull
+	docker-compose build
 
-# Transfer images to the inner container.
-for image in "$INTEGRATION_IMAGE" registry:0.9.1 dockerintegration_nginx dockerintegration_registryv2; do
-	docker save "$image" | "$DOCKER_BINARY" -H "127.0.0.1:$ENGINE_PORT" load
-done
-
-#DOCKER_HOST="tcp://127.0.0.1:$ENGINE_PORT" docker-compose pull
-#DOCKER_HOST="tcp://127.0.0.1:$ENGINE_PORT" docker-compose build
+	# Transfer images to the inner container.
+	for image in "$INTEGRATION_IMAGE" registry:0.9.1 dockerintegration_nginx dockerintegration_registryv2; do
+		docker save "$image" | docker exec -i "$ID" docker load
+	done
+fi
 
 # Run the tests.
-docker exec -it "$ID" sh -c "DOCKER_HOST=tcp://127.0.0.1:$ENGINE_PORT ./test_runner.sh $TESTS"
+docker exec -it "$ID" sh -c "./test_runner.sh $TESTS"
 
-# Stop container
-docker rm -f -v "$ID"

--- a/contrib/docker-integration/run_engine.sh
+++ b/contrib/docker-integration/run_engine.sh
@@ -2,11 +2,14 @@
 set -e
 set -x
 
+DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-overlay}
+EXEC_DRIVER=${EXEC_DRIVER:-native}
+
 # Set IP address in /etc/hosts for localregistry
 IP=$(ifconfig eth0|grep "inet addr:"| cut -d: -f2 | awk '{ print $1}')
 echo "$IP localregistry" >> /etc/hosts
 
 sh install_certs.sh localregistry
 
-docker --daemon -H "0.0.0.0:$ENGINE_PORT" --log-level=panic \
+docker --daemon --log-level=panic \
 	--storage-driver="$DOCKER_GRAPHDRIVER" --exec-driver="$EXEC_DRIVER"


### PR DESCRIPTION
When running a different version of docker outside of the default in the integration image, then commands will fail with mismatched version unless the docker binary is specified to the correct version.

Add various cleanups to run script.
Run all commands interacting with docker inside the container in an exec.
Remove port binding to outside of container since all commands run inside.
Trap docker rm to exit in case of failure which prevents final command from running.
Do no copy images when $DOCKER_VOLUME is specified, this allows for faster runs when mounting a volume with a warm image cache.
Move exec and graph driver defaulting into run engine script.
Remove duplicated update of /etc/hosts.

@aaronlehmann sorry was not able to review last change to integration tests. I addressed some of the issues I found doing my local testing. The redesign is much cleaner. LMK if you disagree about skipping the copy based on `$DOCKER_VOLUME` being set. Could use a different variable but it needs to be able to be switched off to reduce the run time for repeated local testing.