### PR TITLE
Remove pathMapper object

### DIFF
--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -13,7 +13,6 @@ import (
 // creating and traversing backend links.
 type blobStore struct {
 	driver  driver.StorageDriver
-	pm      *pathMapper
 	statter distribution.BlobStatter
 }
 
@@ -94,7 +93,7 @@ func (bs *blobStore) Put(ctx context.Context, mediaType string, p []byte) (distr
 // path returns the canonical path for the blob identified by digest. The blob
 // may or may not exist.
 func (bs *blobStore) path(dgst digest.Digest) (string, error) {
-	bp, err := bs.pm.path(blobDataPathSpec{
+	bp, err := pathFor(blobDataPathSpec{
 		digest: dgst,
 	})
 
@@ -140,7 +139,6 @@ func (bs *blobStore) resolve(ctx context.Context, path string) (string, error) {
 
 type blobStatter struct {
 	driver driver.StorageDriver
-	pm     *pathMapper
 }
 
 var _ distribution.BlobDescriptorService = &blobStatter{}
@@ -149,9 +147,10 @@ var _ distribution.BlobDescriptorService = &blobStatter{}
 // in the main blob store. If this method returns successfully, there is
 // strong guarantee that the blob exists and is available.
 func (bs *blobStatter) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
-	path, err := bs.pm.path(blobDataPathSpec{
+	path, err := pathFor(blobDataPathSpec{
 		digest: dgst,
 	})
+
 	if err != nil {
 		return distribution.Descriptor{}, err
 	}

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -266,7 +266,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 // identified by dgst. The layer should be validated before commencing the
 // move.
 func (bw *blobWriter) moveBlob(ctx context.Context, desc distribution.Descriptor) error {
-	blobPath, err := bw.blobStore.pm.path(blobDataPathSpec{
+	blobPath, err := pathFor(blobDataPathSpec{
 		digest: desc.Digest,
 	})
 
@@ -324,7 +324,7 @@ func (bw *blobWriter) moveBlob(ctx context.Context, desc distribution.Descriptor
 // instance. An error will be returned if the clean up cannot proceed. If the
 // resources are already not present, no error will be returned.
 func (bw *blobWriter) removeResources(ctx context.Context) error {
-	dataPath, err := bw.blobStore.pm.path(uploadDataPathSpec{
+	dataPath, err := pathFor(uploadDataPathSpec{
 		name: bw.blobStore.repository.Name(),
 		id:   bw.id,
 	})

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -111,12 +111,13 @@ type hashStateEntry struct {
 
 // getStoredHashStates returns a slice of hashStateEntries for this upload.
 func (bw *blobWriter) getStoredHashStates(ctx context.Context) ([]hashStateEntry, error) {
-	uploadHashStatePathPrefix, err := bw.blobStore.pm.path(uploadHashStatePathSpec{
+	uploadHashStatePathPrefix, err := pathFor(uploadHashStatePathSpec{
 		name: bw.blobStore.repository.Name(),
 		id:   bw.id,
 		alg:  bw.digester.Digest().Algorithm(),
 		list: true,
 	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -156,12 +157,13 @@ func (bw *blobWriter) storeHashState(ctx context.Context) error {
 		return errResumableDigestNotAvailable
 	}
 
-	uploadHashStatePath, err := bw.blobStore.pm.path(uploadHashStatePathSpec{
+	uploadHashStatePath, err := pathFor(uploadHashStatePathSpec{
 		name:   bw.blobStore.repository.Name(),
 		id:     bw.id,
 		alg:    bw.digester.Digest().Algorithm(),
 		offset: int64(h.Len()),
 	})
+
 	if err != nil {
 		return err
 	}

--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -22,7 +22,7 @@ func (reg *registry) Repositories(ctx context.Context, repos []string, last stri
 		return 0, errors.New("no space in slice")
 	}
 
-	root, err := defaultPathMapper.path(repositoriesRootPathSpec{})
+	root, err := pathFor(repositoriesRootPathSpec{})
 	if err != nil {
 		return 0, err
 	}

--- a/registry/storage/catalog_test.go
+++ b/registry/storage/catalog_test.go
@@ -23,7 +23,7 @@ func setupFS(t *testing.T) *setupEnv {
 	c := []byte("")
 	ctx := context.Background()
 	registry := NewRegistryWithDriver(ctx, d, memory.NewInMemoryBlobDescriptorCacheProvider(), false, true, false)
-	rootpath, _ := defaultPathMapper.path(repositoriesRootPathSpec{})
+	rootpath, _ := pathFor(repositoriesRootPathSpec{})
 
 	repos := []string{
 		"/foo/a/_layers/1",

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -385,7 +385,7 @@ func TestLinkPathFuncs(t *testing.T) {
 			expected:   "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/deadbeaf/link",
 		},
 	} {
-		p, err := testcase.linkPathFn(defaultPathMapper, testcase.repo, testcase.digest)
+		p, err := testcase.linkPathFn(testcase.repo, testcase.digest)
 		if err != nil {
 			t.Fatalf("unexpected error calling linkPathFn(pm, %q, %q): %v", testcase.repo, testcase.digest, err)
 		}

--- a/registry/storage/paths_test.go
+++ b/registry/storage/paths_test.go
@@ -7,10 +7,6 @@ import (
 )
 
 func TestPathMapper(t *testing.T) {
-	pm := &pathMapper{
-		root: "/pathmapper-test",
-	}
-
 	for _, testcase := range []struct {
 		spec     pathSpec
 		expected string
@@ -21,14 +17,14 @@ func TestPathMapper(t *testing.T) {
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789",
 		},
 		{
 			spec: manifestRevisionLinkPathSpec{
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: manifestSignatureLinkPathSpec{
@@ -36,41 +32,41 @@ func TestPathMapper(t *testing.T) {
 				revision:  "sha256:abcdef0123456789",
 				signature: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures/sha256/abcdef0123456789/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: manifestSignaturesPathSpec{
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures",
 		},
 		{
 			spec: manifestTagsPathSpec{
 				name: "foo/bar",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags",
 		},
 		{
 			spec: manifestTagPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag",
 		},
 		{
 			spec: manifestTagCurrentPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/current/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/current/link",
 		},
 		{
 			spec: manifestTagIndexPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/index",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index",
 		},
 		{
 			spec: manifestTagIndexEntryPathSpec{
@@ -78,7 +74,7 @@ func TestPathMapper(t *testing.T) {
 				tag:      "thetag",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789",
 		},
 		{
 			spec: manifestTagIndexEntryLinkPathSpec{
@@ -86,26 +82,26 @@ func TestPathMapper(t *testing.T) {
 				tag:      "thetag",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: layerLinkPathSpec{
 				name:   "foo/bar",
 				digest: "tarsum.v1+test:abcdef",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_layers/tarsum/v1/test/abcdef/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_layers/tarsum/v1/test/abcdef/link",
 		},
 		{
 			spec: blobDataPathSpec{
 				digest: digest.Digest("tarsum.dev+sha512:abcdefabcdefabcdef908909909"),
 			},
-			expected: "/pathmapper-test/blobs/tarsum/dev/sha512/ab/abcdefabcdefabcdef908909909/data",
+			expected: "/docker/registry/v2/blobs/tarsum/dev/sha512/ab/abcdefabcdefabcdef908909909/data",
 		},
 		{
 			spec: blobDataPathSpec{
 				digest: digest.Digest("tarsum.v1+sha256:abcdefabcdefabcdef908909909"),
 			},
-			expected: "/pathmapper-test/blobs/tarsum/v1/sha256/ab/abcdefabcdefabcdef908909909/data",
+			expected: "/docker/registry/v2/blobs/tarsum/v1/sha256/ab/abcdefabcdefabcdef908909909/data",
 		},
 
 		{
@@ -113,17 +109,17 @@ func TestPathMapper(t *testing.T) {
 				name: "foo/bar",
 				id:   "asdf-asdf-asdf-adsf",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/data",
+			expected: "/docker/registry/v2/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/data",
 		},
 		{
 			spec: uploadStartedAtPathSpec{
 				name: "foo/bar",
 				id:   "asdf-asdf-asdf-adsf",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/startedat",
+			expected: "/docker/registry/v2/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/startedat",
 		},
 	} {
-		p, err := pm.path(testcase.spec)
+		p, err := pathFor(testcase.spec)
 		if err != nil {
 			t.Fatalf("unexpected generating path (%T): %v", testcase.spec, err)
 		}
@@ -136,9 +132,10 @@ func TestPathMapper(t *testing.T) {
 	// Add a few test cases to ensure we cover some errors
 
 	// Specify a path that requires a revision and get a digest validation error.
-	badpath, err := pm.path(manifestSignaturesPathSpec{
+	badpath, err := pathFor(manifestSignaturesPathSpec{
 		name: "foo/bar",
 	})
+
 	if err == nil {
 		t.Fatalf("expected an error when mapping an invalid revision: %s", badpath)
 	}

--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -62,10 +62,11 @@ func getOutstandingUploads(ctx context.Context, driver storageDriver.StorageDriv
 	uploads := make(map[string]uploadData, 0)
 
 	inUploadDir := false
-	root, err := defaultPathMapper.path(repositoriesRootPathSpec{})
+	root, err := pathFor(repositoriesRootPathSpec{})
 	if err != nil {
 		return uploads, append(errors, err)
 	}
+
 	err = Walk(ctx, driver, root, func(fileInfo storageDriver.FileInfo) error {
 		filePath := fileInfo.Path()
 		_, file := path.Split(filePath)

--- a/registry/storage/purgeuploads_test.go
+++ b/registry/storage/purgeuploads_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/docker/distribution/uuid"
 )
 
-var pm = defaultPathMapper
-
 func testUploadFS(t *testing.T, numUploads int, repoName string, startedAt time.Time) (driver.StorageDriver, context.Context) {
 	d := inmemory.New()
 	ctx := context.Background()
@@ -24,7 +22,7 @@ func testUploadFS(t *testing.T, numUploads int, repoName string, startedAt time.
 }
 
 func addUploads(ctx context.Context, t *testing.T, d driver.StorageDriver, uploadID, repo string, startedAt time.Time) {
-	dataPath, err := pm.path(uploadDataPathSpec{name: repo, id: uploadID})
+	dataPath, err := pathFor(uploadDataPathSpec{name: repo, id: uploadID})
 	if err != nil {
 		t.Fatalf("Unable to resolve path")
 	}
@@ -32,7 +30,7 @@ func addUploads(ctx context.Context, t *testing.T, d driver.StorageDriver, uploa
 		t.Fatalf("Unable to write data file")
 	}
 
-	startedAtPath, err := pm.path(uploadStartedAtPathSpec{name: repo, id: uploadID})
+	startedAtPath, err := pathFor(uploadStartedAtPathSpec{name: repo, id: uploadID})
 	if err != nil {
 		t.Fatalf("Unable to resolve path")
 	}
@@ -115,7 +113,7 @@ func TestPurgeOnlyUploads(t *testing.T) {
 
 	// Create a directory tree outside _uploads and ensure
 	// these files aren't deleted.
-	dataPath, err := pm.path(uploadDataPathSpec{name: "test-repo", id: uuid.Generate().String()})
+	dataPath, err := pathFor(uploadDataPathSpec{name: "test-repo", id: uuid.Generate().String()})
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -30,7 +30,6 @@ func NewRegistryWithDriver(ctx context.Context, driver storagedriver.StorageDriv
 	// create global statter, with cache.
 	var statter distribution.BlobDescriptorService = &blobStatter{
 		driver: driver,
-		pm:     defaultPathMapper,
 	}
 
 	if blobDescriptorCacheProvider != nil {
@@ -39,7 +38,6 @@ func NewRegistryWithDriver(ctx context.Context, driver storagedriver.StorageDriv
 
 	bs := &blobStore{
 		driver:  driver,
-		pm:      defaultPathMapper,
 		statter: statter,
 	}
 

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -26,7 +26,7 @@ func newSignatureStore(ctx context.Context, repo *repository, blobStore *blobSto
 var _ distribution.SignatureService = &signatureStore{}
 
 func (s *signatureStore) Get(dgst digest.Digest) ([][]byte, error) {
-	signaturesPath, err := s.blobStore.pm.path(manifestSignaturesPathSpec{
+	signaturesPath, err := pathFor(manifestSignaturesPathSpec{
 		name:     s.repository.Name(),
 		revision: dgst,
 	})
@@ -119,12 +119,13 @@ func (s *signatureStore) Put(dgst digest.Digest, signatures ...[]byte) error {
 // manifest with the given digest. Effectively, each signature link path
 // layout is a unique linked blob store.
 func (s *signatureStore) linkedBlobStore(ctx context.Context, revision digest.Digest) *linkedBlobStore {
-	linkpath := func(pm *pathMapper, name string, dgst digest.Digest) (string, error) {
-		return pm.path(manifestSignatureLinkPathSpec{
+	linkpath := func(name string, dgst digest.Digest) (string, error) {
+		return pathFor(manifestSignatureLinkPathSpec{
 			name:      name,
 			revision:  revision,
 			signature: dgst,
 		})
+
 	}
 
 	return &linkedBlobStore{

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -18,9 +18,10 @@ type tagStore struct {
 
 // tags lists the manifest tags for the specified repository.
 func (ts *tagStore) tags() ([]string, error) {
-	p, err := ts.blobStore.pm.path(manifestTagPathSpec{
+	p, err := pathFor(manifestTagPathSpec{
 		name: ts.repository.Name(),
 	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -47,10 +48,11 @@ func (ts *tagStore) tags() ([]string, error) {
 
 // exists returns true if the specified manifest tag exists in the repository.
 func (ts *tagStore) exists(tag string) (bool, error) {
-	tagPath, err := ts.blobStore.pm.path(manifestTagCurrentPathSpec{
+	tagPath, err := pathFor(manifestTagCurrentPathSpec{
 		name: ts.repository.Name(),
 		tag:  tag,
 	})
+
 	if err != nil {
 		return false, err
 	}
@@ -66,7 +68,7 @@ func (ts *tagStore) exists(tag string) (bool, error) {
 // tag tags the digest with the given tag, updating the the store to point at
 // the current tag. The digest must point to a manifest.
 func (ts *tagStore) tag(tag string, revision digest.Digest) error {
-	currentPath, err := ts.blobStore.pm.path(manifestTagCurrentPathSpec{
+	currentPath, err := pathFor(manifestTagCurrentPathSpec{
 		name: ts.repository.Name(),
 		tag:  tag,
 	})
@@ -87,10 +89,11 @@ func (ts *tagStore) tag(tag string, revision digest.Digest) error {
 
 // resolve the current revision for name and tag.
 func (ts *tagStore) resolve(tag string) (digest.Digest, error) {
-	currentPath, err := ts.blobStore.pm.path(manifestTagCurrentPathSpec{
+	currentPath, err := pathFor(manifestTagCurrentPathSpec{
 		name: ts.repository.Name(),
 		tag:  tag,
 	})
+
 	if err != nil {
 		return "", err
 	}
@@ -111,10 +114,11 @@ func (ts *tagStore) resolve(tag string) (digest.Digest, error) {
 // delete removes the tag from repository, including the history of all
 // revisions that have the specified tag.
 func (ts *tagStore) delete(tag string) error {
-	tagPath, err := ts.blobStore.pm.path(manifestTagPathSpec{
+	tagPath, err := pathFor(manifestTagPathSpec{
 		name: ts.repository.Name(),
 		tag:  tag,
 	})
+
 	if err != nil {
 		return err
 	}
@@ -131,12 +135,13 @@ func (ts *tagStore) linkedBlobStore(ctx context.Context, tag string) *linkedBlob
 		blobStore:  ts.blobStore,
 		repository: ts.repository,
 		ctx:        ctx,
-		linkPathFns: []linkPathFunc{func(pm *pathMapper, name string, dgst digest.Digest) (string, error) {
-			return pm.path(manifestTagIndexEntryLinkPathSpec{
+		linkPathFns: []linkPathFunc{func(name string, dgst digest.Digest) (string, error) {
+			return pathFor(manifestTagIndexEntryLinkPathSpec{
 				name:     name,
 				tag:      tag,
 				revision: dgst,
 			})
+
 		}},
 	}
 }

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -18,13 +18,11 @@ func NewVacuum(ctx context.Context, driver driver.StorageDriver) Vacuum {
 	return Vacuum{
 		ctx:    ctx,
 		driver: driver,
-		pm:     defaultPathMapper,
 	}
 }
 
 // Vacuum removes content from the filesystem
 type Vacuum struct {
-	pm     *pathMapper
 	driver driver.StorageDriver
 	ctx    context.Context
 }
@@ -36,7 +34,7 @@ func (v Vacuum) RemoveBlob(dgst string) error {
 		return err
 	}
 
-	blobPath, err := v.pm.path(blobDataPathSpec{digest: d})
+	blobPath, err := pathFor(blobDataPathSpec{digest: d})
 	if err != nil {
 		return err
 	}
@@ -52,7 +50,7 @@ func (v Vacuum) RemoveBlob(dgst string) error {
 // RemoveRepository removes a repository directory from the
 // filesystem
 func (v Vacuum) RemoveRepository(repoName string) error {
-	rootForRepository, err := v.pm.path(repositoriesRootPathSpec{})
+	rootForRepository, err := pathFor(repositoriesRootPathSpec{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The use of the pathMapper is no longer needed the way we have organized the
code base. The extra level of indirection has proved unnecessary and confusing
so we've opted to clean it up. In the future, we may require more flexibility,
but now it is simply not required.

Signed-off-by: Stephen J Day <stephen.day@docker.com>