### PR TITLE
set version to 2.1.1 in version.go

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,4 +8,4 @@ var Package = "github.com/docker/distribution"
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "v2.1.0+unknown"
+var Version = "v2.1.1+unknown"


### PR DESCRIPTION
otherwise if you install it with "go get" it will output the wrong value

fixes #962

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>