### PR TITLE
Add configurable file-existence and HTTP health checks

### DIFF
--- a/cmd/registry/config-cache.yml
+++ b/cmd/registry/config-cache.yml
@@ -48,3 +48,8 @@ proxy:
   remoteurl: https://registry-1.docker.io
   username: username
   password: password
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/cmd/registry/config-dev.yml
+++ b/cmd/registry/config-dev.yml
@@ -59,4 +59,8 @@ notifications:
           threshold: 10
           backoff: 1s
           disabled: true 
-
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/cmd/registry/config-example.yml
+++ b/cmd/registry/config-example.yml
@@ -11,3 +11,8 @@ http:
     addr: :5000
     headers:
         X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -202,6 +202,8 @@ type HTTPChecker struct {
 	Interval time.Duration `yaml:"interval,omitempty"`
 	// URI is the HTTP URI to check
 	URI string `yaml:"uri,omitempty"`
+	// Headers lists static headers that should be added to all requests
+	Headers http.Header `yaml:"headers"`
 	// Threshold is the number of times a check must fail to trigger an
 	// unhealthy state
 	Threshold int `yaml:"threshold,omitempty"`

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -135,6 +135,8 @@ type Configuration struct {
 		} `yaml:"pool,omitempty"`
 	} `yaml:"redis,omitempty"`
 
+	Health Health `yaml:"health,omitempty"`
+
 	Proxy Proxy `yaml:"proxy,omitempty"`
 }
 
@@ -177,6 +179,37 @@ type MailOptions struct {
 
 	// To defines mail receiving address
 	To []string `yaml:"to,omitempty"`
+}
+
+// FileChecker is a type of entry in the checkers section for checking files
+type FileChecker struct {
+	// Interval is the number of seconds in between checks
+	Interval time.Duration `yaml:"interval,omitempty"`
+	// File is the path to check
+	File string `yaml:"file,omitempty"`
+	// Threshold is the number of times a check must fail to trigger an
+	// unhealthy state
+	Threshold int `yaml:"threshold,omitempty"`
+}
+
+// HTTPChecker is a type of entry in the checkers section for checking HTTP
+// URIs
+type HTTPChecker struct {
+	// Interval is the number of seconds in between checks
+	Interval time.Duration `yaml:"interval,omitempty"`
+	// URI is the HTTP URI to check
+	URI string `yaml:"uri,omitempty"`
+	// Threshold is the number of times a check must fail to trigger an
+	// unhealthy state
+	Threshold int `yaml:"threshold,omitempty"`
+}
+
+// Health provides the configuration section for health checks.
+type Health struct {
+	// FileChecker is a list of paths to check
+	FileCheckers []FileChecker `yaml:"file,omitempty"`
+	// HTTPChecker is a list of URIs to check
+	HTTPCheckers []HTTPChecker `yaml:"http,omitempty"`
 }
 
 // v0_1Configuration is a Version 0.1 Configuration struct

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -210,6 +210,17 @@ type Health struct {
 	FileCheckers []FileChecker `yaml:"file,omitempty"`
 	// HTTPChecker is a list of URIs to check
 	HTTPCheckers []HTTPChecker `yaml:"http,omitempty"`
+	// StorageDriver configures a health check on the configured storage
+	// driver
+	StorageDriver struct {
+		// Enabled turns on the health check for the storage driver
+		Enabled bool `yaml:"enabled,omitempty"`
+		// Interval is the number of seconds in between checks
+		Interval time.Duration `yaml:"interval,omitempty"`
+		// Threshold is the number of times a check must fail to trigger an
+		// unhealthy state
+		Threshold int `yaml:"threshold,omitempty"`
+	} `yaml:"storagedriver,omitempty"`
 }
 
 // v0_1Configuration is a Version 0.1 Configuration struct

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -181,9 +181,9 @@ type MailOptions struct {
 	To []string `yaml:"to,omitempty"`
 }
 
-// FileChecker is a type of entry in the checkers section for checking files
+// FileChecker is a type of entry in the health section for checking files.
 type FileChecker struct {
-	// Interval is the number of seconds in between checks
+	// Interval is the duration in between checks
 	Interval time.Duration `yaml:"interval,omitempty"`
 	// File is the path to check
 	File string `yaml:"file,omitempty"`
@@ -192,10 +192,13 @@ type FileChecker struct {
 	Threshold int `yaml:"threshold,omitempty"`
 }
 
-// HTTPChecker is a type of entry in the checkers section for checking HTTP
-// URIs
+// HTTPChecker is a type of entry in the health section for checking HTTP URIs.
 type HTTPChecker struct {
-	// Interval is the number of seconds in between checks
+	// Timeout is the duration to wait before timing out the HTTP request
+	Timeout time.Duration `yaml:"interval,omitempty"`
+	// StatusCode is the expected status code
+	StatusCode int
+	// Interval is the duration in between checks
 	Interval time.Duration `yaml:"interval,omitempty"`
 	// URI is the HTTP URI to check
 	URI string `yaml:"uri,omitempty"`
@@ -204,18 +207,33 @@ type HTTPChecker struct {
 	Threshold int `yaml:"threshold,omitempty"`
 }
 
+// TCPChecker is a type of entry in the health section for checking TCP servers.
+type TCPChecker struct {
+	// Timeout is the duration to wait before timing out the TCP connection
+	Timeout time.Duration `yaml:"interval,omitempty"`
+	// Interval is the duration in between checks
+	Interval time.Duration `yaml:"interval,omitempty"`
+	// Addr is the TCP address to check
+	Addr string `yaml:"addr,omitempty"`
+	// Threshold is the number of times a check must fail to trigger an
+	// unhealthy state
+	Threshold int `yaml:"threshold,omitempty"`
+}
+
 // Health provides the configuration section for health checks.
 type Health struct {
-	// FileChecker is a list of paths to check
+	// FileCheckers is a list of paths to check
 	FileCheckers []FileChecker `yaml:"file,omitempty"`
-	// HTTPChecker is a list of URIs to check
+	// HTTPCheckers is a list of URIs to check
 	HTTPCheckers []HTTPChecker `yaml:"http,omitempty"`
+	// TCPCheckers is a list of URIs to check
+	TCPCheckers []TCPChecker `yaml:"tcp,omitempty"`
 	// StorageDriver configures a health check on the configured storage
 	// driver
 	StorageDriver struct {
 		// Enabled turns on the health check for the storage driver
 		Enabled bool `yaml:"enabled,omitempty"`
-		// Interval is the number of seconds in between checks
+		// Interval is the duration in between checks
 		Interval time.Duration `yaml:"interval,omitempty"`
 		// Threshold is the number of times a check must fail to trigger an
 		// unhealthy state

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,6 +196,10 @@ information about each option that appears later in this page.
         maxactive: 64
         idletimeout: 300s
     health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
       file:
         - file: /path/to/checked/file
           interval: 10s
@@ -1600,6 +1604,10 @@ Configure the behavior of the Redis connection pool.
 ## health
 
     health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
       file:
         - file: /path/to/checked/file
           interval: 10s
@@ -1609,8 +1617,72 @@ Configure the behavior of the Redis connection pool.
           interval: 10s
           threshold: 3
 
-The health option is **optional**. It may contain lists of file checkers
-and/or HTTP checkers.
+The health option is **optional**. It may contain preferences for a periodic
+health check on the storage driver's backend storage, and optional periodic
+checks on local files and/or HTTP URIs. The results of the health checks are
+available at /debug/health on the debug HTTP server if the debug HTTP server is
+enabled (see http section).
+
+### storagedriver
+
+storagedriver contains options for a health check on the configured storage
+driver's backend storage. enabled must be set to true for this health check to
+be active.
+
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>
+      <code>enabled</code>
+    </td>
+    <td>
+      yes
+    </td>
+    <td>
+"true" to enable the storage driver health check or "false" to disable it.
+</td>
+  </tr>
+  <tr>
+    <td>
+      <code>interval</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      The length of time to wait between repetitions of the check. This field
+      takes a positive integer and an optional suffix indicating the unit of
+      time. Possible units are:
+      <ul>
+        <li><code>ns</code> (nanoseconds)</li>
+        <li><code>us</code> (microseconds)</li>
+        <li><code>ms</code> (milliseconds)</li>
+        <li><code>s</code> (seconds)</li>
+        <li><code>m</code> (minutes)</li>
+        <li><code>h</code> (hours)</li>
+      </ul>
+    If you omit the suffix, the system interprets the value as nanoseconds.
+    The default value is 10 seconds if this field is omitted.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>threshold</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      An integer specifying the number of times the check must fail before the
+      check triggers an unhealthy state. If this filed is not specified, a
+      single failure will trigger an unhealthy state.
+    </td>
+  </tr>
+</table>
 
 ### file
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,9 +203,15 @@ information about each option that appears later in this page.
       file:
         - file: /path/to/checked/file
           interval: 10s
-          threshold: 3
       http:
         - uri: http://server.to.check/must/return/200
+          statuscode: 200
+          timeout: 3s
+          interval: 10s
+          threshold: 3
+      tcp:
+        - addr: redis-server.domain.com:6379
+          timeout: 3s
           interval: 10s
           threshold: 3
 
@@ -1611,17 +1617,23 @@ Configure the behavior of the Redis connection pool.
       file:
         - file: /path/to/checked/file
           interval: 10s
-          threshold: 3
       http:
         - uri: http://server.to.check/must/return/200
+          statuscode: 200
+          timeout: 3s
+          interval: 10s
+          threshold: 3
+      tcp:
+        - addr: redis-server.domain.com:6379
+          timeout: 3s
           interval: 10s
           threshold: 3
 
 The health option is **optional**. It may contain preferences for a periodic
 health check on the storage driver's backend storage, and optional periodic
-checks on local files and/or HTTP URIs. The results of the health checks are
-available at /debug/health on the debug HTTP server if the debug HTTP server is
-enabled (see http section).
+checks on local files, HTTP URIs, and/or TCP servers. The results of the health
+checks are available at /debug/health on the debug HTTP server if the debug
+HTTP server is enabled (see http section).
 
 ### storagedriver
 
@@ -1730,25 +1742,13 @@ The path to check for the existence of a file.
     The default value is 10 seconds if this field is omitted.
     </td>
   </tr>
-  <tr>
-    <td>
-      <code>threshold</code>
-    </td>
-    <td>
-      no
-    </td>
-    <td>
-      An integer specifying the number of times the check must fail before the
-      check triggers an unhealthy state. If this filed is not specified, a
-      single failure will trigger an unhealthy state.
-    </td>
-  </tr>
 </table>
 
 ### http
 
 http is a list of HTTP URIs to be periodically checked with HEAD requests. If
-a HEAD request returns a status code other than 200, the health check will fail.
+a HEAD request doesn't complete or returns an unexpected status code, the
+health check will fail.
 
 <table>
   <tr>
@@ -1766,6 +1766,122 @@ a HEAD request returns a status code other than 200, the health check will fail.
     <td>
 The URI to check.
 </td>
+  </tr>
+  <tr>
+    <td>
+      <code>statuscode</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+Expected status code from the HTTP URI. Defaults to 200.
+</td>
+  </tr>
+  <tr>
+    <td>
+      <code>timeout</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      The length of time to wait before timing out the HTTP request. This field
+      takes a positive integer and an optional suffix indicating the unit of
+      time. Possible units are:
+      <ul>
+        <li><code>ns</code> (nanoseconds)</li>
+        <li><code>us</code> (microseconds)</li>
+        <li><code>ms</code> (milliseconds)</li>
+        <li><code>s</code> (seconds)</li>
+        <li><code>m</code> (minutes)</li>
+        <li><code>h</code> (hours)</li>
+      </ul>
+    If you omit the suffix, the system interprets the value as nanoseconds.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>interval</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      The length of time to wait between repetitions of the check. This field
+      takes a positive integer and an optional suffix indicating the unit of
+      time. Possible units are:
+      <ul>
+        <li><code>ns</code> (nanoseconds)</li>
+        <li><code>us</code> (microseconds)</li>
+        <li><code>ms</code> (milliseconds)</li>
+        <li><code>s</code> (seconds)</li>
+        <li><code>m</code> (minutes)</li>
+        <li><code>h</code> (hours)</li>
+      </ul>
+    If you omit the suffix, the system interprets the value as nanoseconds.
+    The default value is 10 seconds if this field is omitted.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>threshold</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      An integer specifying the number of times the check must fail before the
+      check triggers an unhealthy state. If this filed is not specified, a
+      single failure will trigger an unhealthy state.
+    </td>
+  </tr>
+</table>
+
+### tcp
+
+tcp is a list of TCP addresses to be periodically checked with connection
+attempts. The addresses must include port numbers. If a connection attempt
+fails, the health check will fail.
+
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>
+      <code>addr</code>
+    </td>
+    <td>
+      yes
+    </td>
+    <td>
+The TCP address to connect to, including a port number.
+</td>
+  </tr>
+  <tr>
+    <td>
+      <code>timeout</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      The length of time to wait before timing out the TCP connection. This
+      field takes a positive integer and an optional suffix indicating the unit
+      of time. Possible units are:
+      <ul>
+        <li><code>ns</code> (nanoseconds)</li>
+        <li><code>us</code> (microseconds)</li>
+        <li><code>ms</code> (milliseconds)</li>
+        <li><code>s</code> (seconds)</li>
+        <li><code>m</code> (minutes)</li>
+        <li><code>h</code> (hours)</li>
+      </ul>
+    If you omit the suffix, the system interprets the value as nanoseconds.
+    </td>
   </tr>
   <tr>
     <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,6 +205,8 @@ information about each option that appears later in this page.
           interval: 10s
       http:
         - uri: http://server.to.check/must/return/200
+          headers:
+            Authorization: [Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==]
           statuscode: 200
           timeout: 3s
           interval: 10s
@@ -1400,7 +1402,9 @@ The URL to which events should be published.
       yes
     </td>
     <td>
-      Static headers to add to each request.
+      Static headers to add to each request. Each header's name should be a key
+      underneath headers, and each value is a list of payloads for that
+      header name. Note that values must always be lists.
     </td>
   </tr>
   <tr>
@@ -1619,6 +1623,8 @@ Configure the behavior of the Redis connection pool.
           interval: 10s
       http:
         - uri: http://server.to.check/must/return/200
+          headers:
+            Authorization: [Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==]
           statuscode: 200
           timeout: 3s
           interval: 10s
@@ -1766,6 +1772,19 @@ health check will fail.
     <td>
 The URI to check.
 </td>
+  </tr>
+   <tr>
+    <td>
+      <code>headers</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      Static headers to add to each request. Each header's name should be a key
+      underneath headers, and each value is a list of payloads for that
+      header name. Note that values must always be lists.
+    </td>
   </tr>
   <tr>
     <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,6 +195,15 @@ information about each option that appears later in this page.
         maxidle: 16
         maxactive: 64
         idletimeout: 300s
+    health:
+      file:
+        - file: /path/to/checked/file
+          interval: 10s
+          threshold: 3
+      http:
+        - uri: http://server.to.check/must/return/200
+          interval: 10s
+          threshold: 3
 
 In some instances a configuration option is **optional** but it contains child
 options marked as **required**. This indicates that you can omit the parent with
@@ -1588,6 +1597,141 @@ Configure the behavior of the Redis connection pool.
   </tr>
 </table>
 
+## health
+
+    health:
+      file:
+        - file: /path/to/checked/file
+          interval: 10s
+          threshold: 3
+      http:
+        - uri: http://server.to.check/must/return/200
+          interval: 10s
+          threshold: 3
+
+The health option is **optional**. It may contain lists of file checkers
+and/or HTTP checkers.
+
+### file
+
+file is a list of paths to be periodically checked for the existence of a file.
+If a file exists at the given path, the health check will fail. This can be
+used as a way of bringing a registry out of rotation by creating a file.
+
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>
+      <code>file</code>
+    </td>
+    <td>
+      yes
+    </td>
+    <td>
+The path to check for the existence of a file.
+</td>
+  </tr>
+  <tr>
+    <td>
+      <code>interval</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      The length of time to wait between repetitions of the check. This field
+      takes a positive integer and an optional suffix indicating the unit of
+      time. Possible units are:
+      <ul>
+        <li><code>ns</code> (nanoseconds)</li>
+        <li><code>us</code> (microseconds)</li>
+        <li><code>ms</code> (milliseconds)</li>
+        <li><code>s</code> (seconds)</li>
+        <li><code>m</code> (minutes)</li>
+        <li><code>h</code> (hours)</li>
+      </ul>
+    If you omit the suffix, the system interprets the value as nanoseconds.
+    The default value is 10 seconds if this field is omitted.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>threshold</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      An integer specifying the number of times the check must fail before the
+      check triggers an unhealthy state. If this filed is not specified, a
+      single failure will trigger an unhealthy state.
+    </td>
+  </tr>
+</table>
+
+### http
+
+http is a list of HTTP URIs to be periodically checked with HEAD requests. If
+a HEAD request returns a status code other than 200, the health check will fail.
+
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>
+      <code>uri</code>
+    </td>
+    <td>
+      yes
+    </td>
+    <td>
+The URI to check.
+</td>
+  </tr>
+  <tr>
+    <td>
+      <code>interval</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      The length of time to wait between repetitions of the check. This field
+      takes a positive integer and an optional suffix indicating the unit of
+      time. Possible units are:
+      <ul>
+        <li><code>ns</code> (nanoseconds)</li>
+        <li><code>us</code> (microseconds)</li>
+        <li><code>ms</code> (milliseconds)</li>
+        <li><code>s</code> (seconds)</li>
+        <li><code>m</code> (minutes)</li>
+        <li><code>h</code> (hours)</li>
+      </ul>
+    If you omit the suffix, the system interprets the value as nanoseconds.
+    The default value is 10 seconds if this field is omitted.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>threshold</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      An integer specifying the number of times the check must fail before the
+      check triggers an unhealthy state. If this filed is not specified, a
+      single failure will trigger an unhealthy state.
+    </td>
+  </tr>
+</table>
 
 ## Example: Development configuration
 

--- a/health/checks/checks.go
+++ b/health/checks/checks.go
@@ -2,9 +2,11 @@ package checks
 
 import (
 	"errors"
-	"github.com/docker/distribution/health"
 	"net/http"
 	"os"
+	"strconv"
+
+	"github.com/docker/distribution/health"
 )
 
 // FileChecker checks the existence of a file and returns and error
@@ -28,7 +30,7 @@ func HTTPChecker(r string) health.Checker {
 			return errors.New("error while checking: " + r)
 		}
 		if response.StatusCode != http.StatusOK {
-			return errors.New("downstream service returned unexpected status: " + string(response.StatusCode))
+			return errors.New("downstream service returned unexpected status: " + strconv.Itoa(response.StatusCode))
 		}
 		return nil
 	})

--- a/health/checks/checks.go
+++ b/health/checks/checks.go
@@ -24,12 +24,21 @@ func FileChecker(f string) health.Checker {
 
 // HTTPChecker does a HEAD request and verifies that the HTTP status code
 // returned matches statusCode.
-func HTTPChecker(r string, statusCode int, timeout time.Duration) health.Checker {
+func HTTPChecker(r string, statusCode int, timeout time.Duration, headers http.Header) health.Checker {
 	return health.CheckFunc(func() error {
 		client := http.Client{
 			Timeout: timeout,
 		}
-		response, err := client.Head(r)
+		req, err := http.NewRequest("HEAD", r, nil)
+		if err != nil {
+			return errors.New("error creating request: " + r)
+		}
+		for headerName, headerValues := range headers {
+			for _, headerValue := range headerValues {
+				req.Header.Add(headerName, headerValue)
+			}
+		}
+		response, err := client.Do(req)
 		if err != nil {
 			return errors.New("error while checking: " + r)
 		}

--- a/health/checks/checks.go
+++ b/health/checks/checks.go
@@ -2,15 +2,17 @@ package checks
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/docker/distribution/health"
 )
 
-// FileChecker checks the existence of a file and returns and error
-// if the file exists, taking the application out of rotation
+// FileChecker checks the existence of a file and returns an error
+// if the file exists.
 func FileChecker(f string) health.Checker {
 	return health.CheckFunc(func() error {
 		if _, err := os.Stat(f); err == nil {
@@ -20,18 +22,32 @@ func FileChecker(f string) health.Checker {
 	})
 }
 
-// HTTPChecker does a HEAD request and verifies if the HTTP status
-// code return is a 200, taking the application out of rotation if
-// otherwise
-func HTTPChecker(r string) health.Checker {
+// HTTPChecker does a HEAD request and verifies that the HTTP status code
+// returned matches statusCode.
+func HTTPChecker(r string, statusCode int, timeout time.Duration) health.Checker {
 	return health.CheckFunc(func() error {
-		response, err := http.Head(r)
+		client := http.Client{
+			Timeout: timeout,
+		}
+		response, err := client.Head(r)
 		if err != nil {
 			return errors.New("error while checking: " + r)
 		}
-		if response.StatusCode != http.StatusOK {
+		if response.StatusCode != statusCode {
 			return errors.New("downstream service returned unexpected status: " + strconv.Itoa(response.StatusCode))
 		}
+		return nil
+	})
+}
+
+// TCPChecker attempts to open a TCP connection.
+func TCPChecker(addr string, timeout time.Duration) health.Checker {
+	return health.CheckFunc(func() error {
+		conn, err := net.DialTimeout("tcp", addr, timeout)
+		if err != nil {
+			return errors.New("connection to " + addr + " failed")
+		}
+		conn.Close()
 		return nil
 	})
 }

--- a/health/checks/checks_test.go
+++ b/health/checks/checks_test.go
@@ -15,11 +15,11 @@ func TestFileChecker(t *testing.T) {
 }
 
 func TestHTTPChecker(t *testing.T) {
-	if err := HTTPChecker("https://www.google.cybertron", 200, 0).Check(); err == nil {
+	if err := HTTPChecker("https://www.google.cybertron", 200, 0, nil).Check(); err == nil {
 		t.Errorf("Google on Cybertron was expected as not exists")
 	}
 
-	if err := HTTPChecker("https://www.google.pt", 200, 0).Check(); err != nil {
+	if err := HTTPChecker("https://www.google.pt", 200, 0, nil).Check(); err != nil {
 		t.Errorf("Google at Portugal was expected as exists, error:%v", err)
 	}
 }

--- a/health/checks/checks_test.go
+++ b/health/checks/checks_test.go
@@ -15,11 +15,11 @@ func TestFileChecker(t *testing.T) {
 }
 
 func TestHTTPChecker(t *testing.T) {
-	if err := HTTPChecker("https://www.google.cybertron").Check(); err == nil {
+	if err := HTTPChecker("https://www.google.cybertron", 200, 0).Check(); err == nil {
 		t.Errorf("Google on Cybertron was expected as not exists")
 	}
 
-	if err := HTTPChecker("https://www.google.pt").Check(); err != nil {
+	if err := HTTPChecker("https://www.google.pt", 200, 0).Check(); err != nil {
 		t.Errorf("Google at Portugal was expected as exists, error:%v", err)
 	}
 }

--- a/health/doc.go
+++ b/health/doc.go
@@ -39,7 +39,7 @@
 //
 // The recommended way of registering checks is using a periodic Check.
 // PeriodicChecks run on a certain schedule and asynchronously update the
-// status of the check. This allows "CheckStatus()" to return without blocking
+// status of the check. This allows CheckStatus to return without blocking
 // on an expensive check.
 //
 // A trivial example of a check that runs every 5 seconds and shuts down our

--- a/health/health.go
+++ b/health/health.go
@@ -170,6 +170,20 @@ func Register(name string, check Checker) {
 	registeredChecks[name] = check
 }
 
+// Unregister removes the named checker.
+func Unregister(name string) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	delete(registeredChecks, name)
+}
+
+// UnregisterAll removes all registered checkers.
+func UnregisterAll() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	registeredChecks = make(map[string]Checker)
+}
+
 // RegisterFunc allows the convenience of registering a checker directly
 // from an arbitrary func() error
 func RegisterFunc(name string, check func() error) {

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -51,7 +51,7 @@ func TestReturns503IfThereAreErrorChecks(t *testing.T) {
 // the web application when things aren't so healthy.
 func TestHealthHandler(t *testing.T) {
 	// clear out existing checks.
-	registeredChecks = make(map[string]Checker)
+	DefaultRegistry = NewRegistry()
 
 	// protect an http server
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/registry/auth/silly/access_test.go
+++ b/registry/auth/silly/access_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/auth"
-	"golang.org/x/net/context"
 )
 
 func TestSillyAccessController(t *testing.T) {

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/auth"
 	"github.com/docker/libtrust"
-	"golang.org/x/net/context"
 )
 
 func makeRootKeys(numKeys int) ([]libtrust.PrivateKey, error) {

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/registry/api/errcode"
@@ -27,7 +28,6 @@ import (
 	"github.com/docker/distribution/testutil"
 	"github.com/docker/libtrust"
 	"github.com/gorilla/handlers"
-	"golang.org/x/net/context"
 )
 
 var headerConfig = http.Header{

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -281,7 +281,7 @@ func (app *App) RegisterHealthChecks(healthRegistries ...*health.Registry) {
 			statusCode = 200
 		}
 
-		checker := checks.HTTPChecker(httpChecker.URI, statusCode, httpChecker.Timeout)
+		checker := checks.HTTPChecker(httpChecker.URI, statusCode, httpChecker.Timeout, httpChecker.Headers)
 
 		if httpChecker.Threshold != 0 {
 			ctxu.GetLogger(app).Infof("configuring HTTP health check uri=%s, interval=%d, threshold=%d", httpChecker.URI, interval/time.Second, httpChecker.Threshold)

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/auth"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/distribution/registry/storage"
 	memorycache "github.com/docker/distribution/registry/storage/cache/memory"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
-	"golang.org/x/net/context"
 )
 
 // TestAppDispatcher builds an application with a test dispatcher and ensures

--- a/registry/handlers/health_test.go
+++ b/registry/handlers/health_test.go
@@ -1,0 +1,200 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/health"
+	"golang.org/x/net/context"
+)
+
+func TestFileHealthCheck(t *testing.T) {
+	// In case other tests registered checks before this one
+	health.UnregisterAll()
+
+	interval := time.Second
+
+	tmpfile, err := ioutil.TempFile(os.TempDir(), "healthcheck")
+	if err != nil {
+		t.Fatalf("could not create temporary file: %v", err)
+	}
+	defer tmpfile.Close()
+
+	config := configuration.Configuration{
+		Storage: configuration.Storage{
+			"inmemory": configuration.Parameters{},
+		},
+		Health: configuration.Health{
+			FileCheckers: []configuration.FileChecker{
+				{
+					Interval: interval,
+					File:     tmpfile.Name(),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	app := NewApp(ctx, config)
+	app.RegisterHealthChecks()
+
+	debugServer := httptest.NewServer(nil)
+
+	// Wait for health check to happen
+	<-time.After(2 * interval)
+
+	resp, err := http.Get(debugServer.URL + "/debug/health")
+	if err != nil {
+		t.Fatalf("error performing HTTP GET: %v", err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("error reading HTTP body: %v", err)
+	}
+	resp.Body.Close()
+	var decoded map[string]string
+	err = json.Unmarshal(body, &decoded)
+	if err != nil {
+		t.Fatalf("error unmarshaling json: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatal("expected 1 item in returned json")
+	}
+	if decoded[tmpfile.Name()] != "file exists" {
+		t.Fatal(`did not get "file exists" result for health check`)
+	}
+
+	os.Remove(tmpfile.Name())
+
+	<-time.After(2 * interval)
+	resp, err = http.Get(debugServer.URL + "/debug/health")
+	if err != nil {
+		t.Fatalf("error performing HTTP GET: %v", err)
+	}
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("error reading HTTP body: %v", err)
+	}
+	resp.Body.Close()
+	var decoded2 map[string]string
+	err = json.Unmarshal(body, &decoded2)
+	if err != nil {
+		t.Fatalf("error unmarshaling json: %v", err)
+	}
+	if len(decoded2) != 0 {
+		t.Fatal("expected 0 items in returned json")
+	}
+}
+
+func TestHTTPHealthCheck(t *testing.T) {
+	// In case other tests registered checks before this one
+	health.UnregisterAll()
+
+	interval := time.Second
+	threshold := 3
+
+	stopFailing := make(chan struct{})
+
+	checkedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "HEAD" {
+			t.Fatalf("expected HEAD request, got %s", r.Method)
+		}
+		select {
+		case <-stopFailing:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+
+	config := configuration.Configuration{
+		Storage: configuration.Storage{
+			"inmemory": configuration.Parameters{},
+		},
+		Health: configuration.Health{
+			HTTPCheckers: []configuration.HTTPChecker{
+				{
+					Interval:  interval,
+					URI:       checkedServer.URL,
+					Threshold: threshold,
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	app := NewApp(ctx, config)
+	app.RegisterHealthChecks()
+
+	debugServer := httptest.NewServer(nil)
+
+	for i := 0; ; i++ {
+		<-time.After(interval)
+
+		resp, err := http.Get(debugServer.URL + "/debug/health")
+		if err != nil {
+			t.Fatalf("error performing HTTP GET: %v", err)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("error reading HTTP body: %v", err)
+		}
+		resp.Body.Close()
+		var decoded map[string]string
+		err = json.Unmarshal(body, &decoded)
+		if err != nil {
+			t.Fatalf("error unmarshaling json: %v", err)
+		}
+
+		if i < threshold-1 {
+			// definitely shouldn't have hit the threshold yet
+			if len(decoded) != 0 {
+				t.Fatal("expected 1 items in returned json")
+			}
+			continue
+		}
+		if i < threshold+1 {
+			// right on the threshold - don't expect a failure yet
+			continue
+		}
+
+		if len(decoded) != 1 {
+			t.Fatal("expected 1 item in returned json")
+		}
+		if decoded[checkedServer.URL] != "downstream service returned unexpected status: 500" {
+			t.Fatal("did not get expected result for health check")
+		}
+
+		break
+	}
+
+	// Signal HTTP handler to start returning 200
+	close(stopFailing)
+
+	<-time.After(2 * interval)
+	resp, err := http.Get(debugServer.URL + "/debug/health")
+	if err != nil {
+		t.Fatalf("error performing HTTP GET: %v", err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("error reading HTTP body: %v", err)
+	}
+	resp.Body.Close()
+	var decoded map[string]string
+	err = json.Unmarshal(body, &decoded)
+	if err != nil {
+		t.Fatalf("error unmarshaling json: %v", err)
+	}
+	if len(decoded) != 0 {
+		t.Fatal("expected 0 items in returned json")
+	}
+}

--- a/registry/handlers/health_test.go
+++ b/registry/handlers/health_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/health"
-	"golang.org/x/net/context"
 )
 
 func TestFileHealthCheck(t *testing.T) {


### PR DESCRIPTION
Add a section to the config file called "health". Within this section,
"filecheckers" and "httpcheckers" list checks to run. Each check
specifies a file or URI, a time interval for the check, and a threshold
specifying how many times the check must fail to reach an unhealthy
state.

Document the new options in docs/configuration.md.

Add unit testing for both types of checkers. Add an UnregisterAll
function in the health package to support the unit tests, and an
Unregister function for consistency with Register.

Fix a string conversion problem in the health package's HTTP checker.

Fixes #271.