### PR TITLE
Remove mux dependency from the registry client.

### DIFF
--- a/context/http.go
+++ b/context/http.go
@@ -10,7 +10,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/uuid"
-	"github.com/gorilla/mux"
 )
 
 // Common errors used with this package.
@@ -134,22 +133,6 @@ func GetResponseWriter(ctx Context) (http.ResponseWriter, error) {
 	return rw, nil
 }
 
-// getVarsFromRequest let's us change request vars implementation for testing
-// and maybe future changes.
-var getVarsFromRequest = mux.Vars
-
-// WithVars extracts gorilla/mux vars and makes them available on the returned
-// context. Variables are available at keys with the prefix "vars.". For
-// example, if looking for the variable "name", it can be accessed as
-// "vars.name". Implementations that are accessing values need not know that
-// the underlying context is implemented with gorilla/mux vars.
-func WithVars(ctx Context, r *http.Request) Context {
-	return &muxVarsContext{
-		Context: ctx,
-		vars:    getVarsFromRequest(r),
-	}
-}
-
 // GetRequestLogger returns a logger that contains fields from the request in
 // the current context. If the request is not available in the context, no
 // fields will display. Request loggers can safely be pushed onto the context.
@@ -241,29 +224,6 @@ func (ctx *httpRequestContext) Value(key interface{}) interface{} {
 	}
 
 fallback:
-	return ctx.Context.Value(key)
-}
-
-type muxVarsContext struct {
-	Context
-	vars map[string]string
-}
-
-func (ctx *muxVarsContext) Value(key interface{}) interface{} {
-	if keyStr, ok := key.(string); ok {
-		if keyStr == "vars" {
-			return ctx.vars
-		}
-
-		if strings.HasPrefix(keyStr, "vars.") {
-			keyStr = strings.TrimPrefix(keyStr, "vars.")
-		}
-
-		if v, ok := ctx.vars[keyStr]; ok {
-			return v
-		}
-	}
-
 	return ctx.Context.Value(key)
 }
 

--- a/context/http_test.go
+++ b/context/http_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -176,47 +175,6 @@ func TestWithResponseWriter(t *testing.T) {
 
 	if ctx.Value("http.response.status") != http.StatusBadRequest {
 		t.Fatalf("unexpected response status in context: %v != %v", ctx.Value("http.response.status"), http.StatusBadRequest)
-	}
-}
-
-func TestWithVars(t *testing.T) {
-	var req http.Request
-	vars := map[string]string{
-		"foo": "asdf",
-		"bar": "qwer",
-	}
-
-	getVarsFromRequest = func(r *http.Request) map[string]string {
-		if r != &req {
-			t.Fatalf("unexpected request: %v != %v", r, req)
-		}
-
-		return vars
-	}
-
-	ctx := WithVars(Background(), &req)
-	for _, testcase := range []struct {
-		key      string
-		expected interface{}
-	}{
-		{
-			key:      "vars",
-			expected: vars,
-		},
-		{
-			key:      "vars.foo",
-			expected: "asdf",
-		},
-		{
-			key:      "vars.bar",
-			expected: "qwer",
-		},
-	} {
-		v := ctx.Value(testcase.key)
-
-		if !reflect.DeepEqual(v, testcase.expected) {
-			t.Fatalf("%q: %v != %v", testcase.key, v, testcase.expected)
-		}
 	}
 }
 

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -633,7 +633,7 @@ func (app *App) logError(context context.Context, errors errcode.Errors) {
 // called once per request.
 func (app *App) context(w http.ResponseWriter, r *http.Request) *Context {
 	ctx := defaultContextManager.context(app, w, r)
-	ctx = ctxu.WithVars(ctx, r)
+	ctx = contextWithVars(ctx, r)
 	ctx = ctxu.WithLogger(ctx, ctxu.GetLogger(ctx,
 		"vars.name",
 		"vars.reference",

--- a/registry/handlers/context_test.go
+++ b/registry/handlers/context_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestContextWithVars(t *testing.T) {
+	var req http.Request
+	vars := map[string]string{
+		"foo": "asdf",
+		"bar": "qwer",
+	}
+
+	getVarsFromRequest = func(r *http.Request) map[string]string {
+		if r != &req {
+			t.Fatalf("unexpected request: %v != %v", r, req)
+		}
+
+		return vars
+	}
+
+	ctx := contextWithVars(context.Background(), &req)
+	for _, testcase := range []struct {
+		key      string
+		expected interface{}
+	}{
+		{
+			key:      "vars",
+			expected: vars,
+		},
+		{
+			key:      "vars.foo",
+			expected: "asdf",
+		},
+		{
+			key:      "vars.bar",
+			expected: "qwer",
+		},
+	} {
+		v := ctx.Value(testcase.key)
+
+		if !reflect.DeepEqual(v, testcase.expected) {
+			t.Fatalf("%q: %v != %v", testcase.key, v, testcase.expected)
+		}
+	}
+}


### PR DESCRIPTION
By moving functions that are only used by the handlers to
the registry/handlers package.

Signed-off-by: David Calavera <david.calavera@gmail.com>