### PR TITLE
Don't return nil, nil from functions

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,15 +1,20 @@
 package distribution
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/docker/distribution/digest"
 )
 
+// ErrManifestNotModified is returned when a conditional manifest GetByTag
+// returns nil due to the client indicating it has the latest version
+var ErrManifestNotModified = errors.New("manifest not modified")
+
 // ErrUnsupported is returned when an unimplemented or unsupported action is
 // performed
-var ErrUnsupported = fmt.Errorf("operation unsupported")
+var ErrUnsupported = errors.New("operation unsupported")
 
 // ErrRepositoryUnknown is returned if the named repository is not known by
 // the registry.

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -211,8 +211,6 @@ func (ms *manifests) Tags() ([]string, error) {
 		}
 
 		return tagsResponse.Tags, nil
-	} else if resp.StatusCode == http.StatusNotFound {
-		return nil, nil
 	}
 	return nil, handleErrorResponse(resp)
 }

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -288,7 +288,7 @@ func (ms *manifests) GetByTag(tag string, options ...distribution.ManifestServic
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotModified {
-		return nil, nil
+		return nil, distribution.ErrManifestNotModified
 	} else if SuccessStatus(resp.StatusCode) {
 		var sm schema1.SignedManifest
 		decoder := json.NewDecoder(resp.Body)

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -603,12 +603,9 @@ func TestManifestFetchWithEtag(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m2, err := ms.GetByTag("latest", AddEtagToTag("latest", d1.String()))
-	if err != nil {
+	_, err = ms.GetByTag("latest", AddEtagToTag("latest", d1.String()))
+	if err != distribution.ErrManifestNotModified {
 		t.Fatal(err)
-	}
-	if m2 != nil {
-		t.Fatal("Expected empty manifest for matching etag")
 	}
 }
 

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -102,11 +102,11 @@ func (pms proxyManifestStore) GetByTag(tag string, options ...distribution.Manif
 fromremote:
 	var sm *schema1.SignedManifest
 	sm, err = pms.remoteManifests.GetByTag(tag, client.AddEtagToTag(tag, localDigest.String()))
-	if err != nil {
+	if err != nil && err != distribution.ErrManifestNotModified {
 		return nil, err
 	}
 
-	if sm == nil {
+	if err == distribution.ErrManifestNotModified {
 		context.GetLogger(pms.ctx).Debugf("Local manifest for %q is latest, dgst=%s", tag, localDigest.String())
 		return localManifest, nil
 	}


### PR DESCRIPTION
Avoid returning nil, nil when fetching a manifest by tag by introducing a new error ErrManifestNotModified which can be checked by clients.

Don't return a nil array and a nil error if the Tags endpoint cannot be found.

closes #983 