### PR TITLE
Add http.host parameter

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -64,6 +64,10 @@ type Configuration struct {
 		// Net specifies the net portion of the bind address. A default empty value means tcp.
 		Net string `yaml:"net,omitempty"`
 
+		// Host specifies an externally-reachable address for the registry, as a fully
+		// qualified URL.
+		Host string `yaml:"host,omitempty"`
+
 		Prefix string `yaml:"prefix,omitempty"`
 
 		// Secret specifies the secret key which HMAC tokens are created with.

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -65,6 +65,7 @@ var configStruct = Configuration{
 	HTTP: struct {
 		Addr   string `yaml:"addr,omitempty"`
 		Net    string `yaml:"net,omitempty"`
+		Host   string `yaml:"host,omitempty"`
 		Prefix string `yaml:"prefix,omitempty"`
 		Secret string `yaml:"secret,omitempty"`
 		TLS    struct {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,7 @@ information about each option that appears later in this page.
     http:
       addr: localhost:5000
       prefix: /my/nested/registry/
+      host: https://myregistryaddress.org:5000
       secret: asecretforlocaldevelopment
       tls:
         certificate: /path/to/x509/public
@@ -1189,6 +1190,7 @@ configuration may contain both.
       addr: localhost:5000
       net: tcp
       prefix: /my/nested/registry/
+      host: https://myregistryaddress.org:5000
       secret: asecretforlocaldevelopment
       tls:
         certificate: /path/to/x509/public
@@ -1233,7 +1235,7 @@ The `http` option details the configuration for the HTTP server that hosts the r
      The default empty value means tcp.
     </td>
   </tr>
-    <tr>
+  <tr>
     <td>
       <code>prefix</code>
     </td>
@@ -1244,6 +1246,19 @@ The `http` option details the configuration for the HTTP server that hosts the r
 If the server does not run at the root path use this value to specify the
 prefix. The root path is the section before <code>v2</code>. It
 should have both preceding and trailing slashes, for example <code>/path/</code>.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>host</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+This parameter specifies an externally-reachable address for the registry, as a
+fully qualified URL. If present, it is used when creating generated URLs.
+Otherwise, these URLs are derived from client requests.
     </td>
   </tr>
   <tr>

--- a/registry/api/v2/urls_test.go
+++ b/registry/api/v2/urls_test.go
@@ -158,8 +158,10 @@ func TestBuilderFromRequest(t *testing.T) {
 	forwardedHostHeader2.Set("X-Forwarded-Host", "first.example.com, proxy1.example.com")
 
 	testRequests := []struct {
-		request *http.Request
-		base    string
+		request      *http.Request
+		base         string
+		configScheme string
+		configHost   string
 	}{
 		{
 			request: &http.Request{URL: u, Host: u.Host},
@@ -177,10 +179,16 @@ func TestBuilderFromRequest(t *testing.T) {
 			request: &http.Request{URL: u, Host: u.Host, Header: forwardedHostHeader2},
 			base:    "http://first.example.com",
 		},
+		{
+			request:      &http.Request{URL: u, Host: u.Host, Header: forwardedHostHeader2},
+			base:         "https://third.example.com:5000",
+			configScheme: "https",
+			configHost:   "third.example.com:5000",
+		},
 	}
 
 	for _, tr := range testRequests {
-		builder := NewURLBuilderFromRequest(tr.request)
+		builder := NewURLBuilderFromRequest(tr.request, tr.configScheme, tr.configHost)
 
 		for _, testCase := range makeURLBuilderTestCases(builder) {
 			url, err := testCase.build()
@@ -207,8 +215,10 @@ func TestBuilderFromRequestWithPrefix(t *testing.T) {
 	forwardedProtoHeader.Set("X-Forwarded-Proto", "https")
 
 	testRequests := []struct {
-		request *http.Request
-		base    string
+		request      *http.Request
+		base         string
+		configScheme string
+		configHost   string
 	}{
 		{
 			request: &http.Request{URL: u, Host: u.Host},
@@ -218,10 +228,16 @@ func TestBuilderFromRequestWithPrefix(t *testing.T) {
 			request: &http.Request{URL: u, Host: u.Host, Header: forwardedProtoHeader},
 			base:    "https://example.com/prefix/",
 		},
+		{
+			request:      &http.Request{URL: u, Host: u.Host, Header: forwardedProtoHeader},
+			base:         "https://subdomain.example.com/prefix/",
+			configScheme: "https",
+			configHost:   "subdomain.example.com",
+		},
 	}
 
 	for _, tr := range testRequests {
-		builder := NewURLBuilderFromRequest(tr.request)
+		builder := NewURLBuilderFromRequest(tr.request, tr.configScheme, tr.configHost)
 
 		for _, testCase := range makeURLBuilderTestCases(builder) {
 			url, err := testCase.build()

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -53,6 +54,10 @@ type App struct {
 	driver           storagedriver.StorageDriver // driver maintains the app global storage driver instance.
 	registry         distribution.Namespace      // registry is the primary registry backend for the app instance.
 	accessController auth.AccessController       // main access controller for application
+
+	// httpHost is a parsed representation of the http.host parameter from
+	// the configuration. Only the Scheme and Host fields are used.
+	httpHost url.URL
 
 	// events contains notification related configuration.
 	events struct {
@@ -119,6 +124,14 @@ func NewApp(ctx context.Context, configuration *configuration.Configuration) *Ap
 	app.configureEvents(configuration)
 	app.configureRedis(configuration)
 	app.configureLogHook(configuration)
+
+	if configuration.HTTP.Host != "" {
+		u, err := url.Parse(configuration.HTTP.Host)
+		if err != nil {
+			panic(fmt.Sprintf(`could not parse http "host" parameter: %v`, err))
+		}
+		app.httpHost = *u
+	}
 
 	options := []storage.RegistryOption{}
 
@@ -641,7 +654,7 @@ func (app *App) context(w http.ResponseWriter, r *http.Request) *Context {
 	context := &Context{
 		App:        app,
 		Context:    ctx,
-		urlBuilder: v2.NewURLBuilderFromRequest(r),
+		urlBuilder: v2.NewURLBuilderFromRequest(r, app.httpHost.Scheme, app.httpHost.Host),
 	}
 
 	return context


### PR DESCRIPTION
This allows the administrator to specify an externally-reachable URL for
the registry. It takes precedence over the X-Forwarded-Proto and
X-Forwarded-Host headers, and the hostname in the request.

Fixes #996