### PR TITLE
Don't create a tag index for Manifests

### DIFF
--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -193,45 +193,6 @@ func pathFor(spec pathSpec) (string, error) {
 		}
 
 		return path.Join(root, "current", "link"), nil
-	case manifestTagIndexPathSpec:
-		root, err := pathFor(manifestTagPathSpec{
-			name: v.name,
-			tag:  v.tag,
-		})
-
-		if err != nil {
-			return "", err
-		}
-
-		return path.Join(root, "index"), nil
-	case manifestTagIndexEntryLinkPathSpec:
-		root, err := pathFor(manifestTagIndexEntryPathSpec{
-			name:     v.name,
-			tag:      v.tag,
-			revision: v.revision,
-		})
-
-		if err != nil {
-			return "", err
-		}
-
-		return path.Join(root, "link"), nil
-	case manifestTagIndexEntryPathSpec:
-		root, err := pathFor(manifestTagIndexPathSpec{
-			name: v.name,
-			tag:  v.tag,
-		})
-
-		if err != nil {
-			return "", err
-		}
-
-		components, err := digestPathComponents(v.revision, false)
-		if err != nil {
-			return "", err
-		}
-
-		return path.Join(root, path.Join(components...)), nil
 	case layerLinkPathSpec:
 		components, err := digestPathComponents(v.digest, false)
 		if err != nil {
@@ -348,35 +309,7 @@ type manifestTagCurrentPathSpec struct {
 
 func (manifestTagCurrentPathSpec) pathSpec() {}
 
-// manifestTagCurrentPathSpec describes the link to the index of revisions
-// with the given tag.
-type manifestTagIndexPathSpec struct {
-	name string
-	tag  string
-}
-
-func (manifestTagIndexPathSpec) pathSpec() {}
-
-// manifestTagIndexEntryPathSpec contains the entries of the index by revision.
-type manifestTagIndexEntryPathSpec struct {
-	name     string
-	tag      string
-	revision digest.Digest
-}
-
-func (manifestTagIndexEntryPathSpec) pathSpec() {}
-
-// manifestTagIndexEntryLinkPathSpec describes the link to a revisions of a
-// manifest with given tag within the index.
-type manifestTagIndexEntryLinkPathSpec struct {
-	name     string
-	tag      string
-	revision digest.Digest
-}
-
-func (manifestTagIndexEntryLinkPathSpec) pathSpec() {}
-
-// blobLinkPathSpec specifies a path for a blob link, which is a file with a
+// layerLinkPathSpec specifies a path for a blob link, which is a file with a
 // blob id. The blob link will contain a content addressable blob id reference
 // into the blob store. The format of the contents is as follows:
 //

--- a/registry/storage/paths_test.go
+++ b/registry/storage/paths_test.go
@@ -62,29 +62,6 @@ func TestPathMapper(t *testing.T) {
 			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/current/link",
 		},
 		{
-			spec: manifestTagIndexPathSpec{
-				name: "foo/bar",
-				tag:  "thetag",
-			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index",
-		},
-		{
-			spec: manifestTagIndexEntryPathSpec{
-				name:     "foo/bar",
-				tag:      "thetag",
-				revision: "sha256:abcdef0123456789",
-			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789",
-		},
-		{
-			spec: manifestTagIndexEntryLinkPathSpec{
-				name:     "foo/bar",
-				tag:      "thetag",
-				revision: "sha256:abcdef0123456789",
-			},
-			expected: "/docker/registry/v2/repositories/foo/bar/_manifests/tags/thetag/index/sha256/abcdef0123456789/link",
-		},
-		{
 			spec: layerLinkPathSpec{
 				name:   "foo/bar",
 				digest: "tarsum.v1+test:abcdef",

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -77,12 +77,6 @@ func (ts *tagStore) tag(tag string, revision digest.Digest) error {
 		return err
 	}
 
-	nbs := ts.linkedBlobStore(ts.ctx, tag)
-	// Link into the index
-	if err := nbs.linkBlob(ts.ctx, distribution.Descriptor{Digest: revision}); err != nil {
-		return err
-	}
-
 	// Overwrite the current link
 	return ts.blobStore.link(ts.ctx, currentPath, revision)
 }
@@ -124,24 +118,4 @@ func (ts *tagStore) delete(tag string) error {
 	}
 
 	return ts.blobStore.driver.Delete(ts.ctx, tagPath)
-}
-
-// linkedBlobStore returns the linkedBlobStore for the named tag, allowing one
-// to index manifest blobs by tag name. While the tag store doesn't map
-// precisely to the linked blob store, using this ensures the links are
-// managed via the same code path.
-func (ts *tagStore) linkedBlobStore(ctx context.Context, tag string) *linkedBlobStore {
-	return &linkedBlobStore{
-		blobStore:  ts.blobStore,
-		repository: ts.repository,
-		ctx:        ctx,
-		linkPathFns: []linkPathFunc{func(name string, dgst digest.Digest) (string, error) {
-			return pathFor(manifestTagIndexEntryLinkPathSpec{
-				name:     name,
-				tag:      tag,
-				revision: dgst,
-			})
-
-		}},
-	}
 }


### PR DESCRIPTION
Don't create a tag index for Manifests (it was not being used) and remove the 
code for creating it.

Closes #938 

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>