### PR TITLE
Move manifest package to schema1

### DIFF
--- a/manifest/doc.go
+++ b/manifest/doc.go
@@ -1,0 +1,1 @@
+package manifest

--- a/manifest/schema1/manifest.go
+++ b/manifest/schema1/manifest.go
@@ -1,9 +1,10 @@
-package manifest
+package schema1
 
 import (
 	"encoding/json"
 
 	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest"
 	"github.com/docker/libtrust"
 )
 
@@ -17,18 +18,18 @@ const (
 	ManifestMediaType = "application/vnd.docker.distribution.manifest.v1+json"
 )
 
-// Versioned provides a struct with just the manifest schemaVersion. Incoming
-// content with unknown schema version can be decoded against this struct to
-// check the version.
-type Versioned struct {
-	// SchemaVersion is the image manifest schema that this image follows
-	SchemaVersion int `json:"schemaVersion"`
-}
+var (
+	// SchemaVersion provides a pre-initialized version structure for this
+	// packages version of the manifest.
+	SchemaVersion = manifest.Versioned{
+		SchemaVersion: 1,
+	}
+)
 
 // Manifest provides the base accessible fields for working with V2 image
 // format in the registry.
 type Manifest struct {
-	Versioned
+	manifest.Versioned
 
 	// Name is the name of the image's repository
 	Name string `json:"name"`

--- a/manifest/schema1/manifest_test.go
+++ b/manifest/schema1/manifest_test.go
@@ -1,4 +1,4 @@
-package manifest
+package schema1
 
 import (
 	"bytes"
@@ -80,11 +80,9 @@ func genEnv(t *testing.T) *testEnv {
 	name, tag := "foo/bar", "test"
 
 	m := Manifest{
-		Versioned: Versioned{
-			SchemaVersion: 1,
-		},
-		Name: name,
-		Tag:  tag,
+		Versioned: SchemaVersion,
+		Name:      name,
+		Tag:       tag,
 		FSLayers: []FSLayer{
 			{
 				BlobSum: "asdf",

--- a/manifest/schema1/sign.go
+++ b/manifest/schema1/sign.go
@@ -1,4 +1,4 @@
-package manifest
+package schema1
 
 import (
 	"crypto/x509"

--- a/manifest/schema1/verify.go
+++ b/manifest/schema1/verify.go
@@ -1,4 +1,4 @@
-package manifest
+package schema1
 
 import (
 	"crypto/x509"

--- a/manifest/versioned.go
+++ b/manifest/versioned.go
@@ -1,0 +1,9 @@
+package manifest
+
+// Versioned provides a struct with just the manifest schemaVersion. Incoming
+// content with unknown schema version can be decoded against this struct to
+// check the version.
+type Versioned struct {
+	// SchemaVersion is the image manifest schema that this image follows
+	SchemaVersion int `json:"schemaVersion"`
+}

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/uuid"
 )
 
@@ -53,15 +53,15 @@ func NewRequestRecord(id string, r *http.Request) RequestRecord {
 	}
 }
 
-func (b *bridge) ManifestPushed(repo string, sm *manifest.SignedManifest) error {
+func (b *bridge) ManifestPushed(repo string, sm *schema1.SignedManifest) error {
 	return b.createManifestEventAndWrite(EventActionPush, repo, sm)
 }
 
-func (b *bridge) ManifestPulled(repo string, sm *manifest.SignedManifest) error {
+func (b *bridge) ManifestPulled(repo string, sm *schema1.SignedManifest) error {
 	return b.createManifestEventAndWrite(EventActionPull, repo, sm)
 }
 
-func (b *bridge) ManifestDeleted(repo string, sm *manifest.SignedManifest) error {
+func (b *bridge) ManifestDeleted(repo string, sm *schema1.SignedManifest) error {
 	return b.createManifestEventAndWrite(EventActionDelete, repo, sm)
 }
 
@@ -77,7 +77,7 @@ func (b *bridge) BlobDeleted(repo string, desc distribution.Descriptor) error {
 	return b.createBlobEventAndWrite(EventActionDelete, repo, desc)
 }
 
-func (b *bridge) createManifestEventAndWrite(action string, repo string, sm *manifest.SignedManifest) error {
+func (b *bridge) createManifestEventAndWrite(action string, repo string, sm *schema1.SignedManifest) error {
 	manifestEvent, err := b.createManifestEvent(action, repo, sm)
 	if err != nil {
 		return err
@@ -86,9 +86,9 @@ func (b *bridge) createManifestEventAndWrite(action string, repo string, sm *man
 	return b.sink.Write(*manifestEvent)
 }
 
-func (b *bridge) createManifestEvent(action string, repo string, sm *manifest.SignedManifest) (*Event, error) {
+func (b *bridge) createManifestEvent(action string, repo string, sm *schema1.SignedManifest) (*Event, error) {
 	event := b.createEvent(action)
-	event.Target.MediaType = manifest.ManifestMediaType
+	event.Target.MediaType = schema1.ManifestMediaType
 	event.Target.Repository = repo
 
 	p, err := sm.Payload()

--- a/notifications/bridge_test.go
+++ b/notifications/bridge_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/docker/libtrust"
 
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/uuid"
@@ -27,12 +27,12 @@ var (
 		Name: "test",
 	}
 	request = RequestRecord{}
-	m       = manifest.Manifest{
+	m       = schema1.Manifest{
 		Name: repo,
 		Tag:  "latest",
 	}
 
-	sm      *manifest.SignedManifest
+	sm      *schema1.SignedManifest
 	payload []byte
 	dgst    digest.Digest
 )
@@ -80,7 +80,7 @@ func createTestEnv(t *testing.T, fn testSinkFn) Listener {
 		t.Fatalf("error generating private key: %v", err)
 	}
 
-	sm, err = manifest.Sign(&m, pk)
+	sm, err = schema1.Sign(&m, pk)
 	if err != nil {
 		t.Fatalf("error signing manifest: %v", err)
 	}

--- a/notifications/event_test.go
+++ b/notifications/event_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 )
 
 // TestEventJSONFormat provides silly test to detect if the event format or
@@ -120,7 +120,7 @@ func TestEventEnvelopeJSONFormat(t *testing.T) {
 	manifestPush.Target.Digest = "sha256:0123456789abcdef0"
 	manifestPush.Target.Length = 1
 	manifestPush.Target.Size = 1
-	manifestPush.Target.MediaType = manifest.ManifestMediaType
+	manifestPush.Target.MediaType = schema1.ManifestMediaType
 	manifestPush.Target.Repository = "library/test"
 	manifestPush.Target.URL = "http://example.com/v2/library/test/manifests/latest"
 

--- a/notifications/http_test.go
+++ b/notifications/http_test.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 )
 
 // TestHTTPSink mocks out an http endpoint and notifies it under a couple of
@@ -75,12 +75,12 @@ func TestHTTPSink(t *testing.T) {
 		{
 			statusCode: http.StatusOK,
 			events: []Event{
-				createTestEvent("push", "library/test", manifest.ManifestMediaType)},
+				createTestEvent("push", "library/test", schema1.ManifestMediaType)},
 		},
 		{
 			statusCode: http.StatusOK,
 			events: []Event{
-				createTestEvent("push", "library/test", manifest.ManifestMediaType),
+				createTestEvent("push", "library/test", schema1.ManifestMediaType),
 				createTestEvent("push", "library/test", layerMediaType),
 				createTestEvent("push", "library/test", layerMediaType),
 			},

--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -7,18 +7,18 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 )
 
 // ManifestListener describes a set of methods for listening to events related to manifests.
 type ManifestListener interface {
-	ManifestPushed(repo string, sm *manifest.SignedManifest) error
-	ManifestPulled(repo string, sm *manifest.SignedManifest) error
+	ManifestPushed(repo string, sm *schema1.SignedManifest) error
+	ManifestPulled(repo string, sm *schema1.SignedManifest) error
 
 	// TODO(stevvooe): Please note that delete support is still a little shaky
 	// and we'll need to propagate these in the future.
 
-	ManifestDeleted(repo string, sm *manifest.SignedManifest) error
+	ManifestDeleted(repo string, sm *schema1.SignedManifest) error
 }
 
 // BlobListener describes a listener that can respond to layer related events.
@@ -74,7 +74,7 @@ type manifestServiceListener struct {
 	parent *repositoryListener
 }
 
-func (msl *manifestServiceListener) Get(dgst digest.Digest) (*manifest.SignedManifest, error) {
+func (msl *manifestServiceListener) Get(dgst digest.Digest) (*schema1.SignedManifest, error) {
 	sm, err := msl.ManifestService.Get(dgst)
 	if err == nil {
 		if err := msl.parent.listener.ManifestPulled(msl.parent.Repository.Name(), sm); err != nil {
@@ -85,7 +85,7 @@ func (msl *manifestServiceListener) Get(dgst digest.Digest) (*manifest.SignedMan
 	return sm, err
 }
 
-func (msl *manifestServiceListener) Put(sm *manifest.SignedManifest) error {
+func (msl *manifestServiceListener) Put(sm *schema1.SignedManifest) error {
 	err := msl.ManifestService.Put(sm)
 
 	if err == nil {
@@ -97,7 +97,7 @@ func (msl *manifestServiceListener) Put(sm *manifest.SignedManifest) error {
 	return err
 }
 
-func (msl *manifestServiceListener) GetByTag(tag string, options ...distribution.ManifestServiceOption) (*manifest.SignedManifest, error) {
+func (msl *manifestServiceListener) GetByTag(tag string, options ...distribution.ManifestServiceOption) (*schema1.SignedManifest, error) {
 	sm, err := msl.ManifestService.GetByTag(tag, options...)
 	if err == nil {
 		if err := msl.parent.listener.ManifestPulled(msl.parent.Repository.Name(), sm); err != nil {

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/registry/storage"
 	"github.com/docker/distribution/registry/storage/cache/memory"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
@@ -54,18 +55,18 @@ type testListener struct {
 	ops map[string]int
 }
 
-func (tl *testListener) ManifestPushed(repo string, sm *manifest.SignedManifest) error {
+func (tl *testListener) ManifestPushed(repo string, sm *schema1.SignedManifest) error {
 	tl.ops["manifest:push"]++
 
 	return nil
 }
 
-func (tl *testListener) ManifestPulled(repo string, sm *manifest.SignedManifest) error {
+func (tl *testListener) ManifestPulled(repo string, sm *schema1.SignedManifest) error {
 	tl.ops["manifest:pull"]++
 	return nil
 }
 
-func (tl *testListener) ManifestDeleted(repo string, sm *manifest.SignedManifest) error {
+func (tl *testListener) ManifestDeleted(repo string, sm *schema1.SignedManifest) error {
 	tl.ops["manifest:delete"]++
 	return nil
 }
@@ -94,7 +95,7 @@ func checkExerciseRepository(t *testing.T, repository distribution.Repository) {
 	// update counts. Basically, it would make writing tests a lot easier.
 	ctx := context.Background()
 	tag := "thetag"
-	m := manifest.Manifest{
+	m := schema1.Manifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 1,
 		},
@@ -127,7 +128,7 @@ func checkExerciseRepository(t *testing.T, repository distribution.Repository) {
 			t.Fatalf("unexpected error finishing upload: %v", err)
 		}
 
-		m.FSLayers = append(m.FSLayers, manifest.FSLayer{
+		m.FSLayers = append(m.FSLayers, schema1.FSLayer{
 			BlobSum: dgst,
 		})
 
@@ -144,7 +145,7 @@ func checkExerciseRepository(t *testing.T, repository distribution.Repository) {
 		t.Fatalf("unexpected error generating key: %v", err)
 	}
 
-	sm, err := manifest.Sign(&m, pk)
+	sm, err := schema1.Sign(&m, pk)
 	if err != nil {
 		t.Fatalf("unexpected error signing manifest: %v", err)
 	}

--- a/registry.go
+++ b/registry.go
@@ -3,7 +3,7 @@ package distribution
 import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 )
 
 // Scope defines the set of items that match a namespace.
@@ -76,13 +76,13 @@ type ManifestService interface {
 	Exists(dgst digest.Digest) (bool, error)
 
 	// Get retrieves the identified by the digest, if it exists.
-	Get(dgst digest.Digest) (*manifest.SignedManifest, error)
+	Get(dgst digest.Digest) (*schema1.SignedManifest, error)
 
 	// Delete removes the manifest, if it exists.
 	Delete(dgst digest.Digest) error
 
 	// Put creates or updates the manifest.
-	Put(manifest *manifest.SignedManifest) error
+	Put(manifest *schema1.SignedManifest) error
 
 	// TODO(stevvooe): The methods after this message should be moved to a
 	// discrete TagService, per active proposals.
@@ -94,7 +94,7 @@ type ManifestService interface {
 	ExistsByTag(tag string) (bool, error)
 
 	// GetByTag retrieves the named manifest, if it exists.
-	GetByTag(tag string, options ...ManifestServiceOption) (*manifest.SignedManifest, error)
+	GetByTag(tag string, options ...ManifestServiceOption) (*schema1.SignedManifest, error)
 
 	// TODO(stevvooe): There are several changes that need to be done to this
 	// interface:

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/distribution/registry/storage/cache"
@@ -242,7 +242,7 @@ func (ms *manifests) ExistsByTag(tag string) (bool, error) {
 	return false, handleErrorResponse(resp)
 }
 
-func (ms *manifests) Get(dgst digest.Digest) (*manifest.SignedManifest, error) {
+func (ms *manifests) Get(dgst digest.Digest) (*schema1.SignedManifest, error) {
 	// Call by Tag endpoint since the API uses the same
 	// URL endpoint for tags and digests.
 	return ms.GetByTag(dgst.String())
@@ -262,7 +262,7 @@ func AddEtagToTag(tag, etag string) distribution.ManifestServiceOption {
 	}
 }
 
-func (ms *manifests) GetByTag(tag string, options ...distribution.ManifestServiceOption) (*manifest.SignedManifest, error) {
+func (ms *manifests) GetByTag(tag string, options ...distribution.ManifestServiceOption) (*schema1.SignedManifest, error) {
 	for _, option := range options {
 		err := option(ms)
 		if err != nil {
@@ -290,7 +290,7 @@ func (ms *manifests) GetByTag(tag string, options ...distribution.ManifestServic
 	if resp.StatusCode == http.StatusNotModified {
 		return nil, nil
 	} else if SuccessStatus(resp.StatusCode) {
-		var sm manifest.SignedManifest
+		var sm schema1.SignedManifest
 		decoder := json.NewDecoder(resp.Body)
 
 		if err := decoder.Decode(&sm); err != nil {
@@ -301,7 +301,7 @@ func (ms *manifests) GetByTag(tag string, options ...distribution.ManifestServic
 	return nil, handleErrorResponse(resp)
 }
 
-func (ms *manifests) Put(m *manifest.SignedManifest) error {
+func (ms *manifests) Put(m *schema1.SignedManifest) error {
 	manifestURL, err := ms.ub.BuildManifestURL(ms.name, m.Tag)
 	if err != nil {
 		return err

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/testutil"
 )
@@ -419,19 +420,19 @@ func TestBlobUploadMonolithic(t *testing.T) {
 	}
 }
 
-func newRandomSchemaV1Manifest(name, tag string, blobCount int) (*manifest.SignedManifest, digest.Digest) {
-	blobs := make([]manifest.FSLayer, blobCount)
-	history := make([]manifest.History, blobCount)
+func newRandomSchemaV1Manifest(name, tag string, blobCount int) (*schema1.SignedManifest, digest.Digest) {
+	blobs := make([]schema1.FSLayer, blobCount)
+	history := make([]schema1.History, blobCount)
 
 	for i := 0; i < blobCount; i++ {
 		dgst, blob := newRandomBlob((i % 5) * 16)
 
-		blobs[i] = manifest.FSLayer{BlobSum: dgst}
-		history[i] = manifest.History{V1Compatibility: fmt.Sprintf("{\"Hex\": \"%x\"}", blob)}
+		blobs[i] = schema1.FSLayer{BlobSum: dgst}
+		history[i] = schema1.History{V1Compatibility: fmt.Sprintf("{\"Hex\": \"%x\"}", blob)}
 	}
 
-	m := &manifest.SignedManifest{
-		Manifest: manifest.Manifest{
+	m := &schema1.SignedManifest{
+		Manifest: schema1.Manifest{
 			Name:         name,
 			Tag:          tag,
 			Architecture: "x86",
@@ -521,7 +522,7 @@ func addTestManifest(repo, reference string, content []byte, m *testutil.Request
 
 }
 
-func checkEqualManifest(m1, m2 *manifest.SignedManifest) error {
+func checkEqualManifest(m1, m2 *schema1.SignedManifest) error {
 	if m1.Name != m2.Name {
 		return fmt.Errorf("name does not match %q != %q", m1.Name, m2.Name)
 	}

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/distribution"
 	ctxu "github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/gorilla/handlers"
@@ -57,7 +57,7 @@ func (imh *imageManifestHandler) GetImageManifest(w http.ResponseWriter, r *http
 		return
 	}
 
-	var sm *manifest.SignedManifest
+	var sm *schema1.SignedManifest
 	if imh.Tag != "" {
 		sm, err = manifests.GetByTag(imh.Tag)
 	} else {
@@ -119,7 +119,7 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 		return
 	}
 
-	var manifest manifest.SignedManifest
+	var manifest schema1.SignedManifest
 	if err := json.Unmarshal(jsonBuf.Bytes(), &manifest); err != nil {
 		imh.Errors = append(imh.Errors, v2.ErrorCodeManifestInvalid.WithDetail(err))
 		return
@@ -229,7 +229,7 @@ func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *h
 
 // digestManifest takes a digest of the given manifest. This belongs somewhere
 // better but we'll wait for a refactoring cycle to find that real somewhere.
-func digestManifest(ctx context.Context, sm *manifest.SignedManifest) (digest.Digest, error) {
+func digestManifest(ctx context.Context, sm *schema1.SignedManifest) (digest.Digest, error) {
 	p, err := sm.Payload()
 	if err != nil {
 		if !strings.Contains(err.Error(), "missing signature key") {

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/proxy/scheduler"
 )
@@ -36,7 +36,7 @@ func (pms proxyManifestStore) Exists(dgst digest.Digest) (bool, error) {
 	return pms.remoteManifests.Exists(dgst)
 }
 
-func (pms proxyManifestStore) Get(dgst digest.Digest) (*manifest.SignedManifest, error) {
+func (pms proxyManifestStore) Get(dgst digest.Digest) (*schema1.SignedManifest, error) {
 	sm, err := pms.localManifests.Get(dgst)
 	if err == nil {
 		proxyMetrics.ManifestPush(uint64(len(sm.Raw)))
@@ -81,7 +81,7 @@ func (pms proxyManifestStore) ExistsByTag(tag string) (bool, error) {
 	return pms.remoteManifests.ExistsByTag(tag)
 }
 
-func (pms proxyManifestStore) GetByTag(tag string, options ...distribution.ManifestServiceOption) (*manifest.SignedManifest, error) {
+func (pms proxyManifestStore) GetByTag(tag string, options ...distribution.ManifestServiceOption) (*schema1.SignedManifest, error) {
 	var localDigest digest.Digest
 
 	localManifest, err := pms.localManifests.GetByTag(tag, options...)
@@ -100,7 +100,7 @@ func (pms proxyManifestStore) GetByTag(tag string, options ...distribution.Manif
 	}
 
 fromremote:
-	var sm *manifest.SignedManifest
+	var sm *schema1.SignedManifest
 	sm, err = pms.remoteManifests.GetByTag(tag, client.AddEtagToTag(tag, localDigest.String()))
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ fromremote:
 	return sm, err
 }
 
-func manifestDigest(sm *manifest.SignedManifest) (digest.Digest, error) {
+func manifestDigest(sm *schema1.SignedManifest) (digest.Digest, error) {
 	payload, err := sm.Payload()
 	if err != nil {
 		return "", err
@@ -145,7 +145,7 @@ func manifestDigest(sm *manifest.SignedManifest) (digest.Digest, error) {
 	return dgst, nil
 }
 
-func (pms proxyManifestStore) Put(manifest *manifest.SignedManifest) error {
+func (pms proxyManifestStore) Put(manifest *schema1.SignedManifest) error {
 	return distribution.ErrUnsupported
 }
 

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/registry/proxy/scheduler"
 	"github.com/docker/distribution/registry/storage"
 	"github.com/docker/distribution/registry/storage/cache/memory"
@@ -51,17 +52,17 @@ func (sm statsManifest) ExistsByTag(tag string) (bool, error) {
 	return sm.manifests.ExistsByTag(tag)
 }
 
-func (sm statsManifest) Get(dgst digest.Digest) (*manifest.SignedManifest, error) {
+func (sm statsManifest) Get(dgst digest.Digest) (*schema1.SignedManifest, error) {
 	sm.stats["get"]++
 	return sm.manifests.Get(dgst)
 }
 
-func (sm statsManifest) GetByTag(tag string, options ...distribution.ManifestServiceOption) (*manifest.SignedManifest, error) {
+func (sm statsManifest) GetByTag(tag string, options ...distribution.ManifestServiceOption) (*schema1.SignedManifest, error) {
 	sm.stats["getbytag"]++
 	return sm.manifests.GetByTag(tag, options...)
 }
 
-func (sm statsManifest) Put(manifest *manifest.SignedManifest) error {
+func (sm statsManifest) Put(manifest *schema1.SignedManifest) error {
 	sm.stats["put"]++
 	return sm.manifests.Put(manifest)
 }
@@ -126,7 +127,7 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 }
 
 func populateRepo(t *testing.T, ctx context.Context, repository distribution.Repository, name, tag string) (digest.Digest, error) {
-	m := manifest.Manifest{
+	m := schema1.Manifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 1,
 		},
@@ -159,7 +160,7 @@ func populateRepo(t *testing.T, ctx context.Context, repository distribution.Rep
 		t.Fatalf("unexpected error generating private key: %v", err)
 	}
 
-	sm, err := manifest.Sign(&m, pk)
+	sm, err := schema1.Sign(&m, pk)
 	if err != nil {
 		t.Fatalf("error signing manifest: %v", err)
 	}

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/registry/storage/cache/memory"
 	"github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
@@ -75,7 +76,7 @@ func TestManifestStorage(t *testing.T) {
 		}
 	}
 
-	m := manifest.Manifest{
+	m := schema1.Manifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 1,
 		},
@@ -94,7 +95,7 @@ func TestManifestStorage(t *testing.T) {
 		dgst := digest.Digest(ds)
 
 		testLayers[digest.Digest(dgst)] = rs
-		m.FSLayers = append(m.FSLayers, manifest.FSLayer{
+		m.FSLayers = append(m.FSLayers, schema1.FSLayer{
 			BlobSum: dgst,
 		})
 	}
@@ -104,7 +105,7 @@ func TestManifestStorage(t *testing.T) {
 		t.Fatalf("unexpected error generating private key: %v", err)
 	}
 
-	sm, merr := manifest.Sign(&m, pk)
+	sm, merr := schema1.Sign(&m, pk)
 	if merr != nil {
 		t.Fatalf("error signing manifest: %v", err)
 	}
@@ -232,7 +233,7 @@ func TestManifestStorage(t *testing.T) {
 		t.Fatalf("unexpected error generating private key: %v", err)
 	}
 
-	sm2, err := manifest.Sign(&m, pk2)
+	sm2, err := schema1.Sign(&m, pk2)
 	if err != nil {
 		t.Fatalf("unexpected error signing manifest: %v", err)
 	}
@@ -260,7 +261,7 @@ func TestManifestStorage(t *testing.T) {
 		t.Fatalf("unexpected error fetching manifest: %v", err)
 	}
 
-	if _, err := manifest.Verify(fetched); err != nil {
+	if _, err := schema1.Verify(fetched); err != nil {
 		t.Fatalf("unexpected error verifying manifest: %v", err)
 	}
 

--- a/registry/storage/revisionstore.go
+++ b/registry/storage/revisionstore.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/libtrust"
 )
 
@@ -18,7 +18,7 @@ type revisionStore struct {
 }
 
 // get retrieves the manifest, keyed by revision digest.
-func (rs *revisionStore) get(ctx context.Context, revision digest.Digest) (*manifest.SignedManifest, error) {
+func (rs *revisionStore) get(ctx context.Context, revision digest.Digest) (*schema1.SignedManifest, error) {
 	// Ensure that this revision is available in this repository.
 	_, err := rs.blobStore.Stat(ctx, revision)
 	if err != nil {
@@ -64,7 +64,7 @@ func (rs *revisionStore) get(ctx context.Context, revision digest.Digest) (*mani
 		return nil, err
 	}
 
-	var sm manifest.SignedManifest
+	var sm schema1.SignedManifest
 	if err := json.Unmarshal(raw, &sm); err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (rs *revisionStore) get(ctx context.Context, revision digest.Digest) (*mani
 
 // put stores the manifest in the repository, if not already present. Any
 // updated signatures will be stored, as well.
-func (rs *revisionStore) put(ctx context.Context, sm *manifest.SignedManifest) (distribution.Descriptor, error) {
+func (rs *revisionStore) put(ctx context.Context, sm *schema1.SignedManifest) (distribution.Descriptor, error) {
 	// Resolve the payload in the manifest.
 	payload, err := sm.Payload()
 	if err != nil {
@@ -82,7 +82,7 @@ func (rs *revisionStore) put(ctx context.Context, sm *manifest.SignedManifest) (
 	}
 
 	// Digest and store the manifest payload in the blob store.
-	revision, err := rs.blobStore.Put(ctx, manifest.ManifestMediaType, payload)
+	revision, err := rs.blobStore.Put(ctx, schema1.ManifestMediaType, payload)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("error putting payload into blobstore: %v", err)
 		return distribution.Descriptor{}, err


### PR DESCRIPTION
As we begin our march towards multi-arch, we must prepare for the reality of
multiple manifest schemas. This is the beginning of a set of changes to
facilitate this. We are both moving this package into its target position where
it may live peacefully next to other manfiest versions.

Signed-off-by: Stephen J Day <stephen.day@docker.com>