### PR TITLE
Fix incorrect default

### DIFF
--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -27,7 +27,7 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
 
 `secure`: (optional) Whether you would like to transfer data to the bucket over ssl or not. Defaults to true (meaning transferring over ssl) if not specified. Note that while setting this to false will improve performance, it is not recommended due to security concerns.
 
-`v4auth`: (optional) Whether you would like to use aws signature version 4 with your requests. This defaults to true if not specified (note that the eu-central-1 region does not work with version 2 signatures, so the driver will error out if initialized with this region and v4auth set to false)
+`v4auth`: (optional) Whether you would like to use aws signature version 4 with your requests. This defaults to false if not specified (note that the eu-central-1 region does not work with version 2 signatures, so the driver will error out if initialized with this region and v4auth set to false)
 
 `chunksize`: (optional) The default part size for multipart uploads (performed by WriteStream) to s3. The default is 10 MB. Keep in mind that the minimum part size for s3 is 5MB. You might experience better performance for larger chunk sizes depending on the speed of your connection to s3.
 


### PR DESCRIPTION
According to [the S3 storage driver documentation](https://github.com/docker/distribution/blob/51bd34eaeda4702dfa1fbae96e0fcff47452798c/docs/storage-drivers/s3.md), the default should be true:

> `v4auth`: (optional) Whether you would like to use aws signature version 4 with your requests. **This defaults to true** if not specified (note that the eu-central-1 region does not work with version 2 signatures, so the driver will error out if initialized with this region and v4auth set to false)