### PR TITLE
Avoid importing "testing" in externally-facing code

### DIFF
--- a/registry/storage/cache/cachecheck/suite.go
+++ b/registry/storage/cache/cachecheck/suite.go
@@ -1,4 +1,4 @@
-package cache
+package cachecheck
 
 import (
 	"testing"
@@ -6,19 +6,20 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/registry/storage/cache"
 )
 
 // CheckBlobDescriptorCache takes a cache implementation through a common set
 // of operations. If adding new tests, please add them here so new
 // implementations get the benefit. This should be used for unit tests.
-func CheckBlobDescriptorCache(t *testing.T, provider BlobDescriptorCacheProvider) {
+func CheckBlobDescriptorCache(t *testing.T, provider cache.BlobDescriptorCacheProvider) {
 	ctx := context.Background()
 
 	checkBlobDescriptorCacheEmptyRepository(t, ctx, provider)
 	checkBlobDescriptorCacheSetAndRead(t, ctx, provider)
 }
 
-func checkBlobDescriptorCacheEmptyRepository(t *testing.T, ctx context.Context, provider BlobDescriptorCacheProvider) {
+func checkBlobDescriptorCacheEmptyRepository(t *testing.T, ctx context.Context, provider cache.BlobDescriptorCacheProvider) {
 	if _, err := provider.Stat(ctx, "sha384:abc"); err != distribution.ErrBlobUnknown {
 		t.Fatalf("expected unknown blob error with empty store: %v", err)
 	}
@@ -56,7 +57,7 @@ func checkBlobDescriptorCacheEmptyRepository(t *testing.T, ctx context.Context, 
 	}
 }
 
-func checkBlobDescriptorCacheSetAndRead(t *testing.T, ctx context.Context, provider BlobDescriptorCacheProvider) {
+func checkBlobDescriptorCacheSetAndRead(t *testing.T, ctx context.Context, provider cache.BlobDescriptorCacheProvider) {
 	localDigest := digest.Digest("sha384:abc")
 	expected := distribution.Descriptor{
 		Digest:    "sha256:abc",
@@ -140,7 +141,7 @@ func checkBlobDescriptorCacheSetAndRead(t *testing.T, ctx context.Context, provi
 	}
 }
 
-func checkBlobDescriptorClear(t *testing.T, ctx context.Context, provider BlobDescriptorCacheProvider) {
+func checkBlobDescriptorClear(t *testing.T, ctx context.Context, provider cache.BlobDescriptorCacheProvider) {
 	localDigest := digest.Digest("sha384:abc")
 	expected := distribution.Descriptor{
 		Digest:    "sha256:abc",

--- a/registry/storage/cache/memory/memory_test.go
+++ b/registry/storage/cache/memory/memory_test.go
@@ -3,11 +3,11 @@ package memory
 import (
 	"testing"
 
-	"github.com/docker/distribution/registry/storage/cache"
+	"github.com/docker/distribution/registry/storage/cache/cachecheck"
 )
 
 // TestInMemoryBlobInfoCache checks the in memory implementation is working
 // correctly.
 func TestInMemoryBlobInfoCache(t *testing.T) {
-	cache.CheckBlobDescriptorCache(t, NewInMemoryBlobDescriptorCacheProvider())
+	cachecheck.CheckBlobDescriptorCache(t, NewInMemoryBlobDescriptorCacheProvider())
 }

--- a/registry/storage/cache/redis/redis_test.go
+++ b/registry/storage/cache/redis/redis_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/distribution/registry/storage/cache"
+	"github.com/docker/distribution/registry/storage/cache/cachecheck"
 	"github.com/garyburd/redigo/redis"
 )
 
@@ -47,5 +47,5 @@ func TestRedisBlobDescriptorCacheProvider(t *testing.T) {
 		t.Fatalf("unexpected error flushing redis db: %v", err)
 	}
 
-	cache.CheckBlobDescriptorCache(t, NewRedisBlobDescriptorCacheProvider(pool))
+	cachecheck.CheckBlobDescriptorCache(t, NewRedisBlobDescriptorCacheProvider(pool))
 }


### PR DESCRIPTION
The "testing" package adds some flags in its init function, so utilities
that import distribution code can print a page of extra testing flags in
their help output.

This commit solves the issue by moving an import of "testing" in the
registry/storage/cache package to a new registry/storage/cache/testsuite
package, which is only imported by tests.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>