### PR TITLE
s3 Compatible: registry s3 driver support radosgw

### DIFF
--- a/registry/storage/driver/s3/s3_test.go
+++ b/registry/storage/driver/s3/s3_test.go
@@ -26,6 +26,7 @@ func init() {
 	bucket := os.Getenv("S3_BUCKET")
 	encrypt := os.Getenv("S3_ENCRYPT")
 	secure := os.Getenv("S3_SECURE")
+	s3EntryPoint := os.Getenv("S3_ENTRYPOINT")
 	v4auth := os.Getenv("S3_USE_V4_AUTH")
 	region := os.Getenv("AWS_REGION")
 	root, err := ioutil.TempDir("", "driver-")
@@ -59,11 +60,23 @@ func init() {
 			}
 		}
 
+		var realregion aws.Region
+		if region == "generic" {
+			if s3EntryPoint == "" {
+				return nil, fmt.Errorf("No S3 endpoint for generic region")
+			}
+			realregion = aws.Region{Name: region, S3Endpoint: s3EntryPoint, S3LocationConstraint: true}
+		} else {
+			realregion = aws.GetRegion(region)
+			if realregion.Name == "" {
+				return nil, fmt.Errorf("Invalid region provided: %v", region)
+			}
+		}
 		parameters := DriverParameters{
 			accessKey,
 			secretKey,
 			bucket,
-			aws.GetRegion(region),
+			realregion,
 			encryptBool,
 			secureBool,
 			v4AuthBool,
@@ -76,6 +89,12 @@ func init() {
 
 	// Skip S3 storage driver tests if environment variable parameters are not provided
 	skipS3 = func() string {
+		if region == "generic" && (accessKey == "" || secretKey == "" || bucket == "" || regionSupportsHead == "" || s3EntryPoint == "") {
+			return "Must set AWS_ACCESS_KEY, AWS_SECRET_KEY, S3_BUCKET, REGION_SUPPORTS_HEAD, and S3_ENTRYPOINT to test RadosGW as storage"
+		}
+		if region == "generic" {
+			return ""
+		}
 		if accessKey == "" || secretKey == "" || region == "" || bucket == "" || encrypt == "" {
 			return "Must set AWS_ACCESS_KEY, AWS_SECRET_KEY, AWS_REGION, S3_BUCKET, and S3_ENCRYPT to run S3 tests"
 		}


### PR DESCRIPTION
Now, registry s3 driver unsupport RadosGW. 
The pull request https://github.com/docker/distribution/pull/808 @lorieri aims to this issue. Regrettably,  pull request https://github.com/docker/distribution/pull/808 is not enough beacuse there are several amazon S3 REST API that registry used but RadosGW unsupport:

 - regionendpoit configurable (solved by https://github.com/docker/distribution/pull/808)
 - HEAD for object info (solved by https://github.com/docker/distribution/pull/808)
 - x-amz-copy-source-range (used when upload multi part)
 - x-amz-copy-source (used when upload multi part)
 - delete multiple objects (used when delele multiple objects )
 - complete upload multiple part need http header content-length (needed by RadosGW fix in https://github.com/AdRoll/goamz/pull/392)


**This pull request  aims to fix S3 compatibility  mentioned above, and this PR work with two PRs below**
  -  https://github.com/AdRoll/goamz/pull/392 [**merged**]
  -  https://github.com/docker/distribution/pull/808 [**waiting merge**]

**About test, if there is a RadosGW , set env below to run CI tests using RadosGW as storage**

AWS_REGION=generic
AWS_ACCESS_KEY=xxxxx
AWS_SECRET_KEY=xxxxx
S3_BUCKET=xxxx
S3_ENTRYPOINT=xxxx

**In my environment, I set env mentioned above using a RadosGW as storage , all the tests in registry/storage/driver/testsuites/testsuites.go passed**

Signed-off-by: wangmingshuai <736808191@qq.com>