### PR TITLE
More consistent return from ErrorCode.Error()

### DIFF
--- a/registry/api/errcode/errors.go
+++ b/registry/api/errcode/errors.go
@@ -25,7 +25,8 @@ func (ec ErrorCode) ErrorCode() ErrorCode {
 
 // Error returns the ID/Value
 func (ec ErrorCode) Error() string {
-	return ec.Descriptor().Value
+	// NOTE(stevvooe): Cannot use message here since it may have unpopulated args.
+	return strings.ToLower(strings.Replace(ec.String(), "_", " ", -1))
 }
 
 // Descriptor returns the descriptor for the error code.
@@ -104,9 +105,7 @@ func (e Error) ErrorCode() ErrorCode {
 
 // Error returns a human readable representation of the error.
 func (e Error) Error() string {
-	return fmt.Sprintf("%s: %s",
-		strings.ToLower(strings.Replace(e.Code.String(), "_", " ", -1)),
-		e.Message)
+	return fmt.Sprintf("%s: %s", e.Code.Error(), e.Message)
 }
 
 // WithDetail will return a new Error, based on the current one, but with

--- a/registry/api/errcode/errors_test.go
+++ b/registry/api/errcode/errors_test.go
@@ -4,8 +4,32 @@ import (
 	"encoding/json"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+// TestErrorsManagement does a quick check of the Errors type to ensure that
+// members are properly pushed and marshaled.
+var ErrorCodeTest1 = Register("test.errors", ErrorDescriptor{
+	Value:          "TEST1",
+	Message:        "test error 1",
+	Description:    `Just a test message #1.`,
+	HTTPStatusCode: http.StatusInternalServerError,
+})
+
+var ErrorCodeTest2 = Register("test.errors", ErrorDescriptor{
+	Value:          "TEST2",
+	Message:        "test error 2",
+	Description:    `Just a test message #2.`,
+	HTTPStatusCode: http.StatusNotFound,
+})
+
+var ErrorCodeTest3 = Register("test.errors", ErrorDescriptor{
+	Value:          "TEST3",
+	Message:        "Sorry %q isn't valid",
+	Description:    `Just a test message #3.`,
+	HTTPStatusCode: http.StatusNotFound,
+})
 
 // TestErrorCodes ensures that error code format, mappings and
 // marshaling/unmarshaling. round trips are stable.
@@ -56,32 +80,14 @@ func TestErrorCodes(t *testing.T) {
 		if ecUnmarshaled != ec {
 			t.Fatalf("unexpected error code during error code marshal/unmarshal: %v != %v", ecUnmarshaled, ec)
 		}
+
+		expectedErrorString := strings.ToLower(strings.Replace(ec.Descriptor().Value, "_", " ", -1))
+		if ec.Error() != expectedErrorString {
+			t.Fatalf("unexpected return from %v.Error(): %q != %q", ec, ec.Error(), expectedErrorString)
+		}
 	}
 
 }
-
-// TestErrorsManagement does a quick check of the Errors type to ensure that
-// members are properly pushed and marshaled.
-var ErrorCodeTest1 = Register("v2.errors", ErrorDescriptor{
-	Value:          "TEST1",
-	Message:        "test error 1",
-	Description:    `Just a test message #1.`,
-	HTTPStatusCode: http.StatusInternalServerError,
-})
-
-var ErrorCodeTest2 = Register("v2.errors", ErrorDescriptor{
-	Value:          "TEST2",
-	Message:        "test error 2",
-	Description:    `Just a test message #2.`,
-	HTTPStatusCode: http.StatusNotFound,
-})
-
-var ErrorCodeTest3 = Register("v2.errors", ErrorDescriptor{
-	Value:          "TEST3",
-	Message:        "Sorry %q isn't valid",
-	Description:    `Just a test message #3.`,
-	HTTPStatusCode: http.StatusNotFound,
-})
 
 func TestErrorsManagement(t *testing.T) {
 	var errs Errors


### PR DESCRIPTION
To bring ErrorCode into liine with Go conventions, ErrorCode.Error() now
returns the "nice" value of the error code. This ensures error message assembly
works similar to commonly used Go conventions when directly using ErrorCode as
an error.

Signed-off-by: Stephen J Day <stephen.day@docker.com>