### PR TITLE
Fix a race condition in pull through cache population

### DIFF
--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -94,7 +94,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name string) (distri
 	}
 
 	return &proxiedRepository{
-		blobStore: proxyBlobStore{
+		blobStore: &proxyBlobStore{
 			localStore:  localRepo.Blobs(ctx),
 			remoteStore: remoteRepo.Blobs(ctx),
 			scheduler:   pr.scheduler,


### PR DESCRIPTION
Fix a race condition in pull through cache population by removing the functionality of readers joining current downloads.  Concurrent requests for the same blob will not block, but only the first instance will be comitted locally.

Add more unit tests.

This is a temporary fix. Closes #944 #913 

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>