### PR TITLE
issue 1008 correct repository name restriction

### DIFF
--- a/registry/api/v2/names.go
+++ b/registry/api/v2/names.go
@@ -17,8 +17,9 @@ const (
 
 // RepositoryNameComponentRegexp restricts registry path component names to
 // start with at least one letter or number, with following parts able to
-// be separated by one period, dash or underscore.
-var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[._-][a-z0-9]+)*`)
+// be separated by one period, dash or underscore, or separated by combination
+// of those such as _-_ or __.
+var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[._-]+[a-z0-9]+)*`)
 
 // RepositoryNameComponentAnchoredRegexp is the version of
 // RepositoryNameComponentRegexp which must completely match the content


### PR DESCRIPTION
To be backwards compatible with v1 repository
names.