### PR TITLE
s3 Compatible: registry s3 driver support radosgw

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -7,15 +7,15 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/AdRoll/goamz/aws",
-			"Rev": "f8c4952d5bc3056c0ca6711a1f56bc88b828d989"
+			"Rev": "462c22f6aef7a52e317a8306b75948c9ca474f6d"
 		},
 		{
 			"ImportPath": "github.com/AdRoll/goamz/cloudfront",
-			"Rev": "f8c4952d5bc3056c0ca6711a1f56bc88b828d989"
+			"Rev": "462c22f6aef7a52e317a8306b75948c9ca474f6d"
 		},
 		{
 			"ImportPath": "github.com/AdRoll/goamz/s3",
-			"Rev": "f8c4952d5bc3056c0ca6711a1f56bc88b828d989"
+			"Rev": "462c22f6aef7a52e317a8306b75948c9ca474f6d"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/storage",


### PR DESCRIPTION
Now, registry s3 driver unsupport RadosGW. 
The pull request https://github.com/docker/distribution/pull/808 @lorieri aims to this issue. Regrettably,  pull request https://github.com/docker/distribution/pull/808 is not enough beacuse there are several amazon S3 REST API that registry used but RadosGW unsupport:

 - regionendpoit configurable (solved by https://github.com/docker/distribution/pull/808)
 - HEAD for object info (solved by https://github.com/docker/distribution/pull/808)
 - x-amz-copy-source-range (used when upload multi part)
 - x-amz-copy-source (used when upload multi part)
 - delete multiple objects (used when delele multiple objects )
 - complete upload multiple part need http header content-length (needed by RadosGW fix in https://github.com/AdRoll/goamz/pull/392)


**This pull request  aims to fix S3 compatibility  mentioned above, and this PR work with two PRs below**
  -  https://github.com/AdRoll/goamz/pull/392 [**merged**]
  -  https://github.com/docker/distribution/pull/808 [**waiting merge**]

**About test, if there is a RadosGW , set env below to run CI tests using RadosGW as storage**

AWS_REGION=generic
AWS_ACCESS_KEY=xxxxx
AWS_SECRET_KEY=xxxxx
S3_BUCKET=xxxx
S3_ENTRYPOINT=xxxx

**In my environment, I set env mentioned above using a RadosGW as storage , all the tests in registry/storage/driver/testsuites/testsuites.go passed**

Signed-off-by: wangmingshuai <736808191@qq.com>