### PR TITLE
Do a simple [create, read, delete] test when creating a storage driver

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -91,7 +91,7 @@ func NewApp(ctx context.Context, configuration *configuration.Configuration) *Ap
 	app.register(v2.RouteNameBlobUploadChunk, blobUploadDispatcher)
 
 	var err error
-	app.driver, err = factory.Create(configuration.Storage.Type(), configuration.Storage.Parameters())
+	app.driver, err = factory.Create(app, configuration.Storage.Type(), configuration.Storage.Parameters())
 	if err != nil {
 		// TODO(stevvooe): Move the creation of a service into a protected
 		// method, where this is created lazily. Its status can be queried via

--- a/registry/storage/driver/factory/factory.go
+++ b/registry/storage/driver/factory/factory.go
@@ -2,8 +2,12 @@ package factory
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 
+	"github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
+	"github.com/docker/distribution/uuid"
 )
 
 // driverFactories stores an internal mapping between storage driver names and their respective
@@ -37,12 +41,66 @@ func Register(name string, factory StorageDriverFactory) {
 // parameters. To use a driver, the StorageDriverFactory must first be
 // registered with the given name. If no drivers are found, an
 // InvalidStorageDriverError is returned
-func Create(name string, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
+func Create(ctx context.Context, name string, parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	driverFactory, ok := driverFactories[name]
 	if !ok {
 		return nil, InvalidStorageDriverError{name}
 	}
-	return driverFactory.Create(parameters)
+	d, err := driverFactory.Create(parameters)
+	if err != nil {
+		return nil, err
+	}
+	err = verify(ctx, d)
+	if err != nil {
+		return nil, fmt.Errorf(`Unable to verify read, write and delete permissions on storage type %q.  
+The registry requires these permissions in order to operate correctly (error : %v)`, name, err)
+	}
+	return d, nil
+}
+
+// Ensure that the configured storage driver has permissions for the registry to function
+// i.e. read, write and delete a file
+func verify(ctx context.Context, driver storagedriver.StorageDriver) error {
+	randomFile := fmt.Sprintf("/%s", uuid.Generate().String())
+	err := driver.PutContent(ctx, randomFile, []byte(""))
+	if err != nil {
+		return fmt.Errorf("unable to write verification file: %s", err)
+	}
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	// May have eventually consistent storage
+	max := 3 * time.Second
+	duration := 10 * time.Millisecond
+
+	for duration < max {
+		if _, err := driver.Stat(ctx, randomFile); err != nil {
+			switch err := err.(type) {
+			case storagedriver.PathNotFoundError:
+				time.Sleep(duration)
+				duration = backOffSeconds(duration)
+				continue
+			default:
+				return err
+			}
+		}
+		_, err := driver.GetContent(ctx, randomFile)
+		if err == nil {
+			break
+		}
+		return fmt.Errorf("unable to read verification file: %s", err)
+	}
+
+	err = driver.Delete(ctx, randomFile)
+	if err != nil {
+		return fmt.Errorf("unable to delete verification file: %s", err)
+	}
+	return nil
+}
+
+func backOffSeconds(d time.Duration) time.Duration {
+	d *= 2
+	d += time.Microsecond * time.Duration(rand.Int63n(1000))
+	return d
 }
 
 // InvalidStorageDriverError records an attempt to construct an unregistered storage driver


### PR DESCRIPTION
This can help debug misconfigured AMIs and other storage driver configurations which would
prevent the registry from operating correctly.

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>