### PR TITLE
Skip creating swift container if already exists

### DIFF
--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -165,8 +165,12 @@ func New(params Parameters) (*Driver, error) {
 		return nil, fmt.Errorf("Swift authentication failed: %s", err)
 	}
 
-	if err := ct.ContainerCreate(params.Container, nil); err != nil {
-		return nil, fmt.Errorf("Failed to create container %s (%s)", params.Container, err)
+	if _, _, err := ct.Container(params.Container); err == swift.ContainerNotFound {
+		if err := ct.ContainerCreate(params.Container, nil); err != nil {
+			return nil, fmt.Errorf("Failed to create container %s (%s)", params.Container, err)
+		}
+	} else if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve info about container %s (%s)", params.Container, err)
 	}
 
 	d := &driver{


### PR DESCRIPTION
With some container ACLs, container creation will error with access denied if the container already exists.