### PR TITLE
Update example config to avoid deprecated option

### DIFF
--- a/cmd/registry/config-example.yml
+++ b/cmd/registry/config-example.yml
@@ -4,7 +4,7 @@ log:
     service: registry
 storage:
     cache:
-        layerinfo: inmemory
+        blobdescriptor: inmemory
     filesystem:
         rootdirectory: /var/lib/registry
 http:

--- a/docs/osx/config.yml
+++ b/docs/osx/config.yml
@@ -6,7 +6,7 @@ log:
     environment: macbook-air
 storage:
     cache:
-        layerinfo: inmemory
+        blobdescriptor: inmemory
     filesystem:
         rootdirectory: /Users/Shared/Registry
 http:


### PR DESCRIPTION
The storage cache option layerinfo is deprecated,
so use blobdescriptor instead in example config files.