### PR TITLE
context: WithVersion and context package cleanup

### DIFF
--- a/context/doc.go
+++ b/context/doc.go
@@ -3,6 +3,19 @@
 // logging relevent request information but this package is not limited to
 // that purpose.
 //
+// The easiest way to get started is to get the background context:
+//
+// 	ctx := context.Background()
+//
+// The returned context should be passed around your application and be the
+// root of all other context instances. If the application has a version, this
+// line should be called before anything else:
+//
+// 	ctx := context.WithVersion(context.Background(), version)
+//
+// The above will store the version in the context and will be available to
+// the logger.
+//
 // Logging
 //
 // The most useful aspect of this package is GetLogger. This function takes

--- a/context/logger.go
+++ b/context/logger.go
@@ -90,8 +90,16 @@ func getLogrusLogger(ctx Context, keys ...interface{}) *logrus.Entry {
 	}
 
 	if logger == nil {
+		fields := logrus.Fields{}
+
+		// Fill in the instance id, if we have it.
+		instanceID := ctx.Value("instance.id")
+		if instanceID != nil {
+			fields["instance.id"] = instanceID
+		}
+
 		// If no logger is found, just return the standard logger.
-		logger = logrus.NewEntry(logrus.StandardLogger())
+		logger = logrus.StandardLogger().WithFields(fields)
 	}
 
 	fields := logrus.Fields{}

--- a/context/logger.go
+++ b/context/logger.go
@@ -54,8 +54,14 @@ func GetLoggerWithField(ctx Context, key, value interface{}, keys ...interface{}
 // GetLoggerWithFields returns a logger instance with the specified fields
 // without affecting the context. Extra specified keys will be resolved from
 // the context.
-func GetLoggerWithFields(ctx Context, fields map[string]interface{}, keys ...interface{}) Logger {
-	return getLogrusLogger(ctx, keys...).WithFields(logrus.Fields(fields))
+func GetLoggerWithFields(ctx Context, fields map[interface{}]interface{}, keys ...interface{}) Logger {
+	// must convert from interface{} -> interface{} to string -> interface{} for logrus.
+	lfields := make(logrus.Fields, len(fields))
+	for key, value := range fields {
+		lfields[fmt.Sprint(key)] = value
+	}
+
+	return getLogrusLogger(ctx, keys...).WithFields(lfields)
 }
 
 // GetLogger returns the logger from the current context, if present. If one
@@ -89,7 +95,6 @@ func getLogrusLogger(ctx Context, keys ...interface{}) *logrus.Entry {
 	}
 
 	fields := logrus.Fields{}
-
 	for _, key := range keys {
 		v := ctx.Value(key)
 		if v != nil {

--- a/context/util.go
+++ b/context/util.go
@@ -20,7 +20,7 @@ func Since(ctx Context, key interface{}) time.Duration {
 
 // GetStringValue returns a string value from the context. The empty string
 // will be returned if not found.
-func GetStringValue(ctx Context, key string) (value string) {
+func GetStringValue(ctx Context, key interface{}) (value string) {
 	stringi := ctx.Value(key)
 	if stringi != nil {
 		if valuev, ok := stringi.(string); ok {

--- a/context/version.go
+++ b/context/version.go
@@ -1,0 +1,16 @@
+package context
+
+// WithVersion stores the application version in the context. The new context
+// gets a logger to ensure log messages are marked with the application
+// version.
+func WithVersion(ctx Context, version string) Context {
+	ctx = WithValue(ctx, "version", version)
+	// push a new logger onto the stack
+	return WithLogger(ctx, GetLogger(ctx, "version"))
+}
+
+// GetVersion returns the application version from the context. An empty
+// string may returned if the version was not set on the context.
+func GetVersion(ctx Context) string {
+	return GetStringValue(ctx, "version")
+}

--- a/context/version_test.go
+++ b/context/version_test.go
@@ -1,0 +1,19 @@
+package context
+
+import "testing"
+
+func TestVersionContext(t *testing.T) {
+	ctx := Background()
+
+	if GetVersion(ctx) != "" {
+		t.Fatalf("context should not yet have a version")
+	}
+
+	expected := "2.1-whatever"
+	ctx = WithVersion(ctx, expected)
+	version := GetVersion(ctx)
+
+	if version != expected {
+		t.Fatalf("version was not set: %q != %q", version, expected)
+	}
+}

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -77,8 +77,6 @@ func NewApp(ctx context.Context, configuration *configuration.Configuration) *Ap
 		isCache: configuration.Proxy.RemoteURL != "",
 	}
 
-	app.Context = ctxu.WithLogger(app.Context, ctxu.GetLogger(app, "instance.id"))
-
 	// Register the handler dispatchers.
 	app.register(v2.RouteNameBase, func(ctx *Context, r *http.Request) http.Handler {
 		return http.HandlerFunc(apiBase)

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -241,7 +241,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 
 	if !verified {
 		context.GetLoggerWithFields(ctx,
-			map[string]interface{}{
+			map[interface{}]interface{}{
 				"canonical": canonical,
 				"provided":  desc.Digest,
 			}, "canonical", "provided").


### PR DESCRIPTION
By adding WithVersion to the context package, we can simplify context setup in the application. This avoids some odd bugs where instantiation order can lead to missing instance.id or version from log messages.

We also allow interface{} keys when using logger to support integer keys.