### PR TITLE
WIP: Remove default prefix from storage package

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -86,14 +87,7 @@ func NewApp(ctx context.Context, configuration configuration.Configuration) *App
 	app.register(v2.RouteNameBlobUpload, blobUploadDispatcher)
 	app.register(v2.RouteNameBlobUploadChunk, blobUploadDispatcher)
 
-	var err error
-	app.driver, err = factory.Create(configuration.Storage.Type(), configuration.Storage.Parameters())
-	if err != nil {
-		// TODO(stevvooe): Move the creation of a service into a protected
-		// method, where this is created lazily. Its status can be queried via
-		// a health check.
-		panic(err)
-	}
+	app.configureDriver(&configuration)
 
 	purgeConfig := uploadPurgeDefaultConfig()
 	if mc, ok := configuration.Storage["maintenance"]; ok {
@@ -108,6 +102,7 @@ func NewApp(ctx context.Context, configuration configuration.Configuration) *App
 
 	startUploadPurger(app, app.driver, ctxu.GetLogger(app), purgeConfig)
 
+	var err error
 	app.driver, err = applyStorageMiddleware(app.driver, configuration.Middleware["storage"])
 	if err != nil {
 		panic(err)
@@ -230,6 +225,83 @@ func (app *App) register(routeName string, dispatch dispatchFunc) {
 	// control over the request execution.
 
 	app.router.GetRoute(routeName).Handler(app.dispatcher(dispatch))
+}
+
+func (app *App) configureDriver(configuration *configuration.Configuration) {
+	for {
+		var err error
+		app.driver, err = factory.Create(configuration.Storage.Type(), configuration.Storage.Parameters())
+		if err != nil {
+			// TODO(stevvooe): Move the creation of a service into a protected
+			// method, where this is created lazily. Its status can be queried via
+			// a health check.
+			panic(err)
+		}
+
+		// HACK(stevvooe): Previously, the storage package automatically added
+		// "/docker/registry" as a path prefix for all registry paths. The
+		// intention was to have common root configuration for all drivers.
+		// Instead, we've opted to leave this up to the driver by allowing the
+		// configuration of "rootdirectory" or similar configuration.
+		//
+		// To make the transition smoother, we are adding a nice hack to
+		// rewrite the rootdirectory path for the drivers that support it. To
+		// do this, we issue a few listings, rewrite the configuration, if
+		// necessary, then loop again.
+		//
+		// For all drivers added after 2.1 release, this doesn't matter.
+		//
+		// Leave this detection in for 2.2 to provide people time to update
+		// their configurations. The below can be removed in 2.3.
+
+		// detect a fresh registry: empty root. "/v2" and "/docker/registry"
+		// don't exist.
+		entries, err := app.driver.List(app, "/")
+		if err != nil {
+			panic(err) // what should be done here?
+		}
+
+		if len(entries) == 0 {
+			break // detected a fresh registry
+		}
+
+		// if "/v2" is present at the root, as a directory, we are good to go.
+		if _, err := app.driver.Stat(app, "/v2"); err == nil {
+			// v2 exists, assume we are configured as desired.
+			break
+		} else {
+			// only proceed if we got a not found error.
+			if _, ok := err.(storagedriver.PathNotFoundError); !ok {
+				panic(err) // actual problem accessing backend.
+			}
+		}
+
+		// confirm that we actually have the old root before proceeding.
+		if _, err := app.driver.Stat(app, "/docker/registry"); err != nil {
+			if _, ok := err.(storagedriver.PathNotFoundError); ok {
+				break // not actually there, no need to rewrite.
+			}
+
+			panic(err) // backend access issue.
+		}
+
+		// we've passed all the conditions, so we must rewrite the configuration.
+		rootI, ok := configuration.Storage.Parameters()["rootdirectory"]
+		if !ok {
+			// nothing we can do. The driver has not support for "rootdirectory". Move along.
+			break
+		}
+
+		root, ok := rootI.(string)
+		if !ok {
+			break // for some reason, it is not a string.
+		}
+
+		rewritten := path.Join(root, "/docker/registry")
+		ctxu.GetLogger(app).Warnf("storage path prefix detected: rewriting storage.%s.rootdirectory %q -> %q. To avoid this warning, set storage.%s.rootdirectory to %q or move the data to %q. If your configuration is not updated before version deploying with 2.3, automatic detection will be deprecated and you may not be able to see your data until the configuration is fixed.",
+			configuration.Storage.Type(), root, rewritten, configuration.Storage.Type(), rewritten, root)
+		configuration.Storage.Parameters()["rootdirectory"] = rewritten
+	}
 }
 
 // configureEvents prepares the event sink for action.

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -13,7 +13,6 @@ import (
 // creating and traversing backend links.
 type blobStore struct {
 	driver  driver.StorageDriver
-	pm      *pathMapper
 	statter distribution.BlobStatter
 }
 
@@ -94,7 +93,7 @@ func (bs *blobStore) Put(ctx context.Context, mediaType string, p []byte) (distr
 // path returns the canonical path for the blob identified by digest. The blob
 // may or may not exist.
 func (bs *blobStore) path(dgst digest.Digest) (string, error) {
-	bp, err := bs.pm.path(blobDataPathSpec{
+	bp, err := pathFor(blobDataPathSpec{
 		digest: dgst,
 	})
 
@@ -140,7 +139,6 @@ func (bs *blobStore) resolve(ctx context.Context, path string) (string, error) {
 
 type blobStatter struct {
 	driver driver.StorageDriver
-	pm     *pathMapper
 }
 
 var _ distribution.BlobDescriptorService = &blobStatter{}
@@ -149,9 +147,10 @@ var _ distribution.BlobDescriptorService = &blobStatter{}
 // in the main blob store. If this method returns successfully, there is
 // strong guarantee that the blob exists and is available.
 func (bs *blobStatter) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
-	path, err := bs.pm.path(blobDataPathSpec{
+	path, err := pathFor(blobDataPathSpec{
 		digest: dgst,
 	})
+
 	if err != nil {
 		return distribution.Descriptor{}, err
 	}

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -266,7 +266,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 // identified by dgst. The layer should be validated before commencing the
 // move.
 func (bw *blobWriter) moveBlob(ctx context.Context, desc distribution.Descriptor) error {
-	blobPath, err := bw.blobStore.pm.path(blobDataPathSpec{
+	blobPath, err := pathFor(blobDataPathSpec{
 		digest: desc.Digest,
 	})
 
@@ -324,7 +324,7 @@ func (bw *blobWriter) moveBlob(ctx context.Context, desc distribution.Descriptor
 // instance. An error will be returned if the clean up cannot proceed. If the
 // resources are already not present, no error will be returned.
 func (bw *blobWriter) removeResources(ctx context.Context) error {
-	dataPath, err := bw.blobStore.pm.path(uploadDataPathSpec{
+	dataPath, err := pathFor(uploadDataPathSpec{
 		name: bw.blobStore.repository.Name(),
 		id:   bw.id,
 	})

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -111,12 +111,13 @@ type hashStateEntry struct {
 
 // getStoredHashStates returns a slice of hashStateEntries for this upload.
 func (bw *blobWriter) getStoredHashStates(ctx context.Context) ([]hashStateEntry, error) {
-	uploadHashStatePathPrefix, err := bw.blobStore.pm.path(uploadHashStatePathSpec{
+	uploadHashStatePathPrefix, err := pathFor(uploadHashStatePathSpec{
 		name: bw.blobStore.repository.Name(),
 		id:   bw.id,
 		alg:  bw.digester.Digest().Algorithm(),
 		list: true,
 	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -156,12 +157,13 @@ func (bw *blobWriter) storeHashState(ctx context.Context) error {
 		return errResumableDigestNotAvailable
 	}
 
-	uploadHashStatePath, err := bw.blobStore.pm.path(uploadHashStatePathSpec{
+	uploadHashStatePath, err := pathFor(uploadHashStatePathSpec{
 		name:   bw.blobStore.repository.Name(),
 		id:     bw.id,
 		alg:    bw.digester.Digest().Algorithm(),
 		offset: int64(h.Len()),
 	})
+
 	if err != nil {
 		return err
 	}

--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -22,7 +22,7 @@ func (reg *registry) Repositories(ctx context.Context, repos []string, last stri
 		return 0, errors.New("no space in slice")
 	}
 
-	root, err := defaultPathMapper.path(repositoriesRootPathSpec{})
+	root, err := pathFor(repositoriesRootPathSpec{})
 	if err != nil {
 		return 0, err
 	}

--- a/registry/storage/catalog_test.go
+++ b/registry/storage/catalog_test.go
@@ -23,7 +23,7 @@ func setupFS(t *testing.T) *setupEnv {
 	c := []byte("")
 	ctx := context.Background()
 	registry := NewRegistryWithDriver(ctx, d, memory.NewInMemoryBlobDescriptorCacheProvider(), false, true, false)
-	rootpath, _ := defaultPathMapper.path(repositoriesRootPathSpec{})
+	rootpath, _ := pathFor(repositoriesRootPathSpec{})
 
 	repos := []string{
 		"/foo/a/_layers/1",

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -385,7 +385,7 @@ func TestLinkPathFuncs(t *testing.T) {
 			expected:   "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/deadbeaf/link",
 		},
 	} {
-		p, err := testcase.linkPathFn(defaultPathMapper, testcase.repo, testcase.digest)
+		p, err := testcase.linkPathFn(testcase.repo, testcase.digest)
 		if err != nil {
 			t.Fatalf("unexpected error calling linkPathFn(pm, %q, %q): %v", testcase.repo, testcase.digest, err)
 		}

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -376,13 +376,13 @@ func TestLinkPathFuncs(t *testing.T) {
 			repo:       "foo/bar",
 			digest:     "sha256:deadbeaf",
 			linkPathFn: blobLinkPath,
-			expected:   "/docker/registry/v2/repositories/foo/bar/_layers/sha256/deadbeaf/link",
+			expected:   "/v2/repositories/foo/bar/_layers/sha256/deadbeaf/link",
 		},
 		{
 			repo:       "foo/bar",
 			digest:     "sha256:deadbeaf",
 			linkPathFn: manifestRevisionLinkPath,
-			expected:   "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/deadbeaf/link",
+			expected:   "/v2/repositories/foo/bar/_manifests/revisions/sha256/deadbeaf/link",
 		},
 	} {
 		p, err := testcase.linkPathFn(testcase.repo, testcase.digest)

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -9,13 +9,7 @@ import (
 )
 
 const (
-	storagePathVersion = "v2"                // fixed storage layout version
-	storagePathRoot    = "/docker/registry/" // all driver paths have a prefix
-
-	// TODO(stevvooe): Get rid of the "storagePathRoot". Initially, we though
-	// storage path root would configurable for all drivers through this
-	// package. In reality, we've found it simpler to do this on a per driver
-	// basis.
+	storagePathVersion = "v2" // fixed storage layout version
 )
 
 // pathFor maps paths based on "object names" and their ids. The "object
@@ -74,35 +68,35 @@ const (
 //
 //	Manifests:
 //
-// 	manifestRevisionPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/
-// 	manifestRevisionLinkPathSpec:  <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/link
-// 	manifestSignaturesPathSpec:    <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/signatures/
-// 	manifestSignatureLinkPathSpec: <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/signatures/<algorithm>/<hex digest>/link
+// 	manifestRevisionPathSpec:      /v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/
+// 	manifestRevisionLinkPathSpec:  /v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/link
+// 	manifestSignaturesPathSpec:    /v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/signatures/
+// 	manifestSignatureLinkPathSpec: /v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/signatures/<algorithm>/<hex digest>/link
 //
 //	Tags:
 //
-// 	manifestTagsPathSpec:                  <root>/v2/repositories/<name>/_manifests/tags/
-// 	manifestTagPathSpec:                   <root>/v2/repositories/<name>/_manifests/tags/<tag>/
-// 	manifestTagCurrentPathSpec:            <root>/v2/repositories/<name>/_manifests/tags/<tag>/current/link
-// 	manifestTagIndexPathSpec:              <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/
-// 	manifestTagIndexEntryPathSpec:         <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/
-// 	manifestTagIndexEntryLinkPathSpec:     <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/link
+// 	manifestTagsPathSpec:                  /v2/repositories/<name>/_manifests/tags/
+// 	manifestTagPathSpec:                   /v2/repositories/<name>/_manifests/tags/<tag>/
+// 	manifestTagCurrentPathSpec:            /v2/repositories/<name>/_manifests/tags/<tag>/current/link
+// 	manifestTagIndexPathSpec:              /v2/repositories/<name>/_manifests/tags/<tag>/index/
+// 	manifestTagIndexEntryPathSpec:         /v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/
+// 	manifestTagIndexEntryLinkPathSpec:     /v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/link
 //
 // 	Blobs:
 //
-// 	layerLinkPathSpec:            <root>/v2/repositories/<name>/_layers/<algorithm>/<hex digest>/link
+// 	layerLinkPathSpec:            /v2/repositories/<name>/_layers/<algorithm>/<hex digest>/link
 //
 //	Uploads:
 //
-// 	uploadDataPathSpec:             <root>/v2/repositories/<name>/_uploads/<id>/data
-// 	uploadStartedAtPathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/startedat
-// 	uploadHashStatePathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/hashstates/<algorithm>/<offset>
+// 	uploadDataPathSpec:             /v2/repositories/<name>/_uploads/<id>/data
+// 	uploadStartedAtPathSpec:        /v2/repositories/<name>/_uploads/<id>/startedat
+// 	uploadHashStatePathSpec:        /v2/repositories/<name>/_uploads/<id>/hashstates/<algorithm>/<offset>
 //
 //	Blob Store:
 //
-// 	blobPathSpec:                   <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>
-// 	blobDataPathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
-// 	blobMediaTypePathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
+// 	blobPathSpec:                   /v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>
+// 	blobDataPathSpec:               /v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
+// 	blobMediaTypePathSpec:               /v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
 //
 // For more information on the semantic meaning of each path and their
 // contents, please see the path spec documentation.
@@ -120,7 +114,7 @@ func pathFor(spec pathSpec) (string, error) {
 	// to an intermediate path object, than can be consumed and mapped by the
 	// other version.
 
-	rootPrefix := []string{storagePathRoot, storagePathVersion}
+	rootPrefix := []string{"/" + storagePathVersion}
 	repoPrefix := append(rootPrefix, "repositories")
 
 	switch v := spec.(type) {

--- a/registry/storage/paths_test.go
+++ b/registry/storage/paths_test.go
@@ -7,10 +7,6 @@ import (
 )
 
 func TestPathMapper(t *testing.T) {
-	pm := &pathMapper{
-		root: "/pathmapper-test",
-	}
-
 	for _, testcase := range []struct {
 		spec     pathSpec
 		expected string
@@ -21,14 +17,14 @@ func TestPathMapper(t *testing.T) {
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789",
 		},
 		{
 			spec: manifestRevisionLinkPathSpec{
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: manifestSignatureLinkPathSpec{
@@ -36,41 +32,41 @@ func TestPathMapper(t *testing.T) {
 				revision:  "sha256:abcdef0123456789",
 				signature: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures/sha256/abcdef0123456789/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: manifestSignaturesPathSpec{
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures",
 		},
 		{
 			spec: manifestTagsPathSpec{
 				name: "foo/bar",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags",
 		},
 		{
 			spec: manifestTagPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag",
 		},
 		{
 			spec: manifestTagCurrentPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/current/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/current/link",
 		},
 		{
 			spec: manifestTagIndexPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/index",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index",
 		},
 		{
 			spec: manifestTagIndexEntryPathSpec{
@@ -78,7 +74,7 @@ func TestPathMapper(t *testing.T) {
 				tag:      "thetag",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789",
 		},
 		{
 			spec: manifestTagIndexEntryLinkPathSpec{
@@ -86,26 +82,26 @@ func TestPathMapper(t *testing.T) {
 				tag:      "thetag",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: layerLinkPathSpec{
 				name:   "foo/bar",
 				digest: "tarsum.v1+test:abcdef",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_layers/tarsum/v1/test/abcdef/link",
+			expected: "/docker/registry/v2/repositories/foo/bar/_layers/tarsum/v1/test/abcdef/link",
 		},
 		{
 			spec: blobDataPathSpec{
 				digest: digest.Digest("tarsum.dev+sha512:abcdefabcdefabcdef908909909"),
 			},
-			expected: "/pathmapper-test/blobs/tarsum/dev/sha512/ab/abcdefabcdefabcdef908909909/data",
+			expected: "/docker/registry/v2/blobs/tarsum/dev/sha512/ab/abcdefabcdefabcdef908909909/data",
 		},
 		{
 			spec: blobDataPathSpec{
 				digest: digest.Digest("tarsum.v1+sha256:abcdefabcdefabcdef908909909"),
 			},
-			expected: "/pathmapper-test/blobs/tarsum/v1/sha256/ab/abcdefabcdefabcdef908909909/data",
+			expected: "/docker/registry/v2/blobs/tarsum/v1/sha256/ab/abcdefabcdefabcdef908909909/data",
 		},
 
 		{
@@ -113,17 +109,17 @@ func TestPathMapper(t *testing.T) {
 				name: "foo/bar",
 				id:   "asdf-asdf-asdf-adsf",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/data",
+			expected: "/docker/registry/v2/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/data",
 		},
 		{
 			spec: uploadStartedAtPathSpec{
 				name: "foo/bar",
 				id:   "asdf-asdf-asdf-adsf",
 			},
-			expected: "/pathmapper-test/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/startedat",
+			expected: "/docker/registry/v2/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/startedat",
 		},
 	} {
-		p, err := pm.path(testcase.spec)
+		p, err := pathFor(testcase.spec)
 		if err != nil {
 			t.Fatalf("unexpected generating path (%T): %v", testcase.spec, err)
 		}
@@ -136,9 +132,10 @@ func TestPathMapper(t *testing.T) {
 	// Add a few test cases to ensure we cover some errors
 
 	// Specify a path that requires a revision and get a digest validation error.
-	badpath, err := pm.path(manifestSignaturesPathSpec{
+	badpath, err := pathFor(manifestSignaturesPathSpec{
 		name: "foo/bar",
 	})
+
 	if err == nil {
 		t.Fatalf("expected an error when mapping an invalid revision: %s", badpath)
 	}

--- a/registry/storage/paths_test.go
+++ b/registry/storage/paths_test.go
@@ -17,14 +17,14 @@ func TestPathMapper(t *testing.T) {
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789",
+			expected: "/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789",
 		},
 		{
 			spec: manifestRevisionLinkPathSpec{
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/link",
+			expected: "/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: manifestSignatureLinkPathSpec{
@@ -32,41 +32,41 @@ func TestPathMapper(t *testing.T) {
 				revision:  "sha256:abcdef0123456789",
 				signature: "sha256:abcdef0123456789",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures/sha256/abcdef0123456789/link",
+			expected: "/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: manifestSignaturesPathSpec{
 				name:     "foo/bar",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures",
+			expected: "/v2/repositories/foo/bar/_manifests/revisions/sha256/abcdef0123456789/signatures",
 		},
 		{
 			spec: manifestTagsPathSpec{
 				name: "foo/bar",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags",
+			expected: "/v2/repositories/foo/bar/_manifests/tags",
 		},
 		{
 			spec: manifestTagPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag",
+			expected: "/v2/repositories/foo/bar/_manifests/tags/thetag",
 		},
 		{
 			spec: manifestTagCurrentPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/current/link",
+			expected: "/v2/repositories/foo/bar/_manifests/tags/thetag/current/link",
 		},
 		{
 			spec: manifestTagIndexPathSpec{
 				name: "foo/bar",
 				tag:  "thetag",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index",
+			expected: "/v2/repositories/foo/bar/_manifests/tags/thetag/index",
 		},
 		{
 			spec: manifestTagIndexEntryPathSpec{
@@ -74,7 +74,7 @@ func TestPathMapper(t *testing.T) {
 				tag:      "thetag",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789",
+			expected: "/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789",
 		},
 		{
 			spec: manifestTagIndexEntryLinkPathSpec{
@@ -82,26 +82,26 @@ func TestPathMapper(t *testing.T) {
 				tag:      "thetag",
 				revision: "sha256:abcdef0123456789",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789/link",
+			expected: "/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789/link",
 		},
 		{
 			spec: layerLinkPathSpec{
 				name:   "foo/bar",
 				digest: "tarsum.v1+test:abcdef",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_layers/tarsum/v1/test/abcdef/link",
+			expected: "/v2/repositories/foo/bar/_layers/tarsum/v1/test/abcdef/link",
 		},
 		{
 			spec: blobDataPathSpec{
 				digest: digest.Digest("tarsum.dev+sha512:abcdefabcdefabcdef908909909"),
 			},
-			expected: "/docker/registry/v2/blobs/tarsum/dev/sha512/ab/abcdefabcdefabcdef908909909/data",
+			expected: "/v2/blobs/tarsum/dev/sha512/ab/abcdefabcdefabcdef908909909/data",
 		},
 		{
 			spec: blobDataPathSpec{
 				digest: digest.Digest("tarsum.v1+sha256:abcdefabcdefabcdef908909909"),
 			},
-			expected: "/docker/registry/v2/blobs/tarsum/v1/sha256/ab/abcdefabcdefabcdef908909909/data",
+			expected: "/v2/blobs/tarsum/v1/sha256/ab/abcdefabcdefabcdef908909909/data",
 		},
 
 		{
@@ -109,14 +109,14 @@ func TestPathMapper(t *testing.T) {
 				name: "foo/bar",
 				id:   "asdf-asdf-asdf-adsf",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/data",
+			expected: "/v2/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/data",
 		},
 		{
 			spec: uploadStartedAtPathSpec{
 				name: "foo/bar",
 				id:   "asdf-asdf-asdf-adsf",
 			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/startedat",
+			expected: "/v2/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/startedat",
 		},
 	} {
 		p, err := pathFor(testcase.spec)

--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -62,10 +62,11 @@ func getOutstandingUploads(ctx context.Context, driver storageDriver.StorageDriv
 	uploads := make(map[string]uploadData, 0)
 
 	inUploadDir := false
-	root, err := defaultPathMapper.path(repositoriesRootPathSpec{})
+	root, err := pathFor(repositoriesRootPathSpec{})
 	if err != nil {
 		return uploads, append(errors, err)
 	}
+
 	err = Walk(ctx, driver, root, func(fileInfo storageDriver.FileInfo) error {
 		filePath := fileInfo.Path()
 		_, file := path.Split(filePath)

--- a/registry/storage/purgeuploads_test.go
+++ b/registry/storage/purgeuploads_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/docker/distribution/uuid"
 )
 
-var pm = defaultPathMapper
-
 func testUploadFS(t *testing.T, numUploads int, repoName string, startedAt time.Time) (driver.StorageDriver, context.Context) {
 	d := inmemory.New()
 	ctx := context.Background()
@@ -24,7 +22,7 @@ func testUploadFS(t *testing.T, numUploads int, repoName string, startedAt time.
 }
 
 func addUploads(ctx context.Context, t *testing.T, d driver.StorageDriver, uploadID, repo string, startedAt time.Time) {
-	dataPath, err := pm.path(uploadDataPathSpec{name: repo, id: uploadID})
+	dataPath, err := pathFor(uploadDataPathSpec{name: repo, id: uploadID})
 	if err != nil {
 		t.Fatalf("Unable to resolve path")
 	}
@@ -32,7 +30,7 @@ func addUploads(ctx context.Context, t *testing.T, d driver.StorageDriver, uploa
 		t.Fatalf("Unable to write data file")
 	}
 
-	startedAtPath, err := pm.path(uploadStartedAtPathSpec{name: repo, id: uploadID})
+	startedAtPath, err := pathFor(uploadStartedAtPathSpec{name: repo, id: uploadID})
 	if err != nil {
 		t.Fatalf("Unable to resolve path")
 	}
@@ -115,7 +113,7 @@ func TestPurgeOnlyUploads(t *testing.T) {
 
 	// Create a directory tree outside _uploads and ensure
 	// these files aren't deleted.
-	dataPath, err := pm.path(uploadDataPathSpec{name: "test-repo", id: uuid.Generate().String()})
+	dataPath, err := pathFor(uploadDataPathSpec{name: "test-repo", id: uuid.Generate().String()})
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -30,7 +30,6 @@ func NewRegistryWithDriver(ctx context.Context, driver storagedriver.StorageDriv
 	// create global statter, with cache.
 	var statter distribution.BlobDescriptorService = &blobStatter{
 		driver: driver,
-		pm:     defaultPathMapper,
 	}
 
 	if blobDescriptorCacheProvider != nil {
@@ -39,7 +38,6 @@ func NewRegistryWithDriver(ctx context.Context, driver storagedriver.StorageDriv
 
 	bs := &blobStore{
 		driver:  driver,
-		pm:      defaultPathMapper,
 		statter: statter,
 	}
 

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -26,7 +26,7 @@ func newSignatureStore(ctx context.Context, repo *repository, blobStore *blobSto
 var _ distribution.SignatureService = &signatureStore{}
 
 func (s *signatureStore) Get(dgst digest.Digest) ([][]byte, error) {
-	signaturesPath, err := s.blobStore.pm.path(manifestSignaturesPathSpec{
+	signaturesPath, err := pathFor(manifestSignaturesPathSpec{
 		name:     s.repository.Name(),
 		revision: dgst,
 	})
@@ -119,12 +119,13 @@ func (s *signatureStore) Put(dgst digest.Digest, signatures ...[]byte) error {
 // manifest with the given digest. Effectively, each signature link path
 // layout is a unique linked blob store.
 func (s *signatureStore) linkedBlobStore(ctx context.Context, revision digest.Digest) *linkedBlobStore {
-	linkpath := func(pm *pathMapper, name string, dgst digest.Digest) (string, error) {
-		return pm.path(manifestSignatureLinkPathSpec{
+	linkpath := func(name string, dgst digest.Digest) (string, error) {
+		return pathFor(manifestSignatureLinkPathSpec{
 			name:      name,
 			revision:  revision,
 			signature: dgst,
 		})
+
 	}
 
 	return &linkedBlobStore{

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -18,9 +18,10 @@ type tagStore struct {
 
 // tags lists the manifest tags for the specified repository.
 func (ts *tagStore) tags() ([]string, error) {
-	p, err := ts.blobStore.pm.path(manifestTagPathSpec{
+	p, err := pathFor(manifestTagPathSpec{
 		name: ts.repository.Name(),
 	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -47,10 +48,11 @@ func (ts *tagStore) tags() ([]string, error) {
 
 // exists returns true if the specified manifest tag exists in the repository.
 func (ts *tagStore) exists(tag string) (bool, error) {
-	tagPath, err := ts.blobStore.pm.path(manifestTagCurrentPathSpec{
+	tagPath, err := pathFor(manifestTagCurrentPathSpec{
 		name: ts.repository.Name(),
 		tag:  tag,
 	})
+
 	if err != nil {
 		return false, err
 	}
@@ -66,7 +68,7 @@ func (ts *tagStore) exists(tag string) (bool, error) {
 // tag tags the digest with the given tag, updating the the store to point at
 // the current tag. The digest must point to a manifest.
 func (ts *tagStore) tag(tag string, revision digest.Digest) error {
-	currentPath, err := ts.blobStore.pm.path(manifestTagCurrentPathSpec{
+	currentPath, err := pathFor(manifestTagCurrentPathSpec{
 		name: ts.repository.Name(),
 		tag:  tag,
 	})
@@ -87,10 +89,11 @@ func (ts *tagStore) tag(tag string, revision digest.Digest) error {
 
 // resolve the current revision for name and tag.
 func (ts *tagStore) resolve(tag string) (digest.Digest, error) {
-	currentPath, err := ts.blobStore.pm.path(manifestTagCurrentPathSpec{
+	currentPath, err := pathFor(manifestTagCurrentPathSpec{
 		name: ts.repository.Name(),
 		tag:  tag,
 	})
+
 	if err != nil {
 		return "", err
 	}
@@ -111,10 +114,11 @@ func (ts *tagStore) resolve(tag string) (digest.Digest, error) {
 // delete removes the tag from repository, including the history of all
 // revisions that have the specified tag.
 func (ts *tagStore) delete(tag string) error {
-	tagPath, err := ts.blobStore.pm.path(manifestTagPathSpec{
+	tagPath, err := pathFor(manifestTagPathSpec{
 		name: ts.repository.Name(),
 		tag:  tag,
 	})
+
 	if err != nil {
 		return err
 	}
@@ -131,12 +135,13 @@ func (ts *tagStore) linkedBlobStore(ctx context.Context, tag string) *linkedBlob
 		blobStore:  ts.blobStore,
 		repository: ts.repository,
 		ctx:        ctx,
-		linkPathFns: []linkPathFunc{func(pm *pathMapper, name string, dgst digest.Digest) (string, error) {
-			return pm.path(manifestTagIndexEntryLinkPathSpec{
+		linkPathFns: []linkPathFunc{func(name string, dgst digest.Digest) (string, error) {
+			return pathFor(manifestTagIndexEntryLinkPathSpec{
 				name:     name,
 				tag:      tag,
 				revision: dgst,
 			})
+
 		}},
 	}
 }

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -18,13 +18,11 @@ func NewVacuum(ctx context.Context, driver driver.StorageDriver) Vacuum {
 	return Vacuum{
 		ctx:    ctx,
 		driver: driver,
-		pm:     defaultPathMapper,
 	}
 }
 
 // Vacuum removes content from the filesystem
 type Vacuum struct {
-	pm     *pathMapper
 	driver driver.StorageDriver
 	ctx    context.Context
 }
@@ -36,7 +34,7 @@ func (v Vacuum) RemoveBlob(dgst string) error {
 		return err
 	}
 
-	blobPath, err := v.pm.path(blobDataPathSpec{digest: d})
+	blobPath, err := pathFor(blobDataPathSpec{digest: d})
 	if err != nil {
 		return err
 	}
@@ -52,7 +50,7 @@ func (v Vacuum) RemoveBlob(dgst string) error {
 // RemoveRepository removes a repository directory from the
 // filesystem
 func (v Vacuum) RemoveRepository(repoName string) error {
-	rootForRepository, err := v.pm.path(repositoriesRootPathSpec{})
+	rootForRepository, err := pathFor(repositoriesRootPathSpec{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Defer full control of the root directory to the storage driver. Often this can
be set with "rootdirectory", if the driver supports it. It was unnecessary to
allow both the storage and driver to have configurations to control the root
path. Since it makes more sense to do this at the driver level, where it can
decide how paths are mapped to a backend, we've opted to leave that
configuration option and remove it from the storage package.

To avoid issues during upgrade, code has been added to detect a change in the
storage path. If we detect the "/docker/registry" prefix, we will rewrite the
configuration in memory and issue a warning to update the configuration or move
the data. This automatic detection will be deprecated in version 2.3, at which
time data will not be accessible until the situation is resolved.

Support for "rootdirectory" has been added to rados so that existing
installations can be properly migrated.

Note that this is currently a work in progress. Documentation is still required.

Depends on #889.

Signed-off-by: Stephen J Day <stephen.day@docker.com>