### PR TITLE
Make expiration a part of the token response.

### DIFF
--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/transport"
 )
@@ -85,11 +86,24 @@ func (ea *endpointAuthorizer) ModifyRequest(req *http.Request) error {
 	return nil
 }
 
+// This is the minimum duration a token can last (in seconds).
+// A token must not live less than 60 seconds because older versions
+// of the Docker client didn't read their expiration from the token
+// response and assumed 60 seconds.  So to remain compatible with
+// those implementations, a token must live at least this long.
+const minimumTokenLifetimeSeconds = 60
+
+// Private interface for time used by this package to enable tests to provide their own implementation.
+type clock interface {
+	Now() time.Time
+}
+
 type tokenHandler struct {
 	header    http.Header
 	creds     CredentialStore
 	scope     tokenScope
 	transport http.RoundTripper
+	clock     clock
 
 	tokenLock       sync.Mutex
 	tokenCache      string
@@ -108,12 +122,24 @@ func (ts tokenScope) String() string {
 	return fmt.Sprintf("%s:%s:%s", ts.Resource, ts.Scope, strings.Join(ts.Actions, ","))
 }
 
+// An implementation of clock for providing real time data.
+type realClock struct{}
+
+// Now implements clock
+func (realClock) Now() time.Time { return time.Now() }
+
 // NewTokenHandler creates a new AuthenicationHandler which supports
 // fetching tokens from a remote token server.
 func NewTokenHandler(transport http.RoundTripper, creds CredentialStore, scope string, actions ...string) AuthenticationHandler {
+	return newTokenHandler(transport, creds, realClock{}, scope, actions...)
+}
+
+// newTokenHandler exposes the option to provide a clock to manipulate time in unit testing.
+func newTokenHandler(transport http.RoundTripper, creds CredentialStore, c clock, scope string, actions ...string) AuthenticationHandler {
 	return &tokenHandler{
 		transport: transport,
 		creds:     creds,
+		clock:     c,
 		scope: tokenScope{
 			Resource: "repository",
 			Scope:    scope,
@@ -146,40 +172,45 @@ func (th *tokenHandler) AuthorizeRequest(req *http.Request, params map[string]st
 func (th *tokenHandler) refreshToken(params map[string]string) error {
 	th.tokenLock.Lock()
 	defer th.tokenLock.Unlock()
-	now := time.Now()
+	now := th.clock.Now()
 	if now.After(th.tokenExpiration) {
-		token, err := th.fetchToken(params)
+		token, expiresIn, err := th.fetchToken(params)
 		if err != nil {
 			return err
 		}
 		th.tokenCache = token
-		th.tokenExpiration = now.Add(time.Minute)
+		th.tokenExpiration = now.Add(time.Duration(expiresIn) * time.Second)
 	}
 
 	return nil
 }
 
 type tokenResponse struct {
-	Token string `json:"token"`
+	Token     string `json:"token"`
+	ExpiresIn int    `json:"expires_in"`
 }
 
-func (th *tokenHandler) fetchToken(params map[string]string) (token string, err error) {
+func (th *tokenHandler) fetchToken(params map[string]string) (token string, expiresIn int, err error) {
+	// The default/minimum lifetime.
+	// This can be overwritten if the token payload specifies an expiration.
+	expiresIn = minimumTokenLifetimeSeconds
+
 	//log.Debugf("Getting bearer token with %s for %s", challenge.Parameters, ta.auth.Username)
 	realm, ok := params["realm"]
 	if !ok {
-		return "", errors.New("no realm specified for token auth challenge")
+		return "", -1, errors.New("no realm specified for token auth challenge")
 	}
 
 	// TODO(dmcgowan): Handle empty scheme
 
 	realmURL, err := url.Parse(realm)
 	if err != nil {
-		return "", fmt.Errorf("invalid token auth challenge realm: %s", err)
+		return "", -1, fmt.Errorf("invalid token auth challenge realm: %s", err)
 	}
 
 	req, err := http.NewRequest("GET", realmURL.String(), nil)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 
 	reqParams := req.URL.Query()
@@ -206,26 +237,31 @@ func (th *tokenHandler) fetchToken(params map[string]string) (token string, err 
 
 	resp, err := th.client().Do(req)
 	if err != nil {
-		return "", err
+		return "", -1, err
 	}
 	defer resp.Body.Close()
 
 	if !client.SuccessStatus(resp.StatusCode) {
-		return "", fmt.Errorf("token auth attempt for registry: %s request failed with status: %d %s", req.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
+		return "", -1, fmt.Errorf("token auth attempt for registry: %s request failed with status: %d %s", req.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
 	decoder := json.NewDecoder(resp.Body)
 
 	tr := new(tokenResponse)
 	if err = decoder.Decode(tr); err != nil {
-		return "", fmt.Errorf("unable to decode token response: %s", err)
+		return "", -1, fmt.Errorf("unable to decode token response: %s", err)
 	}
 
 	if tr.Token == "" {
-		return "", errors.New("authorization server did not include a token in the response")
+		return "", -1, errors.New("authorization server did not include a token in the response")
 	}
 
-	return tr.Token, nil
+	if tr.ExpiresIn > minimumTokenLifetimeSeconds {
+		logrus.Debugf("Increasing token expiration to: %d seconds", tr.ExpiresIn)
+		expiresIn = tr.ExpiresIn
+	}
+
+	return tr.Token, expiresIn, nil
 }
 
 type basicHandler struct {


### PR DESCRIPTION
This change allows for the token endpoint of v2 registries to return an
`expires_in` field with the seconds remaining in the lifetime of the
token.  This enables providers to return much longer lived tokens for
use in registry interations.

For backwards compatibility with older registries, no 'expired_in'
reverts to the prior default of 60 seconds.

For backwards compatibility with older clients, registries should never
use an expiration of less than 60 seconds.