### PR TITLE
[registry/auth] Update interface error handling

### DIFF
--- a/cmd/registry-api-descriptor-template/main.go
+++ b/cmd/registry-api-descriptor-template/main.go
@@ -52,6 +52,7 @@ func main() {
 		RouteDescriptors: v2.APIDescriptor.RouteDescriptors,
 		ErrorDescriptors: append(errcode.GetErrorCodeGroup("registry.api.v2"),
 			// The following are part of the specification but provided by errcode default.
+			errcode.ErrorCodeUnauthenticated.Descriptor(),
 			errcode.ErrorCodeUnauthorized.Descriptor(),
 			errcode.ErrorCodeUnsupported.Descriptor()),
 	}

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1047,14 +1047,15 @@ The error codes encountered via the API are enumerated in the following table:
  `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry.
  `SIZE_INVALID` | provided length did not match content length | When a layer is uploaded, the provided size will be checked against the uploaded content. If they do not match, this error will be returned.
  `TAG_INVALID` | manifest tag did not match URI | During a manifest upload, if the tag in the manifest does not match the uri tag, this error will be returned.
- `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status.
+ `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate.
+ `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource.
  `UNSUPPORTED` | The operation is unsupported. | The operation was unsupported due to a missing implementation or invalid set of parameters.
 
 
 
 ### Base
 
-Base V2 API route. Typically, this can be used for lightweight version checks and to validate registry authorization.
+Base V2 API route. Typically, this can be used for lightweight version checks and to validate registry authentication.
 
 
 
@@ -1094,11 +1095,22 @@ The API implements V2 protocol and is accessible.
 
 
 
-###### On Failure: Unauthorized
+###### On Failure: Not Found
+
+```
+404 Not Found
+```
+
+The registry does not implement the V2 API.
+
+
+
+###### On Failure: Authentication Error
 
 ```
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
 Content-Type: application/json; charset=utf-8
 
 {
@@ -1113,13 +1125,14 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-The client is not authorized to access the registry.
+The client is not authenticated.
 
 The following headers will be returned on the response:
 
 |Name|Description|
 |----|-----------|
 |`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
 
 
 
@@ -1127,17 +1140,7 @@ The error codes that may be included in the response body are enumerated below:
 
 |Code|Message|Description|
 |----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
-
-
-
-###### On Failure: Not Found
-
-```
-404 Not Found
-```
-
-The registry does not implement the V2 API.
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
 
 
 
@@ -1203,10 +1206,50 @@ The following headers will be returned with the response:
 
 
 
-###### On Failure: Not Found
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
 
 ```
 404 Not Found
+Content-Length: <length>
 Content-Type: application/json; charset=utf-8
 
 {
@@ -1223,6 +1266,12 @@ Content-Type: application/json; charset=utf-8
 
 The repository is not known to the registry.
 
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
 
 
 The error codes that may be included in the response body are enumerated below:
@@ -1233,10 +1282,11 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
+###### On Failure: Authorization Error
 
 ```
-401 Unauthorized
+403 Forbidden
+Content-Length: <length>
 Content-Type: application/json; charset=utf-8
 
 {
@@ -1251,7 +1301,13 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-The client does not have access to the repository.
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
 
 
 
@@ -1259,7 +1315,7 @@ The error codes that may be included in the response body are enumerated below:
 
 |Code|Message|Description|
 |----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -1312,10 +1368,50 @@ The following headers will be returned with the response:
 
 
 
-###### On Failure: Not Found
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
 
 ```
 404 Not Found
+Content-Length: <length>
 Content-Type: application/json; charset=utf-8
 
 {
@@ -1332,6 +1428,12 @@ Content-Type: application/json; charset=utf-8
 
 The repository is not known to the registry.
 
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
 
 
 The error codes that may be included in the response body are enumerated below:
@@ -1342,10 +1444,11 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
+###### On Failure: Authorization Error
 
 ```
-401 Unauthorized
+403 Forbidden
+Content-Length: <length>
 Content-Type: application/json; charset=utf-8
 
 {
@@ -1360,7 +1463,13 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-The client does not have access to the repository.
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
 
 
 
@@ -1368,7 +1477,7 @@ The error codes that may be included in the response body are enumerated below:
 
 |Code|Message|Description|
 |----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -1471,10 +1580,12 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
+###### On Failure: Authentication Error
 
 ```
 401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
 Content-Type: application/json; charset=utf-8
 
 {
@@ -1489,7 +1600,14 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-The client does not have access to the repository.
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
 
 
 
@@ -1497,14 +1615,15 @@ The error codes that may be included in the response body are enumerated below:
 
 |Code|Message|Description|
 |----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
 
 
 
-###### On Failure: Not Found
+###### On Failure: No Such Repository Error
 
 ```
 404 Not Found
+Content-Length: <length>
 Content-Type: application/json; charset=utf-8
 
 {
@@ -1519,7 +1638,13 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-The named manifest is not known to the registry.
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
 
 
 
@@ -1528,7 +1653,43 @@ The error codes that may be included in the response body are enumerated below:
 |Code|Message|Description|
 |----|-------|-----------|
 | `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
-| `MANIFEST_UNKNOWN` | manifest unknown | This error is returned when the manifest, identified by name and tag is unknown to the repository. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -1631,10 +1792,12 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
+###### On Failure: Authentication Error
 
 ```
 401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
 Content-Type: application/json; charset=utf-8
 
 {
@@ -1649,7 +1812,14 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-The client does not have permission to push to the repository.
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
 
 
 
@@ -1657,7 +1827,81 @@ The error codes that may be included in the response body are enumerated below:
 
 |Code|Message|Description|
 |----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -1689,45 +1933,6 @@ The error codes that may be included in the response body are enumerated below:
 |Code|Message|Description|
 |----|-------|-----------|
 | `BLOB_UNKNOWN` | blob unknown to registry | This error may be returned when a blob is unknown to the registry in a specified repository. This can be returned with a standard get or if a manifest references an unknown layer during upload. |
-
-
-
-###### On Failure: Unauthorized
-
-```
-401 Unauthorized
-WWW-Authenticate: <scheme> realm="<realm>", ..."
-Content-Length: <length>
-Content-Type: application/json; charset=utf-8
-
-{
-	"errors:" [
-	    {
-            "code": <error code>,
-            "message": "<error message>",
-            "detail": ...
-        },
-        ...
-    ]
-}
-```
-
-
-
-The following headers will be returned on the response:
-
-|Name|Description|
-|----|-----------|
-|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
-
-
-
-The error codes that may be included in the response body are enumerated below:
-
-|Code|Message|Description|
-|----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
 
 
 
@@ -1819,7 +2024,7 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
+###### On Failure: Authentication Error
 
 ```
 401 Unauthorized
@@ -1839,14 +2044,14 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-
+The client is not authenticated.
 
 The following headers will be returned on the response:
 
 |Name|Description|
 |----|-----------|
 |`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
+|`Content-Length`|Length of the JSON response body.|
 
 
 
@@ -1854,7 +2059,81 @@ The error codes that may be included in the response body are enumerated below:
 
 |Code|Message|Description|
 |----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -2014,45 +2293,6 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
-
-```
-401 Unauthorized
-WWW-Authenticate: <scheme> realm="<realm>", ..."
-Content-Length: <length>
-Content-Type: application/json; charset=utf-8
-
-{
-	"errors:" [
-	    {
-            "code": "UNAUTHORIZED",
-            "message": "access to the requested resource is not authorized",
-            "detail": ...
-        },
-        ...
-    ]
-}
-```
-
-The client does not have access to the repository.
-
-The following headers will be returned on the response:
-
-|Name|Description|
-|----|-----------|
-|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
-
-
-
-The error codes that may be included in the response body are enumerated below:
-
-|Code|Message|Description|
-|----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
-
-
-
 ###### On Failure: Not Found
 
 ```
@@ -2081,6 +2321,119 @@ The error codes that may be included in the response body are enumerated below:
 |----|-------|-----------|
 | `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
 | `BLOB_UNKNOWN` | blob unknown to registry | This error may be returned when a blob is unknown to the registry in a specified repository. This can be returned with a standard get or if a manifest references an unknown layer during upload. |
+
+
+
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -2163,45 +2516,6 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
-
-```
-401 Unauthorized
-WWW-Authenticate: <scheme> realm="<realm>", ..."
-Content-Length: <length>
-Content-Type: application/json; charset=utf-8
-
-{
-	"errors:" [
-	    {
-            "code": "UNAUTHORIZED",
-            "message": "access to the requested resource is not authorized",
-            "detail": ...
-        },
-        ...
-    ]
-}
-```
-
-The client does not have access to the repository.
-
-The following headers will be returned on the response:
-
-|Name|Description|
-|----|-----------|
-|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
-
-
-
-The error codes that may be included in the response body are enumerated below:
-
-|Code|Message|Description|
-|----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
-
-
-
 ###### On Failure: Not Found
 
 ```
@@ -2240,6 +2554,119 @@ The error codes that may be included in the response body are enumerated below:
 ```
 
 The range specification cannot be satisfied for the requested content. This can happen when the range is not formatted correctly or if the range is outside of the valid size of the content.
+
+
+
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -2371,6 +2798,119 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
+
+
+
 
 
 ### Initiate Blob Upload
@@ -2453,45 +2993,6 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
-
-```
-401 Unauthorized
-WWW-Authenticate: <scheme> realm="<realm>", ..."
-Content-Length: <length>
-Content-Type: application/json; charset=utf-8
-
-{
-	"errors:" [
-	    {
-            "code": "UNAUTHORIZED",
-            "message": "access to the requested resource is not authorized",
-            "detail": ...
-        },
-        ...
-    ]
-}
-```
-
-The client does not have access to push to the repository.
-
-The following headers will be returned on the response:
-
-|Name|Description|
-|----|-----------|
-|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
-
-
-
-The error codes that may be included in the response body are enumerated below:
-
-|Code|Message|Description|
-|----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
-
-
-
 ###### On Failure: Not allowed
 
 ```
@@ -2507,6 +3008,119 @@ The error codes that may be included in the response body are enumerated below:
 |Code|Message|Description|
 |----|-------|-----------|
 | `UNSUPPORTED` | The operation is unsupported. | The operation was unsupported due to a missing implementation or invalid set of parameters. |
+
+
+
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -2577,7 +3191,7 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
+###### On Failure: Authentication Error
 
 ```
 401 Unauthorized
@@ -2588,8 +3202,8 @@ Content-Type: application/json; charset=utf-8
 {
 	"errors:" [
 	    {
-            "code": "UNAUTHORIZED",
-            "message": "access to the requested resource is not authorized",
+            "code": <error code>,
+            "message": "<error message>",
             "detail": ...
         },
         ...
@@ -2597,14 +3211,14 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-The client does not have access to push to the repository.
+The client is not authenticated.
 
 The following headers will be returned on the response:
 
 |Name|Description|
 |----|-----------|
 |`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
+|`Content-Length`|Length of the JSON response body.|
 
 
 
@@ -2612,7 +3226,81 @@ The error codes that may be included in the response body are enumerated below:
 
 |Code|Message|Description|
 |----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -2705,45 +3393,6 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
-
-```
-401 Unauthorized
-WWW-Authenticate: <scheme> realm="<realm>", ..."
-Content-Length: <length>
-Content-Type: application/json; charset=utf-8
-
-{
-	"errors:" [
-	    {
-            "code": "UNAUTHORIZED",
-            "message": "access to the requested resource is not authorized",
-            "detail": ...
-        },
-        ...
-    ]
-}
-```
-
-The client does not have access to the repository.
-
-The following headers will be returned on the response:
-
-|Name|Description|
-|----|-----------|
-|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
-
-
-
-The error codes that may be included in the response body are enumerated below:
-
-|Code|Message|Description|
-|----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
-
-
-
 ###### On Failure: Not Found
 
 ```
@@ -2771,6 +3420,119 @@ The error codes that may be included in the response body are enumerated below:
 |Code|Message|Description|
 |----|-------|-----------|
 | `BLOB_UPLOAD_UNKNOWN` | blob upload unknown to registry | If a blob upload has been cancelled or was never started, this error code may be returned. |
+
+
+
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -2862,45 +3624,6 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
-
-```
-401 Unauthorized
-WWW-Authenticate: <scheme> realm="<realm>", ..."
-Content-Length: <length>
-Content-Type: application/json; charset=utf-8
-
-{
-	"errors:" [
-	    {
-            "code": "UNAUTHORIZED",
-            "message": "access to the requested resource is not authorized",
-            "detail": ...
-        },
-        ...
-    ]
-}
-```
-
-The client does not have access to push to the repository.
-
-The following headers will be returned on the response:
-
-|Name|Description|
-|----|-----------|
-|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
-
-
-
-The error codes that may be included in the response body are enumerated below:
-
-|Code|Message|Description|
-|----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
-
-
-
 ###### On Failure: Not Found
 
 ```
@@ -2928,6 +3651,119 @@ The error codes that may be included in the response body are enumerated below:
 |Code|Message|Description|
 |----|-------|-----------|
 | `BLOB_UPLOAD_UNKNOWN` | blob upload unknown to registry | If a blob upload has been cancelled or was never started, this error code may be returned. |
+
+
+
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -3017,45 +3853,6 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
-
-```
-401 Unauthorized
-WWW-Authenticate: <scheme> realm="<realm>", ..."
-Content-Length: <length>
-Content-Type: application/json; charset=utf-8
-
-{
-	"errors:" [
-	    {
-            "code": "UNAUTHORIZED",
-            "message": "access to the requested resource is not authorized",
-            "detail": ...
-        },
-        ...
-    ]
-}
-```
-
-The client does not have access to push to the repository.
-
-The following headers will be returned on the response:
-
-|Name|Description|
-|----|-----------|
-|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
-
-
-
-The error codes that may be included in the response body are enumerated below:
-
-|Code|Message|Description|
-|----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
-
-
-
 ###### On Failure: Not Found
 
 ```
@@ -3093,6 +3890,119 @@ The error codes that may be included in the response body are enumerated below:
 ```
 
 The `Content-Range` specification cannot be accepted, either because it does not overlap with the current progress or it is invalid.
+
+
+
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -3187,45 +4097,6 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
-
-```
-401 Unauthorized
-WWW-Authenticate: <scheme> realm="<realm>", ..."
-Content-Length: <length>
-Content-Type: application/json; charset=utf-8
-
-{
-	"errors:" [
-	    {
-            "code": "UNAUTHORIZED",
-            "message": "access to the requested resource is not authorized",
-            "detail": ...
-        },
-        ...
-    ]
-}
-```
-
-The client does not have access to push to the repository.
-
-The following headers will be returned on the response:
-
-|Name|Description|
-|----|-----------|
-|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
-
-
-
-The error codes that may be included in the response body are enumerated below:
-
-|Code|Message|Description|
-|----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
-
-
-
 ###### On Failure: Not Found
 
 ```
@@ -3253,6 +4124,119 @@ The error codes that may be included in the response body are enumerated below:
 |Code|Message|Description|
 |----|-------|-----------|
 | `BLOB_UPLOAD_UNKNOWN` | blob upload unknown to registry | If a blob upload has been cancelled or was never started, this error code may be returned. |
+
+
+
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 
@@ -3335,45 +4319,6 @@ The error codes that may be included in the response body are enumerated below:
 
 
 
-###### On Failure: Unauthorized
-
-```
-401 Unauthorized
-WWW-Authenticate: <scheme> realm="<realm>", ..."
-Content-Length: <length>
-Content-Type: application/json; charset=utf-8
-
-{
-	"errors:" [
-	    {
-            "code": "UNAUTHORIZED",
-            "message": "access to the requested resource is not authorized",
-            "detail": ...
-        },
-        ...
-    ]
-}
-```
-
-The client does not have access to the repository.
-
-The following headers will be returned on the response:
-
-|Name|Description|
-|----|-----------|
-|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
-|`Content-Length`|Length of the JSON error response body.|
-
-
-
-The error codes that may be included in the response body are enumerated below:
-
-|Code|Message|Description|
-|----|-------|-----------|
-| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. Often this will be accompanied by a 401 Unauthorized response status. |
-
-
-
 ###### On Failure: Not Found
 
 ```
@@ -3401,6 +4346,119 @@ The error codes that may be included in the response body are enumerated below:
 |Code|Message|Description|
 |----|-------|-----------|
 | `BLOB_UPLOAD_UNKNOWN` | blob upload unknown to registry | If a blob upload has been cancelled or was never started, this error code may be returned. |
+
+
+
+###### On Failure: Authentication Error
+
+```
+401 Unauthorized
+WWW-Authenticate: <scheme> realm="<realm>", ..."
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client is not authenticated.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`WWW-Authenticate`|An RFC7235 compliant authentication challenge header.|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHENTICATED` | authentication required | The access controller was unable to authenticate the client. Often this will be accompanied by a 401 Unauthorized response status with a Www-Authenticate header indicating how to authenticate. |
+
+
+
+###### On Failure: No Such Repository Error
+
+```
+404 Not Found
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The repository is not known to the registry.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `NAME_UNKNOWN` | repository name not known to registry | This is returned if the name used during an operation is unknown to the registry. |
+
+
+
+###### On Failure: Authorization Error
+
+```
+403 Forbidden
+Content-Length: <length>
+Content-Type: application/json; charset=utf-8
+
+{
+	"errors:" [
+	    {
+            "code": <error code>,
+            "message": "<error message>",
+            "detail": ...
+        },
+        ...
+    ]
+}
+```
+
+The client does not have required access to the repository.
+
+The following headers will be returned on the response:
+
+|Name|Description|
+|----|-----------|
+|`Content-Length`|Length of the JSON response body.|
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `UNAUTHORIZED` | access to the requested resource is not authorized | The access controller denied access for the operation on a resource. |
 
 
 

--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -33,14 +33,25 @@ var (
 		HTTPStatusCode: http.StatusMethodNotAllowed,
 	})
 
+	// ErrorCodeUnauthenticated is returned if a request requires
+	// authentication.
+	ErrorCodeUnauthenticated = Register("errcode", ErrorDescriptor{
+		Value:   "UNAUTHENTICATED",
+		Message: "authentication required",
+		Description: `The access controller was unable to authenticate
+		the client. Often this will be accompanied by a 401
+		Unauthorized response status with a Www-Authenticate header
+		indicating how to authenticate.`,
+		HTTPStatusCode: http.StatusUnauthorized,
+	})
+
 	// ErrorCodeUnauthorized is returned if a request is not authorized.
 	ErrorCodeUnauthorized = Register("errcode", ErrorDescriptor{
 		Value:   "UNAUTHORIZED",
 		Message: "access to the requested resource is not authorized",
-		Description: `The access controller denied access for the operation on
-		a resource. Often this will be accompanied by a 401 Unauthorized
-		response status.`,
-		HTTPStatusCode: http.StatusUnauthorized,
+		Description: `The access controller denied access for the
+		operation on a resource.`,
+		HTTPStatusCode: http.StatusForbidden,
 	})
 
 	// ErrorCodeUnavailable provides a common error to report unavialability

--- a/registry/auth/auth.go
+++ b/registry/auth/auth.go
@@ -1,9 +1,9 @@
 // Package auth defines a standard interface for request access controllers.
 //
 // An access controller has a simple interface with a single `Authorized`
-// method which checks that a given request is authorized to perform one or
-// more actions on one or more resources. This method should return a non-nil
-// error if the request is not authorized.
+// method which checks that a given context is authorized to perform one or
+// more actions on a resource. This method should return a non-nil
+// error if the context is not authorized.
 //
 // An implementation registers its access controller by name with a constructor
 // which accepts an options map for configuring the access controller.
@@ -15,14 +15,26 @@
 //
 // 		func updateOrder(w http.ResponseWriter, r *http.Request) {
 //			orderNumber := r.FormValue("orderNumber")
-//			resource := auth.Resource{Type: "customerOrder", Name: orderNumber}
-// 			access := auth.Access{Resource: resource, Action: "update"}
+//			order := auth.Resource{Type: "customerOrder", Name: orderNumber}
 //
-// 			if ctx, err := accessController.Authorized(ctx, access); err != nil {
-//				if challenge, ok := err.(auth.Challenge) {
-//					// Let the challenge write the response.
-//					challenge.ServeHTTP(w, r)
-//				} else {
+//			// Is the client authorized to update the order?
+//			if ctx, err := accessController.Authorized(ctx, order, "update"); err != nil {
+//				switch err := err.(type) {
+//				case auth.AuthenticationError:
+//					// Let the error set a challenge header.
+//					err.SetChallengeHeaders(w.Header())
+//					w.WriteHeader(http.StatusUnauthorized)
+//					w.Write([]byte(err.AuthenticationErrorDetails()))
+//					return
+//				case auth.AuthorizationError:
+//					if err.ResourceHidden() {
+//						w.WriteHeader(http.StatusNotFound)
+//						return
+//					}
+//					w.WriteHeader(http.StatusForbidden)
+//					w.Write([]byte(err.AuthorizationErrorDetails()))
+//					return
+//				default:
 //					// Some other error.
 //				}
 //			}
@@ -49,40 +61,66 @@ type Resource struct {
 	Name string
 }
 
-// Access describes a specific action that is
-// requested or allowed for a given resource.
-type Access struct {
-	Resource
-	Action string
-}
-
-// Challenge is a special error type which is used for HTTP 401 Unauthorized
-// responses and is able to write the response with WWW-Authenticate challenge
-// header values based on the error.
-type Challenge interface {
+// AuthenticationError is a special error type which is used to indicate that a
+// client either has invalid authentication credentials or, if the client is
+// not authenticated, should attempt to authenticate in order to access the
+// requested resource. A type which implements this interface is able to set
+// HTTP WWW-Authenticate challenge response header values based on the error.
+// Note: HTTP status code "401 Unauthorized" is used semantically to indicate
+// that the client is "Unauthenticated". To indicate that the client is in fact
+// unauthorized (despite being authenticated), an access controller should
+// return an error implementing the AuthorizationError interface.
+type AuthenticationError interface {
 	error
 
-	// SetHeaders prepares the request to conduct a challenge response by
-	// adding the an HTTP challenge header on the response message. Callers
-	// are expected to set the appropriate HTTP status code (e.g. 401)
-	// themselves.
-	SetHeaders(w http.ResponseWriter)
+	// AuthenticationErrorDetails should return a JSON-serializable object
+	// detailing the authentication error, e.g., authentication required,
+	// invalid username/password, expired token, invalid signature, etc.
+	AuthenticationErrorDetails() interface{}
+
+	// SetChallengeHeaders prepares an authentication challenge response by
+	// setting one or more HTTP WWW-Authenticate challenge headers.
+	// Callers are expected to set the appropriate HTTP status code (i.e.,
+	// 401) themselves.
+	SetChallengeHeaders(h http.Header)
 }
 
-// AccessController controls access to registry resources based on a request
-// and required access levels for a request. Implementations can support both
-// complete denial and http authorization challenges.
+// AuthorizationError is a special error type which is used to indicate that a
+// client is not authorized to access the requested resource.
+type AuthorizationError interface {
+	error
+
+	// AuthorizationErrorDetails should return a JSON-serializable object
+	// detailing the authorization error, e.g., user is not authorized to
+	// push, etc. It is the caller's responsibility to include these
+	// details in an HTTP 403 Forbidden response.
+	AuthorizationErrorDetails() interface{}
+
+	// ResourceHidden should return whether the existence of the requested
+	// resource should be exposed to the client. If true, the caller MUST
+	// return an HTTP 404 Not Found response in lieu of a 403 Forbidden or
+	// 401 Unauthorized response so as to not leak the existince of the
+	// resource to the client.
+	ResourceHidden() bool
+}
+
+// AccessController controls access to a registry resource based on a request
+// context and the attempted actions being performed on that resource.
+// Implementations must validate complete authorization or indicate
+// authentication or authorization errors through the AuthenticationError and
+// AuthorizationError interfaces.
 type AccessController interface {
-	// Authorized returns a non-nil error if the context is granted access and
-	// returns a new authorized context. If one or more Access structs are
-	// provided, the requested access will be compared with what is available
-	// to the context. The given context will contain a "http.request" key with
-	// a `*http.Request` value. If the error is non-nil, access should always
-	// be denied. The error may be of type Challenge, in which case the caller
-	// may have the Challenge handle the request or choose what action to take
-	// based on the Challenge header or response status. The returned context
-	// object should have a "auth.user" value set to a UserInfo struct.
-	Authorized(ctx context.Context, access ...Access) (context.Context, error)
+	// Authorized returns a nil error if the context is granted access and
+	// returns a new authorized context. If one or more action strings are
+	// provided, the requested access will be compared with what is
+	// available to the context. The given context will contain a
+	// "http.request" key with a `*http.Request` value. If the error is
+	// non-nil, access should always be denied. The returned error may
+	// implement the AuthenticationError or AuthorizationError interface in
+	// which case the caller should take the appropriate action based on
+	// the error. The returned context object should have a "auth.user"
+	// value set to a UserInfo struct.
+	Authorized(ctx context.Context, resource Resource, actions ...string) (context.Context, error)
 }
 
 // WithUser returns a context with the authorized user info.

--- a/registry/auth/htpasswd/access_test.go
+++ b/registry/auth/htpasswd/access_test.go
@@ -44,11 +44,11 @@ func TestBasicAccessController(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithRequest(ctx, r)
-		authCtx, err := accessController.Authorized(ctx)
+		authCtx, err := accessController.Authorized(ctx, auth.Resource{})
 		if err != nil {
 			switch err := err.(type) {
-			case auth.Challenge:
-				err.SetHeaders(w)
+			case auth.AuthenticationError:
+				err.SetChallengeHeaders(w.Header())
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			default:

--- a/registry/auth/htpasswd/htpasswd.go
+++ b/registry/auth/htpasswd/htpasswd.go
@@ -33,12 +33,12 @@ func (htpasswd *htpasswd) authenticateUser(username string, password string) err
 		// timing attack paranoia
 		bcrypt.CompareHashAndPassword([]byte{}, []byte(password))
 
-		return ErrAuthenticationFailure
+		return ErrInvalidCredentials
 	}
 
 	err := bcrypt.CompareHashAndPassword([]byte(credentials), []byte(password))
 	if err != nil {
-		return ErrAuthenticationFailure
+		return ErrInvalidCredentials
 	}
 
 	return nil

--- a/registry/auth/silly/access_test.go
+++ b/registry/auth/silly/access_test.go
@@ -17,11 +17,11 @@ func TestSillyAccessController(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(nil, "http.request", r)
-		authCtx, err := ac.Authorized(ctx)
+		authCtx, err := ac.Authorized(ctx, auth.Resource{})
 		if err != nil {
 			switch err := err.(type) {
-			case auth.Challenge:
-				err.SetHeaders(w)
+			case auth.AuthenticationError:
+				err.SetChallengeHeaders(w.Header())
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			default:

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -195,8 +195,8 @@ func TestTokenVerify(t *testing.T) {
 	}
 
 	verifyOps := VerifyOptions{
-		TrustedIssuers:    []string{issuer},
-		AcceptedAudiences: []string{audience},
+		TrustedIssuers:    newStringSet(issuer),
+		AcceptedAudiences: newStringSet(audience),
 		Roots:             rootPool,
 		TrustedKeys:       trustedKeys,
 	}
@@ -275,23 +275,24 @@ func TestAccessController(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testAccess := auth.Access{
-		Resource: auth.Resource{
+	var (
+		ctx          = context.WithValue(nil, "http.request", req)
+		testResource = auth.Resource{
 			Type: "foo",
 			Name: "bar",
-		},
-		Action: "baz",
-	}
+		}
+		testAction = "baz"
+	)
 
-	ctx := context.WithValue(nil, "http.request", req)
-	authCtx, err := accessController.Authorized(ctx, testAccess)
-	challenge, ok := err.(auth.Challenge)
-	if !ok {
-		t.Fatal("accessController did not return a challenge")
-	}
-
-	if challenge.Error() != ErrTokenRequired.Error() {
-		t.Fatalf("accessControler did not get expected error - got %s - expected %s", challenge, ErrTokenRequired)
+	authCtx, err := accessController.Authorized(ctx, testResource, testAction)
+	switch err := err.(type) {
+	case auth.AuthenticationError:
+		if err.Error() != errTokenRequired.Error() {
+			t.Fatalf("accessControler did not get expected error - got %s - expected %s", err, errTokenRequired)
+		}
+		t.Log(err.Error())
+	default:
+		t.Fatal("accessController did not return an authentication error")
 	}
 
 	if authCtx != nil {
@@ -302,9 +303,9 @@ func TestAccessController(t *testing.T) {
 	token, err := makeTestToken(
 		issuer, service,
 		[]*ResourceActions{{
-			Type:    testAccess.Type,
-			Name:    testAccess.Name,
-			Actions: []string{testAccess.Action},
+			Type:    testResource.Type,
+			Name:    testResource.Name,
+			Actions: []string{testAction},
 		}},
 		rootKeys[1], 1, // Everything is valid except the key which signed it.
 	)
@@ -314,53 +315,28 @@ func TestAccessController(t *testing.T) {
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.compactRaw()))
 
-	authCtx, err = accessController.Authorized(ctx, testAccess)
-	challenge, ok = err.(auth.Challenge)
-	if !ok {
-		t.Fatal("accessController did not return a challenge")
-	}
-
-	if challenge.Error() != ErrInvalidToken.Error() {
-		t.Fatalf("accessControler did not get expected error - got %s - expected %s", challenge, ErrTokenRequired)
-	}
-
-	if authCtx != nil {
-		t.Fatalf("expected nil auth context but got %s", authCtx)
-	}
-
-	// 3. Supply a token with insufficient access.
-	token, err = makeTestToken(
-		issuer, service,
-		[]*ResourceActions{}, // No access specified.
-		rootKeys[0], 1,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.compactRaw()))
-
-	authCtx, err = accessController.Authorized(ctx, testAccess)
-	challenge, ok = err.(auth.Challenge)
-	if !ok {
-		t.Fatal("accessController did not return a challenge")
-	}
-
-	if challenge.Error() != ErrInsufficientScope.Error() {
-		t.Fatalf("accessControler did not get expected error - got %s - expected %s", challenge, ErrInsufficientScope)
+	authCtx, err = accessController.Authorized(ctx, testResource, testAction)
+	switch err := err.(type) {
+	case auth.AuthenticationError:
+		if err.Error() != errUntrustedTokenSigner.Error() {
+			t.Fatalf("accessControler did not get expected error - got %s - expected %s", err, errUntrustedTokenSigner)
+		}
+		t.Log(err.Error())
+	default:
+		t.Fatal("accessController did not return an authentication error")
 	}
 
 	if authCtx != nil {
 		t.Fatalf("expected nil auth context but got %s", authCtx)
 	}
 
-	// 4. Supply the token we need, or deserve, or whatever.
+	// 3. Supply a token with no access.
 	token, err = makeTestToken(
 		issuer, service,
 		[]*ResourceActions{{
-			Type:    testAccess.Type,
-			Name:    testAccess.Name,
-			Actions: []string{testAccess.Action},
+			Type:    testResource.Type,
+			Name:    testResource.Name,
+			Actions: []string{},
 		}},
 		rootKeys[0], 1,
 	)
@@ -370,7 +346,69 @@ func TestAccessController(t *testing.T) {
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.compactRaw()))
 
-	authCtx, err = accessController.Authorized(ctx, testAccess)
+	authCtx, err = accessController.Authorized(ctx, testResource, testAction)
+	switch err := err.(type) {
+	case auth.AuthorizationError:
+		if !err.ResourceHidden() {
+			t.Fatalf("accessControler did not get expected error - got %s - expected ResourceHidden() to be true", err)
+		}
+		t.Log(err.Error())
+	default:
+		t.Fatal("accessController did not return an authorization error")
+	}
+
+	if authCtx != nil {
+		t.Fatalf("expected nil auth context but got %s", authCtx)
+	}
+
+	// 4. Supply a token with some other access.
+	token, err = makeTestToken(
+		issuer, service,
+		[]*ResourceActions{{
+			Type:    testResource.Type,
+			Name:    testResource.Name,
+			Actions: []string{"someRandomAction"},
+		}},
+		rootKeys[0], 1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.compactRaw()))
+
+	authCtx, err = accessController.Authorized(ctx, testResource, testAction)
+	switch err := err.(type) {
+	case auth.AuthorizationError:
+		if err.ResourceHidden() {
+			t.Fatalf("accessControler did not get expected error - got %s - expected ResourceHidden() to be false", err)
+		}
+		t.Log(err.Error())
+	default:
+		t.Fatal("accessController did not return an authorization error")
+	}
+
+	if authCtx != nil {
+		t.Fatalf("expected nil auth context but got %s", authCtx)
+	}
+
+	// 5. Supply the token we need, or deserve, or whatever.
+	token, err = makeTestToken(
+		issuer, service,
+		[]*ResourceActions{{
+			Type:    testResource.Type,
+			Name:    testResource.Name,
+			Actions: []string{testAction},
+		}},
+		rootKeys[0], 1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.compactRaw()))
+
+	authCtx, err = accessController.Authorized(ctx, testResource, testAction)
 	if err != nil {
 		t.Fatalf("accessController returned unexpected error: %s", err)
 	}

--- a/registry/auth/token/util.go
+++ b/registry/auth/token/util.go
@@ -45,14 +45,3 @@ func newActionSet(actions ...string) actionSet {
 func (s actionSet) contains(action string) bool {
 	return s.stringSet.contains("*") || s.stringSet.contains(action)
 }
-
-// contains returns true if q is found in ss.
-func contains(ss []string, q string) bool {
-	for _, s := range ss {
-		if s == q {
-			return true
-		}
-	}
-
-	return false
-}

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -549,7 +549,7 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 		// Add username to request logging
 		context.Context = ctxu.WithLogger(context.Context, ctxu.GetLogger(context.Context, "auth.user.name"))
 
-		if app.nameRequired(r) {
+		if nameRequired(r) {
 			repository, err := app.registry.Repository(context, getName(context))
 
 			if err != nil {
@@ -652,41 +652,66 @@ func (app *App) context(w http.ResponseWriter, r *http.Request) *Context {
 // repository. An error will be returned if access is not available.
 func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Context) error {
 	ctxu.GetLogger(context).Debug("authorizing request")
-	repo := getName(context)
+
+	var (
+		resource auth.Resource
+		actions  []string
+		repo     = getName(context)
+	)
 
 	if app.accessController == nil {
 		return nil // access controller is not enabled.
 	}
 
-	var accessRecords []auth.Access
-
-	if repo != "" {
-		accessRecords = appendAccessRecords(accessRecords, r.Method, repo)
-	} else {
-		// Only allow the name not to be set on the base route.
-		if app.nameRequired(r) {
-			// For this to be properly secured, repo must always be set for a
-			// resource that may make a modification. The only condition under
-			// which name is not set and we still allow access is when the
-			// base route is accessed. This section prevents us from making
-			// that mistake elsewhere in the code, allowing any operation to
-			// proceed.
-			if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthorized); err != nil {
-				ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
-			}
-			return fmt.Errorf("forbidden: no repository name")
+	switch {
+	case isV2BaseRoute(r):
+		resource = auth.Resource{
+			Type: "registry",
+			Name: "base",
 		}
-		accessRecords = appendCatalogAccessRecord(accessRecords, r)
+		actions = getRequiredV2BaseActions()
+	case isV2CatalogRoute(r):
+		resource = auth.Resource{
+			Type: "registry",
+			Name: "catalog",
+		}
+		actions = getRequiredCatalogActions()
+	case repo != "":
+		resource = auth.Resource{
+			Type: "repository",
+			Name: repo,
+		}
+		actions = getRequiredRepoActions(r.Method)
+	default:
+		// The route is neither the v2 base route, catolog route, nor
+		// is it any reposistory route. If it is an unknown endpoint
+		// then a case should be added above. Until then, access is
+		// forbidden.
+		if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthorized); err != nil {
+			ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
+		}
+		return fmt.Errorf("forbidden: no repository name")
 	}
 
-	ctx, err := app.accessController.Authorized(context.Context, accessRecords...)
+	ctx, err := app.accessController.Authorized(context.Context, resource, actions...)
 	if err != nil {
 		switch err := err.(type) {
-		case auth.Challenge:
+		case auth.AuthenticationError:
 			// Add the appropriate WWW-Auth header
-			err.SetHeaders(w)
+			err.SetChallengeHeaders(w.Header())
 
-			if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthorized.WithDetail(accessRecords)); err != nil {
+			if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthenticated.WithDetail(err.AuthenticationErrorDetails())); err != nil {
+				ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
+			}
+		case auth.AuthorizationError:
+			if err.ResourceHidden() && resource.Type == "repository" {
+				// Return a 404 Not Found error.
+				if err := errcode.ServeJSON(w, v2.ErrorCodeNameUnknown.WithDetail(distribution.ErrRepositoryUnknown{Name: resource.Name})); err != nil {
+					ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
+				}
+			}
+
+			if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthorized.WithDetail(err.AuthorizationErrorDetails())); err != nil {
 				ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
 			}
 		default:
@@ -708,6 +733,54 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 	return nil
 }
 
+func isV2BaseRoute(r *http.Request) bool {
+	return mux.CurrentRoute(r).GetName() == v2.RouteNameBase
+}
+
+func isV2CatalogRoute(r *http.Request) bool {
+	return mux.CurrentRoute(r).GetName() == v2.RouteNameCatalog
+}
+
+func nameRequired(r *http.Request) bool {
+	return !(isV2BaseRoute(r) || isV2CatalogRoute(r))
+}
+
+// Get the actions required for the v2 base endpoint.
+func getRequiredV2BaseActions() []string {
+	// No actions required. This is also kind of a hack to make the token
+	// access controller backend still work. It will require a valid token
+	// but will not require any access claims. Because the v2 base endpoint
+	// acts as an authentication check endpoint, all access controller
+	// implementations SHOULD require that the client be authenticated.
+	// This means that anonymous clients (those who do not attempt to
+	// authenticate) should receive a 401 response with a challenge
+	// header that can be understood by the registry client built into the
+	// Docker daemon.
+	return []string{}
+}
+
+// Get the actions required for the catalog endpoint.
+func getRequiredCatalogActions() []string {
+	return []string{"*"}
+}
+
+// getRequiredRepoActions returns the appropriate actions required for a
+// repository given the HTTP method.
+func getRequiredRepoActions(method string) []string {
+	switch method {
+	case "GET", "HEAD":
+		return []string{"pull"}
+	case "POST", "PUT", "PATCH":
+		return []string{"pull", "push"}
+	case "DELETE":
+		// DELETE access requires full admin rights, which is represented
+		// as "*". This may not be ideal.
+		return []string{"*"}
+	}
+
+	return nil
+}
+
 // eventBridge returns a bridge for the current request, configured with the
 // correct actor and source.
 func (app *App) eventBridge(ctx *Context, r *http.Request) notifications.Listener {
@@ -719,13 +792,6 @@ func (app *App) eventBridge(ctx *Context, r *http.Request) notifications.Listene
 	return notifications.NewBridge(ctx.urlBuilder, app.events.source, actor, request, app.events.sink)
 }
 
-// nameRequired returns true if the route requires a name.
-func (app *App) nameRequired(r *http.Request) bool {
-	route := mux.CurrentRoute(r)
-	routeName := route.GetName()
-	return route == nil || (routeName != v2.RouteNameBase && routeName != v2.RouteNameCatalog)
-}
-
 // apiBase implements a simple yes-man for doing overall checks against the
 // api. This can support auth roundtrips to support docker login.
 func apiBase(w http.ResponseWriter, r *http.Request) {
@@ -735,62 +801,6 @@ func apiBase(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", fmt.Sprint(len(emptyJSON)))
 
 	fmt.Fprint(w, emptyJSON)
-}
-
-// appendAccessRecords checks the method and adds the appropriate Access records to the records list.
-func appendAccessRecords(records []auth.Access, method string, repo string) []auth.Access {
-	resource := auth.Resource{
-		Type: "repository",
-		Name: repo,
-	}
-
-	switch method {
-	case "GET", "HEAD":
-		records = append(records,
-			auth.Access{
-				Resource: resource,
-				Action:   "pull",
-			})
-	case "POST", "PUT", "PATCH":
-		records = append(records,
-			auth.Access{
-				Resource: resource,
-				Action:   "pull",
-			},
-			auth.Access{
-				Resource: resource,
-				Action:   "push",
-			})
-	case "DELETE":
-		// DELETE access requires full admin rights, which is represented
-		// as "*". This may not be ideal.
-		records = append(records,
-			auth.Access{
-				Resource: resource,
-				Action:   "*",
-			})
-	}
-	return records
-}
-
-// Add the access record for the catalog if it's our current route
-func appendCatalogAccessRecord(accessRecords []auth.Access, r *http.Request) []auth.Access {
-	route := mux.CurrentRoute(r)
-	routeName := route.GetName()
-
-	if routeName == v2.RouteNameCatalog {
-		resource := auth.Resource{
-			Type: "registry",
-			Name: "catalog",
-		}
-
-		accessRecords = append(accessRecords,
-			auth.Access{
-				Resource: resource,
-				Action:   "*",
-			})
-	}
-	return accessRecords
 }
 
 // applyRegistryMiddleware wraps a registry instance with the configured middlewares


### PR DESCRIPTION
The existing Challenge error interface is not sufficient enough to represent
the various kinds of responses and policies that an authorization mechanism
may want to have.

This patch replaces the Challenge interface with two separate interfaces:

- AuthenticationError

  This error type is used to indicate that the client should attempt to
  authenticate or has provided invalid authentication credentials. These
  errors should result in HTTP 401 Unauthorized responses with a challenge
  header informing the client of how to authenticate.

- AuthorizationError

  This error type is used to indicate that the authenticated or anonymous
  client does not have permission to access the requested resource. These
  errors usually result in HTTP 403 Forbidden responses but may also indicate
  that the resource should remain hidden from the client, in which case the
  server should respond with 404 Not Found in order to not leak knowledge of
  the existence of that resource.

## Summary of Changes

- **`registry/auth`**
    - Updated the `AccessController` interface to accept only a single resource (multiple resources are never used; we can always change this in the future if we need to, but there's no need to expand the surface of the interface if we do not have to).
    - Replaced the `Challenge` interface with the above described `AuthenticationError` and `AuthorizationError` interfaces.

- **`registry/auth/silly`**
    - This is only a reference basic auth implementation but it has been updated to implement the `AuthenticationError` interface. This access controller does not return `AuthorizationError`s.

- **`registry/auth/htpasswd`**
    - Updated to implement the `AuthenticationError` interface. This access controller does not return `AuthorizationError`s.

- **`registry/auth/token`**
    - Updated to implement the `AuthenticationError` and `AuthorizationError` interfaces. Requests without a token or requests with invalid tokens (e.g., expired or not yet valid, untrusted issuer/signer, unverified signature, etc) result in `AuthenticationError`s. Requests with valid tokens which do not have an appropriate access claim result in `AuthorizationError`s.

- **`registry/handlers`**
    - Updated the `Authorized()` method to handle `auth.AuthenticationError` and `auth.AuthorizationError`. Authorization errors which indicate that the resource should be hidden from the client will result in a `404 Not Found` response with error code `NAME_UNKNOWN`.

- **`registry/api/errcode`**
    - Updated `UNAUTHORIZED` error code message and status to reflect that it is *not* an authentication error and returns `403 Forbidden` responses. These errors should no longer have `Www-Authenticate` response headers.
    - Added `UNAUTHENTICATED` error code message which indicates authentication errors and returns `401 Unauthorized` (read: *unauthenticated*) responses which may have `Www-Authenticate` challenge headers.

Fixes #749
Fixes #967 