### PR TITLE
WIP: Added pruner binary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Aaron Lehmann <aaron.lehmann@docker.com>
+Aaron Vinson <avinson.public@gmail.com>
 Adam Enger <adamenger@gmail.com>
 Adrian Mouat <adrian.mouat@gmail.com>
 Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>
@@ -25,6 +26,7 @@ David Lawrence <david.lawrence@docker.com>
 David Verhasselt <david@crowdway.com>
 David Xia <dxia@spotify.com>
 davidli <wenquan.li@hp.com>
+Dejan Golja <dejan@golja.org>
 Derek McGowan <derek@mcgstyle.net>
 Diogo Mónica <diogo.monica@gmail.com>
 Donald Huang <don.hcd@gmail.com>
@@ -33,6 +35,7 @@ Florentin Raud <florentin.raud@gmail.com>
 Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
 Henri Gomez <henri.gomez@gmail.com>
 Hu Keping <hukeping@huawei.com>
+Hua Wang <wanghua.humble@gmail.com>
 Ian Babrou <ibobrik@gmail.com>
 Jeff Nickoloff <jeff@allingeek.com>
 Jessie Frazelle <jfrazelle@users.noreply.github.com>
@@ -44,15 +47,20 @@ Julien Fernandez <julien.fernandez@gmail.com>
 Kelsey Hightower <kelsey.hightower@gmail.com>
 Kenneth Lim <kennethlimcp@gmail.com>
 Li Yi <denverdino@gmail.com>
+Louis Kottmann <louis.kottmann@gmail.com>
 Luke Carpenter <x@rubynerd.net>
 Mary Anthony <mary@docker.com>
 Matt Bentley <mbentley@mbentley.net>
+Matt Moore <mattmoor@google.com>
 Matt Robenolt <matt@ydekproductions.com>
 Michael Prokop <mika@grml.org>
+Michal Minar <miminar@redhat.com>
+Miquel Sabaté <msabate@suse.com>
 moxiegirl <mary@docker.com>
 Nathan Sullivan <nathan@nightsys.net>
 nevermosby <robolwq@qq.com>
 Nghia Tran <tcnghia@gmail.com>
+Nuutti Kotivuori <nuutti.kotivuori@poplatek.fi>
 Oilbeater <liumengxinfly@gmail.com>
 Olivier Gambier <olivier@docker.com>
 Olivier Jacques <olivier.jacques@hp.com>
@@ -65,6 +73,7 @@ Shreyas Karnik <karnik.shreyas@gmail.com>
 Simon Thulbourn <simon+github@thulbourn.com>
 Spencer Rinehart <anubis@overthemonkey.com>
 Stephen J Day <stephen.day@docker.com>
+Sungho Moon <sungho.moon@navercorp.com>
 Sylvain Baubeau <sbaubeau@redhat.com>
 tgic <farmer1992@gmail.com>
 Thomas Sjögren <konstruktoid@users.noreply.github.com>
@@ -73,7 +82,9 @@ Tibor Vass <teabee89@gmail.com>
 Vincent Batts <vbatts@redhat.com>
 Vincent Demeester <vincent@sbr.pm>
 Vincent Giersch <vincent.giersch@ovh.net>
+Vincent Giersch <vincent@giersch.fr>
 W. Trevor King <wking@tremily.us>
+xg.song <xg.song@venusource.com>
 xiekeyang <xiekeyang@huawei.com>
 Yann ROBERT <yann.robert@anantaplex.fr>
 yuzou <zouyu7@huawei.com>

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ ${PREFIX}/bin/registry-api-descriptor-template: version/version.go $(shell find 
 	@echo "+ $@"
 	@go build -o $@ ${GO_LDFLAGS} ${GO_GCFLAGS} ./cmd/registry-api-descriptor-template
 
+${PREFIX}/bin/pruner: version/version.go $(shell find . -type f -name '*.go')
+	@echo "+ $@"
+	@go build -tags "${DOCKER_BUILDTAGS}" -o $@ ${GO_LDFLAGS}  ${GO_GCFLAGS} ./cmd/pruner
+
 docs/spec/api.md: docs/spec/api.md.tmpl ${PREFIX}/bin/registry-api-descriptor-template
 	./bin/registry-api-descriptor-template $< > $@
 
@@ -66,7 +70,7 @@ test-full:
 	@echo "+ $@"
 	@go test ./...
 
-binaries: ${PREFIX}/bin/registry ${PREFIX}/bin/digest ${PREFIX}/bin/registry-api-descriptor-template
+binaries: ${PREFIX}/bin/registry ${PREFIX}/bin/digest ${PREFIX}/bin/registry-api-descriptor-template ${PREFIX}/bin/pruner
 	@echo "+ $@"
 
 clean:

--- a/cmd/pruner/main.go
+++ b/cmd/pruner/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/docker/distribution/pruner"
+	_ "github.com/docker/distribution/registry"
+	_ "github.com/docker/distribution/registry/auth/silly"
+	_ "github.com/docker/distribution/registry/storage/driver/filesystem"
+)
+
+func main() {
+	pruner.Cmd.Execute()
+}

--- a/pruner/graph.go
+++ b/pruner/graph.go
@@ -1,0 +1,328 @@
+package pruner
+
+import (
+	"bufio"
+	"container/list"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/registry/storage"
+	"github.com/docker/distribution/registry/storage/driver"
+	"github.com/docker/distribution/registry/storage/driver/factory"
+)
+
+const (
+	confirmText = "Do you really want to permanently delete objects? [y/n]: "
+)
+
+type byName []string
+
+func (ris byName) Len() int           { return len(ris) }
+func (ris byName) Less(i, j int) bool { return ris[i] < ris[j] }
+func (ris byName) Swap(i, j int)      { ris[i], ris[j] = ris[j], ris[i] }
+
+// Pruner allows to collect information about registry from local filesystem
+// and to prune no longer needed or invalid objects.
+type Pruner struct {
+	Config
+	ctx context.Context
+}
+
+// NewPruner returns a new instance of pruner.
+func NewPruner(c *Config, ctx context.Context) *Pruner {
+	return &Pruner{*c, ctx}
+}
+
+// O is a helper method that Prints given message to command's output stream.
+func (p *Pruner) O(format string, a ...interface{}) {
+	fmt.Fprintf(p.Out, format, a...)
+}
+
+// LoadRegistryGraph scans a filesystem and returns registry's representation.
+func (p *Pruner) LoadRegistryGraph(reg *Registry) (*storage.RegistryGraph, error) {
+	sd, err := factory.Create(reg.config.Storage.Type(), reg.config.Storage.Parameters())
+	if err != nil {
+		return nil, err
+	}
+	if p.Verbose {
+		fmt.Fprintf(p.Out, "Exploring storage \"%s\" [ver %s] ...\n", sd.Name(), driver.CurrentVersion)
+	}
+	vacuum := storage.NewVacuum(p.ctx, sd)
+	rg, err := storage.LoadRegistryGraph(&vacuum)
+	if err != nil {
+		return nil, err
+	}
+	return rg, nil
+}
+
+// ProcessRegistryGraph prints what can be cleaned in given registry and prunes it if told.
+func (p *Pruner) ProcessRegistryGraph(reg *Registry, rg *storage.RegistryGraph) error {
+	dirty := p.PrintOrphanedObjects(rg)
+	if !dirty {
+		p.O("Registry is clean. Nothing to do.\n")
+		return nil
+	}
+	if p.DryRun {
+		return nil
+	}
+
+	if !p.Confirm || confirmPrune(p.In, p.Out) {
+		return rg.PruneOrphanedObjects(p.RemoveEmpty)
+	}
+	p.O("Nothing changed.\n")
+
+	return nil
+}
+
+// PrintOrphanedObjects prints information about all the objects that can be
+// cleaned up.
+func (p *Pruner) PrintOrphanedObjects(rg *storage.RegistryGraph) bool {
+	what := "About to"
+	suffix := "."
+	if p.DryRun {
+		what = "Would"
+	}
+	if p.Verbose {
+		suffix = ":"
+	}
+
+	registryDirty := false
+	// Collect additional blobs being unreferenced as a consequence of deleting
+	// repository's object.
+	unreferencedBlobs := list.New()
+
+	if p.Verbose {
+		p.O("Total repositories %d.\n", rg.TotalRepositories)
+	}
+
+	prealloc := len(rg.DirtyRepositories)
+	if p.RemoveEmpty && len(rg.EmptyRepositories) > len(rg.DirtyRepositories) {
+		prealloc = len(rg.EmptyRepositories)
+	}
+	repoList := make([]string, 0, prealloc)
+
+	// Print empty repositories
+	if p.RemoveEmpty {
+		for name := range rg.EmptyRepositories {
+			repoList = append(repoList, name)
+		}
+		sort.Sort(byName(repoList))
+		if len(repoList) > 0 {
+			if p.DryRun {
+				p.O("%s remove %d empty repositories:\n", what, len(repoList))
+			} else {
+				p.O("%s to remove %d repositories:\n", what, len(repoList))
+			}
+			for _, name := range repoList {
+				p.O("  %s\n", name)
+				repo := rg.EmptyRepositories[name]
+				for ldgst := range repo.Layers {
+					unreferencedBlobs.PushBack(ldgst)
+				}
+				for _, mi := range repo.DanglingManifests {
+					for _, sdgst := range mi.Signatures {
+						unreferencedBlobs.PushBack(sdgst)
+					}
+				}
+				for _, mi := range repo.UnlinkedManifests {
+					for _, sdgst := range mi.Signatures {
+						unreferencedBlobs.PushBack(sdgst)
+					}
+				}
+			}
+			registryDirty = true
+		}
+		repoList = repoList[0:0]
+	}
+
+	// Print dirty repositories
+	for name := range rg.DirtyRepositories {
+		if _, exists := rg.EmptyRepositories[name]; !p.RemoveEmpty || !exists {
+			repoList = append(repoList, name)
+		}
+	}
+	if len(repoList) > 0 {
+		p.O("%s clean up %d dirty repositories:\n", what, len(repoList))
+		sort.Sort(byName(repoList))
+		for _, name := range repoList {
+			p.O("  %s:\n", name)
+			blobs := p.printOrphanedRepositoryObjects("    ", name, rg.DirtyRepositories[name])
+			unreferencedBlobs.PushBackList(blobs)
+		}
+		registryDirty = true
+	}
+
+	// Unreference additional blobs
+	var blobs storage.BlobRefCounter
+	if unreferencedBlobs.Len() > 0 {
+		// copy rg.Blobs map and decrease ref counters for additional unreferenced blobs
+		blobs = make(map[digest.Digest]uint)
+		for bdgst, rc := range rg.Blobs {
+			blobs[bdgst] = rc
+		}
+		for e := unreferencedBlobs.Front(); e != nil; e = e.Next() {
+			if val, exists := blobs[e.Value.(digest.Digest)]; exists {
+				if val > 0 {
+					blobs[e.Value.(digest.Digest)] = val - 1
+				} else {
+					context.GetLogger(p.ctx).Fatalf("There's a bug in reference counting!")
+				}
+			}
+		}
+	} else {
+		blobs = rg.Blobs
+	}
+
+	// Print all orphaned blobs
+	unreferencedBlobs = blobs.GetUnreferenced()
+	if unreferencedBlobs.Len() > 0 {
+		if p.DryRun {
+			p.O("%s remove %d unreferenced blobs%s\n", what, unreferencedBlobs.Len(), suffix)
+		} else {
+			p.O("%s to remove %d unreferenced blobs%s\n", what, unreferencedBlobs.Len(), suffix)
+		}
+		if p.Verbose {
+			for e := unreferencedBlobs.Front(); e != nil; e = e.Next() {
+				p.O("  %s\n", e.Value.(digest.Digest).String())
+			}
+		}
+		registryDirty = true
+	}
+
+	// Print void blobs
+	if len(rg.VoidBlobs) > 0 {
+		p.O("Would remove %d void blob directories%s\n", len(rg.VoidBlobs), suffix)
+		if p.Verbose {
+			for dgst := range rg.VoidBlobs {
+				p.O("  %s\n", dgst.String())
+			}
+		}
+	}
+
+	return registryDirty
+}
+
+func (p *Pruner) printOrphanedRepositoryObjects(indent string, repoName string, rg *storage.RepositoryGraphInfo) *list.List {
+	what := "About to"
+	suffix := "."
+	if p.DryRun {
+		what = "Would"
+	}
+	if p.Verbose {
+		suffix = ":"
+	}
+
+	unreferencedBlobs := rg.Layers.GetUnreferenced()
+
+	if unreferencedBlobs.Len() > 0 {
+		p.O("%s%s delete %d unreferenced layers%s\n", indent, what, unreferencedBlobs.Len(), suffix)
+		if p.Verbose {
+			for e := unreferencedBlobs.Front(); e != nil; e = e.Next() {
+				p.O("%s  %s\n", indent, e.Value.(digest.Digest).String())
+			}
+		}
+	}
+
+	if len(rg.DanglingLayers) > 0 {
+		p.O("%s%s delete %d dangling layers%s\n", indent, what, len(rg.DanglingLayers), suffix)
+		if p.Verbose {
+			for layerRef := range rg.DanglingLayers {
+				p.O("%s  %s\n", indent, layerRef)
+			}
+		}
+	}
+
+	if len(rg.UnlinkedLayers) > 0 {
+		p.O("%s%s clear %d unlinked layers%s\n", indent, what, len(rg.UnlinkedLayers), suffix)
+		if p.Verbose {
+			for layerRef := range rg.UnlinkedLayers {
+				p.O("%s  %s\n", indent, layerRef)
+			}
+		}
+	}
+
+	if len(rg.DanglingManifests) > 0 {
+		p.O("%s%s delete %d dangling manifest revisions%s\n", indent, what, len(rg.DanglingManifests), suffix)
+		for mRef, mi := range rg.DanglingManifests {
+			if p.Verbose {
+				p.O("%s  %s\n", indent, mRef)
+			}
+			for _, sRef := range mi.Signatures {
+				if p.Verbose {
+					p.O("%s    with signature %s\n", indent, sRef)
+				}
+				unreferencedBlobs.PushBack(sRef)
+			}
+		}
+	}
+
+	if len(rg.UnlinkedManifests) > 0 {
+		p.O("%s%s clear %d unlinked manifest revisions%s\n", indent, what, len(rg.UnlinkedManifests), suffix)
+		for mRef, mi := range rg.UnlinkedManifests {
+			if p.Verbose {
+				p.O("%s  %s\n", indent, mRef)
+			}
+			for _, sRef := range mi.Signatures {
+				if p.Verbose {
+					p.O("%s    with signature %s\n", indent, sRef)
+				}
+				unreferencedBlobs.PushBack(sRef)
+			}
+		}
+	}
+
+	for _, mi := range rg.Manifests {
+		if len(mi.DanglingSignatures) > 0 {
+			revisionName := repoName + ":" + mi.Tag
+			p.O("%s%s delete %s dangling signatures from %s manifest revision%s\n", indent, what, len(mi.DanglingSignatures), revisionName, suffix)
+
+			if p.Verbose {
+				for _, sRef := range mi.DanglingSignatures {
+					p.O("%s  %s\n", indent, sRef)
+				}
+			}
+		}
+	}
+
+	if len(rg.DanglingTags) > 0 {
+		p.O("%s%s delete %d dangling tags from %s repository%s\n", indent, what, len(rg.DanglingTags), repoName, suffix)
+		for tag, dgst := range rg.DanglingTags {
+			p.O("%s  %s -> %s\n", indent, tag, dgst.String())
+		}
+	}
+
+	if len(rg.InvalidTags) > 0 {
+		p.O("%s%s delete %d invalid tags from %s repository%s\n", indent, what, len(rg.InvalidTags), repoName, suffix)
+		for _, tag := range rg.InvalidTags {
+			p.O("%s  %s\n", indent, tag)
+		}
+	}
+
+	return unreferencedBlobs
+}
+
+func confirmPrune(in io.Reader, out io.Writer) bool {
+	answer := ""
+
+	for answer != "n" && answer != "y" {
+		fmt.Fprintf(out, confirmText)
+		answer = strings.ToLower(strings.TrimSpace(readInput(in, out)))
+	}
+
+	return answer == "y"
+}
+
+func readInput(in io.Reader, out io.Writer) string {
+	reader := bufio.NewReader(in)
+	line, _, err := reader.ReadLine()
+	if err != nil {
+		fmt.Fprintln(out, err.Error())
+		os.Exit(1)
+	}
+	return string(line)
+}

--- a/pruner/pruner.go
+++ b/pruner/pruner.go
@@ -1,0 +1,146 @@
+package pruner
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/uuid"
+	"github.com/docker/distribution/version"
+	"github.com/spf13/cobra"
+)
+
+const (
+	binaryName      = "pruner"
+	helpMessageTmpl = `%s allows to print and/or delete registry's orphaned blobs.
+
+Make sure that registry instance isn't running or is running in read-only mode
+before launching this executable.`
+)
+
+// Cmd is a cobra command for running the registry.
+var Cmd = &cobra.Command{
+	Use:   "<config>",
+	Short: fmt.Sprintf("%s deletes orphaned blobs", binaryName),
+	Long:  fmt.Sprintf(helpMessageTmpl, binaryName),
+	Run: func(cmd *cobra.Command, args []string) {
+		if showVersion {
+			version.PrintVersion()
+			return
+		}
+
+		// setup context
+		ctx := context.WithVersion(context.Background(), version.Version)
+
+		registryConfig, err := resolveConfiguration(args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "configuration error: %v\n", err)
+			cmd.Usage()
+			os.Exit(1)
+		}
+
+		registry, err := NewRegistry(ctx, registryConfig)
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		prunerConfig.In = os.Stdin
+		prunerConfig.Out = cmd.Out()
+		if prunerConfig.Out == nil {
+			prunerConfig.Out = os.Stdout
+		}
+
+		pruner := NewPruner(&prunerConfig, ctx)
+		rg, err := pruner.LoadRegistryGraph(registry)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		err = pruner.ProcessRegistryGraph(registry, rg)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	},
+}
+
+// Config holds parameters for Pruner loaded from program arguments and config
+// file.
+type Config struct {
+	RemoveEmpty bool
+	DryRun      bool
+	Confirm     bool
+	Verbose     bool
+	Out         io.Writer
+	In          io.Reader
+}
+
+var (
+	showVersion  bool
+	prunerConfig Config
+)
+
+func init() {
+	Cmd.PersistentFlags().BoolVarP(&prunerConfig.RemoveEmpty, "remove-empty", "e", false, "remove empty repositories (containing 0 manifest revisions)")
+	Cmd.PersistentFlags().BoolVarP(&prunerConfig.DryRun, "dry-run", "n", false, "perform a trial prune with no changes to registry")
+	Cmd.PersistentFlags().BoolVarP(&prunerConfig.Confirm, "confirm", "c", true, "ask for confirmation before making changes")
+	Cmd.PersistentFlags().BoolVarP(&prunerConfig.Verbose, "verbose", "v", false, "turn on verbosive output")
+	Cmd.PersistentFlags().BoolVarP(&showVersion, "version", "V", false, "show the version and exit")
+}
+
+// A Registry represents a complete instance of the registry.
+type Registry struct {
+	config *configuration.Configuration
+}
+
+// NewRegistry creates a new registry from a context and configuration struct.
+func NewRegistry(ctx context.Context, config *configuration.Configuration) (*Registry, error) {
+	var err error
+
+	if prunerConfig.Verbose {
+		log.SetLevel(log.InfoLevel)
+	} else {
+		log.SetLevel(log.WarnLevel)
+	}
+	ctx = context.WithLogger(ctx, context.GetLogger(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("error configuring logger: %v", err)
+	}
+
+	// inject a logger into the uuid library. warns us if there is a problem
+	// with uuid generation under low entropy.
+	uuid.Loggerf = context.GetLogger(ctx).Warnf
+
+	return &Registry{
+		config: config,
+	}, nil
+}
+
+func resolveConfiguration(args []string) (*configuration.Configuration, error) {
+	var configurationPath string
+
+	if len(args) > 0 {
+		configurationPath = args[0]
+	} else if os.Getenv("REGISTRY_CONFIGURATION_PATH") != "" {
+		configurationPath = os.Getenv("REGISTRY_CONFIGURATION_PATH")
+	}
+
+	if configurationPath == "" {
+		return nil, fmt.Errorf("configuration path unspecified")
+	}
+
+	fp, err := os.Open(configurationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer fp.Close()
+
+	config, err := configuration.Parse(fp)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing %s: %v", configurationPath, err)
+	}
+
+	return config, nil
+}

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -37,7 +37,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 
 	s := scheduler.New(ctx, driver, "/scheduler-state.json")
 	s.OnBlobExpire(func(digest string) error {
-		return v.RemoveBlob(digest)
+		return v.RemoveBlob(digest, false)
 	})
 	s.OnManifestExpire(func(repoName string) error {
 		return v.RemoveRepository(repoName)

--- a/registry/storage/graph.go
+++ b/registry/storage/graph.go
@@ -1,0 +1,600 @@
+package storage
+
+import (
+	"container/list"
+	"fmt"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest/schema1"
+)
+
+// graph contains functions for collecting information about orphaned objects
+// and dangling links.
+// These functions will only reliably work on strongly consistent storage
+// systems.
+// https://en.wikipedia.org/wiki/Consistency_model
+
+// Empty is a type of set values using no space.
+type Empty struct{}
+
+// ManifestRevisionReferences maps digests to corresponding manifest revision objects.
+type ManifestRevisionReferences map[digest.Digest]*ManifestRevisionGraphInfo
+
+// BlobRefSet is a set of digests.
+type BlobRefSet map[digest.Digest]Empty
+
+// Add adds digest to the set.
+func (bs BlobRefSet) Add(ds ...digest.Digest) {
+	for _, d := range ds {
+		bs[d] = Empty{}
+	}
+}
+
+// Has returns true if given digest is present in the set.
+func (bs BlobRefSet) Has(d digest.Digest) bool {
+	_, exists := bs[d]
+	return exists
+}
+
+// BlobRefCounter maps digests to its reference counter.
+type BlobRefCounter map[digest.Digest]uint
+
+// Add adds new digest entries to a map with a reference counter 0.
+func (brc BlobRefCounter) Add(ds ...digest.Digest) {
+	for _, d := range ds {
+		brc[d] = 0
+	}
+}
+
+// Has returns true if given digest is contained in the map.
+func (brc BlobRefCounter) Has(d digest.Digest) bool {
+	_, exists := brc[d]
+	return exists
+}
+
+// Reference increments reference counter for given digest and returns its new
+// value if the digest is present. Returns 0 otherwise.
+func (brc BlobRefCounter) Reference(d digest.Digest) uint {
+	if val, exists := brc[d]; exists {
+		brc[d] = val + 1
+		return val + 1
+	}
+	return 0
+}
+
+// Unreference decrements reference counter for given digest and retuns its new
+// value. Decrementing the counter below 0 causes panic. It does nothing for
+// unpresent digests.
+func (brc BlobRefCounter) Unreference(d digest.Digest) uint {
+	if val, exists := brc[d]; exists {
+		if val == 0 {
+			log.Fatalf("Decreasing reference count of blob %s below zero", d.String())
+		}
+		brc[d] = val - 1
+		return val - 1
+	}
+	return 0
+}
+
+// HasUnreferenced returns true if the any of contained digests isn't
+// referenced (its reference counter is 0).
+func (brc BlobRefCounter) HasUnreferenced() bool {
+	for _, rc := range brc {
+		if rc == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// GetUnreferenced returns a list of unreferenced digests.
+func (brc BlobRefCounter) GetUnreferenced() *list.List {
+	res := list.New()
+	for ref, rc := range brc {
+		if rc == 0 {
+			res.PushBack(ref)
+		}
+	}
+	return res
+}
+
+// ManifestRevisionGraphInfo stores information about a manifest revision.
+type ManifestRevisionGraphInfo struct {
+	Tag        string
+	Signatures []digest.Digest
+	// DanglingSignatures is an array of signatures pointing to deleted blobs.
+	DanglingSignatures []digest.Digest
+	// RevisionLinkPath is used to check whether a manifest is stored at its
+	// canonical path.
+	// TODO: use this to move the revision to correct place.
+	RevisionLinkPath string
+}
+
+// IsMisplaced returns true if the manifest revision isn't stored at canonical path.
+// Version 2.1.0 unintentionally linked revisions into  _layers.
+func (mi *ManifestRevisionGraphInfo) IsMisplaced(repoName string, dgst digest.Digest) bool {
+	pth, err := manifestRevisionLinkPath(repoName, dgst)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return mi.RevisionLinkPath != pth
+}
+
+// IsDirty returns true if the manifest revision needs a purge.
+func (mi *ManifestRevisionGraphInfo) IsDirty() bool {
+	return len(mi.DanglingSignatures) > 0
+}
+
+// RepositoryGraphInfo contains information about a repository.
+type RepositoryGraphInfo struct {
+	Layers BlobRefCounter
+	// UnlinkedLayers refer to empty <hex-digest> directories in _layers of the
+	// repository.
+	// TODO: there's no need to count references
+	UnlinkedLayers BlobRefCounter
+	// DanglingLayers is a set of layer digests pointing to deleted blobs.
+	DanglingLayers BlobRefSet
+	// Manifests contains manifest revisions which are either clean or dirty.
+	Manifests ManifestRevisionReferences
+	// UnlinkedManifests contains deleted manifest revisions that can be
+	// cleaned up.
+	UnlinkedManifests ManifestRevisionReferences
+	// DanglingManifests contains manifest revisions refering to deleted blobs.
+	DanglingManifests ManifestRevisionReferences
+	// DanglingTags contains names of tags that point to manifest revistions no
+	// longer presents as keys. Values are digests of deleted manifest
+	// revisions.
+	DanglingTags map[string]digest.Digest
+	// InvalidTags is an array of tag names where a revision reference couldn't
+	// be obtained.
+	InvalidTags []string
+	// TODO: collect unfinished uploads
+}
+
+// IsEmpty returns true if the repository contains no clean or dirty manifests
+// and thus can be removed.
+func (rg *RepositoryGraphInfo) IsEmpty() bool {
+	// TODO: check for uploads in progress
+	return len(rg.Manifests) == 0
+}
+
+// IsDirty returns true if the repository can be purged.
+func (rg *RepositoryGraphInfo) IsDirty() bool {
+	if len(rg.UnlinkedManifests) > 0 ||
+		len(rg.DanglingManifests) > 0 ||
+		len(rg.DanglingLayers) > 0 ||
+		len(rg.DanglingTags) > 0 ||
+		len(rg.InvalidTags) > 0 ||
+		len(rg.DanglingLayers) > 0 ||
+		len(rg.UnlinkedLayers) > 0 ||
+		rg.Layers.HasUnreferenced() {
+		return true
+	}
+	for _, mi := range rg.Manifests {
+		if mi.IsDirty() {
+			return true
+		}
+	}
+	// TODO: check for unfinished uploads
+	return false
+}
+
+// RegistryGraph stores registry objects that can be removed or cleaned up.
+type RegistryGraph struct {
+	Vacuum *Vacuum
+	// Reference counter is increased for each:
+	//  1. layer
+	//  2. clean or dirty manifest revision
+	//  3. signature
+	Blobs BlobRefCounter
+	// VoidBlobs are names (digests) of empty directories (no longer containing
+	// any data) under blob root.
+	VoidBlobs BlobRefSet
+	// DirtyRepositories maps names of dirty repositories to their info objects.
+	DirtyRepositories map[string]*RepositoryGraphInfo
+	// EmptyRepositories maps names of empty repositories to their info objects.
+	EmptyRepositories map[string]*RepositoryGraphInfo
+	TotalRepositories uint
+}
+
+// UnreferencedBlobs returns a list of digests of blobs in global blob store
+// having no referents.
+func (rg *RegistryGraph) UnreferencedBlobs() *list.List {
+	ubl := list.New()
+	for dgst, rc := range rg.Blobs {
+		if rc == 0 {
+			ubl.PushBack(dgst)
+		}
+	}
+	return ubl
+}
+
+// LoadRegistryGraph walks a filesystem and collects all the information needed
+// for a clean up in a new instance of RegistryGraph.
+func LoadRegistryGraph(v *Vacuum) (*RegistryGraph, error) {
+	ns, err := NewRegistry(v.ctx, v.driver, EnableDelete)
+	if err != nil {
+		return nil, err
+	}
+	reg := ns.(*registry)
+
+	blobs, void, err := loadRegistryBlobs(v.ctx, reg.blobStore)
+	if err != nil {
+		return nil, err
+	}
+	rg := &RegistryGraph{
+		Vacuum:            v,
+		Blobs:             blobs,
+		VoidBlobs:         void,
+		DirtyRepositories: make(map[string]*RepositoryGraphInfo),
+		EmptyRepositories: make(map[string]*RepositoryGraphInfo),
+	}
+
+	if err = rg.loadRepositories(reg); err != nil {
+		return nil, err
+	}
+
+	return rg, nil
+}
+
+// PruneOrphanedObjects deletes orphaned blobs, dangling links and empty
+// directories. If removeEmpty is true, delets also empty repositories.
+func (rg *RegistryGraph) PruneOrphanedObjects(removeEmpty bool) error {
+	if removeEmpty {
+		for name, ri := range rg.EmptyRepositories {
+			if err := rg.Vacuum.RemoveRepository(name); err != nil {
+				return err
+			}
+			for lRef := range ri.Layers {
+				rg.Blobs.Unreference(lRef)
+			}
+			for _, mi := range ri.DanglingManifests {
+				for _, sdgst := range mi.Signatures {
+					rg.Blobs.Unreference(sdgst)
+				}
+			}
+			for _, mi := range ri.UnlinkedManifests {
+				for _, sdgst := range mi.Signatures {
+					rg.Blobs.Unreference(sdgst)
+				}
+			}
+		}
+	}
+	for name := range rg.DirtyRepositories {
+		if _, exists := rg.EmptyRepositories[name]; removeEmpty && exists {
+			continue
+		}
+		if err := rg.pruneDirtyRepository(name); err != nil {
+			return err
+		}
+	}
+	if err := rg.pruneOrphanedBlobs(); err != nil {
+		return err
+	}
+	if err := rg.pruneVoidBlobs(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (rg *RegistryGraph) loadRepository(repoName string, repo *repository) (*RepositoryGraphInfo, error) {
+	manServ, err := repo.Manifests(rg.Vacuum.ctx)
+	if err != nil {
+		return nil, err
+	}
+	manStore := manServ.(*manifestStore)
+	sigServ := repo.Signatures()
+	sigStore := sigServ.(*signatureStore)
+	ri := &RepositoryGraphInfo{
+		Layers:            make(BlobRefCounter),
+		DanglingLayers:    make(BlobRefSet),
+		UnlinkedLayers:    make(BlobRefCounter),
+		Manifests:         make(ManifestRevisionReferences),
+		DanglingManifests: make(ManifestRevisionReferences),
+		UnlinkedManifests: make(ManifestRevisionReferences),
+		DanglingTags:      make(map[string]digest.Digest),
+	}
+
+	err = rg.loadRepositoryLayers(repo.Blobs(rg.Vacuum.ctx), ri)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load layers of repository %s: %v", repoName, err)
+	}
+	layers := make([]string, 0, len(ri.Layers))
+	for l := range ri.Layers {
+		layers = append(layers, l.String())
+	}
+	layers = make([]string, 0, len(ri.DanglingLayers))
+	for l := range ri.DanglingLayers {
+		layers = append(layers, l.String())
+	}
+
+	manRefs, err := manStore.revisionStore.list()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ref := range manRefs {
+		var manifest *schema1.SignedManifest
+		mi := &ManifestRevisionGraphInfo{
+			Signatures: make([]digest.Digest, 0, 2),
+		}
+		if ri.Layers.Has(ref) || ri.DanglingLayers.Has(ref) || ri.UnlinkedLayers.Has(ref) {
+			mi.RevisionLinkPath, err = blobLinkPath(repoName, ref)
+		} else {
+			mi.RevisionLinkPath, err = manifestRevisionLinkPath(repoName, ref)
+		}
+		if err != nil {
+			// should not happen
+			return nil, fmt.Errorf("Failed to resolve revision link path of %s@%s", repoName, ref)
+		}
+
+		// Consider it an unlinked layer
+		if mi.IsMisplaced(repoName, ref) && !rg.Blobs.Has(ref) {
+			continue
+		}
+
+		if !rg.Blobs.Has(ref) {
+			ri.DanglingManifests[ref] = mi
+		} else {
+			manifest, err = manStore.Get(ref)
+			if err != nil {
+				// manifests are read also from `_layers` directory which most
+				// certainly contains pointers to binary blobs. Ignore errors when
+				// trying to read them as manifests.
+				isUnknown := strings.Contains(strings.ToLower(err.Error()), "unknown manifest")
+				// TODO: why "manifest unknown" when the manifest actually can't be parsed?
+				if mi.IsMisplaced(repoName, ref) && isUnknown {
+					continue
+				}
+				if isUnknown {
+					ri.UnlinkedManifests[ref] = mi
+				} else {
+					// FIXME: add to BadManifests list for optional disposal?
+					log.Warnf("Failed to load manifest revision %q: %v", ref.String(), err)
+					rg.Blobs.Reference(ref)
+				}
+			} else {
+				mi.Tag = manifest.Tag
+				ri.Manifests[ref] = mi
+				rg.Blobs.Reference(ref)
+			}
+		}
+
+		if manifest != nil {
+			for _, layer := range manifest.FSLayers {
+				if ri.Layers.Reference(layer.BlobSum) == 0 {
+					// FIXME: make manifest invalid
+					qualif := "unknown"
+					if ri.UnlinkedLayers.Reference(layer.BlobSum) > 0 {
+						qualif = "unlinked"
+					} else if ri.DanglingLayers.Has(layer.BlobSum) {
+						qualif = "dangling"
+					}
+					log.Warnf("Manifest %s:%s@%s refers to %s layer %s", repoName, manifest.Tag, ref, qualif, layer.BlobSum)
+				}
+			}
+		}
+
+		signatures, err := sigStore.list(ref)
+		if err != nil {
+			log.Warnf("Failed to list signatures of %s: %v", repoName+"@"+ref.String(), err)
+		} else {
+			for _, signRef := range signatures {
+				if rg.Blobs.Reference(signRef) == 0 {
+					mi.DanglingSignatures = append(mi.DanglingSignatures, signRef)
+				} else {
+					mi.Signatures = append(mi.Signatures, signRef)
+				}
+			}
+		}
+
+		// TODO: Validate signatures / allow them to be recomputed
+	}
+
+	if err := loadRepositoryTags(repoName, manStore.tagStore, ri); err != nil {
+		return nil, err
+	}
+	return ri, nil
+}
+
+func (rg *RegistryGraph) loadRepositoryLayers(bs distribution.BlobStore, ri *RepositoryGraphInfo) error {
+	lbs := bs.(*linkedBlobStore)
+	refs, err := lbs.list()
+	if err != nil {
+		return err
+	}
+	for e := refs.Front(); e != nil; e = e.Next() {
+		ref := e.Value.(digest.Digest)
+		if !rg.Blobs.Has(ref) {
+			ri.DanglingLayers.Add(ref)
+		} else {
+			repoName := lbs.repository.Name()
+			pth, err := pathFor(layerLinkPathSpec{
+				name:   repoName,
+				digest: ref,
+			})
+			if err != nil {
+				log.Errorf("Failed to resolve layer link path spec for %s@%s", repoName, ref)
+				continue
+			}
+			ok, err := exists(lbs.ctx, lbs.driver, pth)
+			if err != nil {
+				log.Errorf("Failed to resolve layer link path spec for %s@%s", repoName, err)
+				continue
+			}
+			if !ok {
+				ri.UnlinkedLayers.Add(ref)
+			} else {
+				ri.Layers.Add(ref)
+				rg.Blobs.Reference(ref)
+			}
+		}
+	}
+	return nil
+}
+
+func (rg *RegistryGraph) loadRepositories(reg *registry) error {
+	rl, err := reg.listRepositories(rg.Vacuum.ctx)
+	if err != nil {
+		return err
+	}
+	for e := rl.Front(); e != nil; e = e.Next() {
+		repoName := e.Value.(string)
+		repoServ, err := reg.Repository(rg.Vacuum.ctx, repoName)
+		if err != nil {
+			// FIXME: these could be added to BadRepositories list for optional disposal
+			log.Warnf("Failed to load repository %q: %v", repoName, err)
+			continue
+		}
+		rg.TotalRepositories++
+		repo := repoServ.(*repository)
+		repoGraph, err := rg.loadRepository(repoName, repo)
+		if err != nil {
+			// FIXME: these could be added to BadRepositories list for optional disposal
+			log.Warnf("Failed to load repository %q: %v", repoName, err)
+			continue
+		}
+		if repoGraph.IsDirty() {
+			rg.DirtyRepositories[repoName] = repoGraph
+		}
+		if repoGraph.IsEmpty() {
+			rg.EmptyRepositories[repoName] = repoGraph
+		}
+	}
+	return err
+}
+
+func (rg *RegistryGraph) pruneDirtyRepository(repoName string) error {
+	ri := rg.DirtyRepositories[repoName]
+	toRemove := ri.Layers.GetUnreferenced()
+	for e := toRemove.Front(); e != nil; e = e.Next() {
+		lRef := e.Value.(digest.Digest)
+		err := rg.Vacuum.UnlinkLayer(repoName, lRef.String(), true)
+		if err != nil {
+			return err
+		}
+		rg.Blobs.Unreference(lRef)
+	}
+	for lRef := range ri.DanglingLayers {
+		err := rg.Vacuum.UnlinkLayer(repoName, lRef.String(), true)
+		if err != nil {
+			return err
+		}
+	}
+	for lRef := range ri.UnlinkedLayers {
+		err := rg.Vacuum.UnlinkLayer(repoName, lRef.String(), true)
+		if err != nil {
+			return err
+		}
+	}
+	unlinkManifests := func(mrs ManifestRevisionReferences) error {
+		for mRef, mi := range mrs {
+			err := rg.Vacuum.UnlinkManifestRevision(repoName, mRef.String())
+			if err != nil {
+				return err
+			}
+			for _, sdgst := range mi.Signatures {
+				rg.Blobs.Unreference(sdgst)
+			}
+		}
+		return nil
+	}
+	if err := unlinkManifests(ri.DanglingManifests); err != nil {
+		return err
+	}
+	if err := unlinkManifests(ri.UnlinkedManifests); err != nil {
+		return err
+	}
+
+	for mRef, mi := range ri.Manifests {
+		for _, sdgst := range mi.DanglingSignatures {
+			rg.Vacuum.UnlinkSignature(repoName, mRef.String(), sdgst.String(), true)
+		}
+	}
+
+	// TODO: allow to restore old references from index
+	for tag := range ri.DanglingTags {
+		rg.Vacuum.DeleteTag(repoName, tag)
+	}
+
+	// TODO: allow to restore old references from index
+	for _, tag := range ri.InvalidTags {
+		rg.Vacuum.DeleteTag(repoName, tag)
+	}
+
+	return nil
+}
+
+func (rg *RegistryGraph) pruneOrphanedBlobs() error {
+	toRemove := rg.Blobs.GetUnreferenced()
+	for e := toRemove.Front(); e != nil; e = e.Next() {
+		err := rg.Vacuum.RemoveBlob(e.Value.(digest.Digest).String(), true)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (rg *RegistryGraph) pruneVoidBlobs() error {
+	for dgst := range rg.VoidBlobs {
+		err := rg.Vacuum.RemoveBlob(dgst.String(), true)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadRegistryBlobs(ctx context.Context, bs *blobStore) (BlobRefCounter, BlobRefSet, error) {
+	bl, err := bs.list(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	brc := make(BlobRefCounter)
+	brs := make(BlobRefSet)
+	for e := bl.Front(); e != nil; e = e.Next() {
+		dgst := e.Value.(digest.Digest)
+		path, err := pathFor(blobDataPathSpec{digest: dgst})
+		if err != nil {
+			log.Errorf("Failed to resolve blob data path spec for %s", dgst.String())
+			continue
+		}
+		ok, err := exists(ctx, bs.driver, path)
+		if err != nil {
+			log.Errorf("Failed to check blob data path %s for existence", dgst.String())
+			continue
+		}
+		if ok {
+			brc.Add(dgst)
+		} else {
+			brs.Add(dgst)
+		}
+	}
+	return brc, brs, nil
+}
+
+// loadRepositoryTags doesn't increment layer nor blob reference counters.
+func loadRepositoryTags(repoName string, ts *tagStore, rg *RepositoryGraphInfo) error {
+	tags, err := ts.tags()
+	if err != nil {
+		return err
+	}
+	for _, tag := range tags {
+		dgst, err := ts.resolve(tag)
+		if err != nil {
+			log.Warnf("Couldn't resolve tag %s:%s: %v", repoName, tag, err)
+			rg.InvalidTags = append(rg.InvalidTags, tag)
+			continue
+		}
+		if _, ok := rg.Manifests[dgst]; !ok {
+			rg.DanglingTags[tag] = dgst
+		}
+	}
+	// TODO: parse tag index and allow to prune it
+	return nil
+}

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -16,6 +16,10 @@ const (
 	// storage path root would configurable for all drivers through this
 	// package. In reality, we've found it simpler to do this on a per driver
 	// basis.
+
+	layersDirectory    = "_layers"
+	manifestsDirectory = "_manifests"
+	uploadsDirectory   = "_uploads"
 )
 
 // pathFor maps paths based on "object names" and their ids. The "object
@@ -42,7 +46,7 @@ const (
 // 						data
 // 						startedat
 // 						hashstates/<algorithm>/<offset>
-//			-> blob/<algorithm>
+//			-> blobs/<algorithm>
 //				<split directory content addressable storage>
 //
 // The storage backend layout is broken up into a content-addressable blob
@@ -74,6 +78,7 @@ const (
 //
 //	Manifests:
 //
+// 	manifestRevisionsPathSpec:     <root>/v2/repositories/<name>/_manifests/revisions/
 // 	manifestRevisionPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/
 // 	manifestRevisionLinkPathSpec:  <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/link
 // 	manifestSignaturesPathSpec:    <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/signatures/
@@ -90,6 +95,7 @@ const (
 //
 // 	Blobs:
 //
+// 	layersPathSpec:               <root>/v2/repositories/<name>/_layers/
 // 	layerLinkPathSpec:            <root>/v2/repositories/<name>/_layers/<algorithm>/<hex digest>/link
 //
 //	Uploads:
@@ -125,13 +131,20 @@ func pathFor(spec pathSpec) (string, error) {
 
 	switch v := spec.(type) {
 
+	case manifestRevisionsPathSpec:
+
+		return path.Join(append(repoPrefix, v.name, manifestsDirectory, "revisions")...), nil
 	case manifestRevisionPathSpec:
+		revisionsPrefix, err := pathFor(manifestRevisionsPathSpec{name: v.name})
+		if err != nil {
+			return "", err
+		}
 		components, err := digestPathComponents(v.revision, false)
 		if err != nil {
 			return "", err
 		}
 
-		return path.Join(append(append(repoPrefix, v.name, "_manifests", "revisions"), components...)...), nil
+		return path.Join(append([]string{revisionsPrefix}, components...)...), nil
 	case manifestRevisionLinkPathSpec:
 		root, err := pathFor(manifestRevisionPathSpec{
 			name:     v.name,
@@ -171,7 +184,7 @@ func pathFor(spec pathSpec) (string, error) {
 
 		return path.Join(root, path.Join(append(signatureComponents, "link")...)), nil
 	case manifestTagsPathSpec:
-		return path.Join(append(repoPrefix, v.name, "_manifests", "tags")...), nil
+		return path.Join(append(repoPrefix, v.name, manifestsDirectory, "tags")...), nil
 	case manifestTagPathSpec:
 		root, err := pathFor(manifestTagsPathSpec{
 			name: v.name,
@@ -232,40 +245,54 @@ func pathFor(spec pathSpec) (string, error) {
 		}
 
 		return path.Join(root, path.Join(components...)), nil
+	case layersPathSpec:
+
+		return path.Join(append(repoPrefix, v.name, layersDirectory)...), nil
 	case layerLinkPathSpec:
+		layersPrefix, err := pathFor(layersPathSpec{name: v.name})
+		if err != nil {
+			return "", err
+		}
 		components, err := digestPathComponents(v.digest, false)
 		if err != nil {
 			return "", err
 		}
+		components = append(components, "link")
 
 		// TODO(stevvooe): Right now, all blobs are linked under "_layers". If
 		// we have future migrations, we may want to rename this to "_blobs".
 		// A migration strategy would simply leave existing items in place and
 		// write the new paths, commit a file then delete the old files.
 
-		blobLinkPathComponents := append(repoPrefix, v.name, "_layers")
-
-		return path.Join(path.Join(append(blobLinkPathComponents, components...)...), "link"), nil
-	case blobDataPathSpec:
+		return path.Join(append([]string{layersPrefix}, components...)...), nil
+	case blobPathSpec:
 		components, err := digestPathComponents(v.digest, true)
 		if err != nil {
 			return "", err
 		}
 
-		components = append(components, "data")
 		blobPathPrefix := append(rootPrefix, "blobs")
-		return path.Join(append(blobPathPrefix, components...)...), nil
 
+		return path.Join(append(blobPathPrefix, components...)...), nil
+	case blobDataPathSpec:
+		blobPathPrefix, err := pathFor(blobPathSpec{
+			digest: v.digest,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(blobPathPrefix, "data"), nil
 	case uploadDataPathSpec:
-		return path.Join(append(repoPrefix, v.name, "_uploads", v.id, "data")...), nil
+		return path.Join(append(repoPrefix, v.name, uploadsDirectory, v.id, "data")...), nil
 	case uploadStartedAtPathSpec:
-		return path.Join(append(repoPrefix, v.name, "_uploads", v.id, "startedat")...), nil
+		return path.Join(append(repoPrefix, v.name, uploadsDirectory, v.id, "startedat")...), nil
 	case uploadHashStatePathSpec:
 		offset := fmt.Sprintf("%d", v.offset)
 		if v.list {
 			offset = "" // Limit to the prefix for listing offsets.
 		}
-		return path.Join(append(repoPrefix, v.name, "_uploads", v.id, "hashstates", string(v.alg), offset)...), nil
+		return path.Join(append(repoPrefix, v.name, uploadsDirectory, v.id, "hashstates", string(v.alg), offset)...), nil
 	case repositoriesRootPathSpec:
 		return path.Join(repoPrefix...), nil
 	default:
@@ -280,6 +307,14 @@ func pathFor(spec pathSpec) (string, error) {
 type pathSpec interface {
 	pathSpec()
 }
+
+// manifestRevisionsPathSpec describes the components of the directory path for
+// a root of repository revisions.
+type manifestRevisionsPathSpec struct {
+	name string
+}
+
+func (manifestRevisionsPathSpec) pathSpec() {}
 
 // manifestRevisionPathSpec describes the components of the directory path for
 // a manifest revision.
@@ -376,6 +411,13 @@ type manifestTagIndexEntryLinkPathSpec struct {
 
 func (manifestTagIndexEntryLinkPathSpec) pathSpec() {}
 
+// layersPathSpec describes the root directory of repository layer links.
+type layersPathSpec struct {
+	name string
+}
+
+func (layersPathSpec) pathSpec() {}
+
 // blobLinkPathSpec specifies a path for a blob link, which is a file with a
 // blob id. The blob link will contain a content addressable blob id reference
 // into the blob store. The format of the contents is as follows:
@@ -405,12 +447,12 @@ var blobAlgorithmReplacer = strings.NewReplacer(
 	";", "/",
 )
 
-// // blobPathSpec contains the path for the registry global blob store.
-// type blobPathSpec struct {
-// 	digest digest.Digest
-// }
+// blobPathSpec contains the path for the registry global blob store.
+type blobPathSpec struct {
+	digest digest.Digest
+}
 
-// func (blobPathSpec) pathSpec() {}
+func (blobPathSpec) pathSpec() {}
 
 // blobDataPathSpec contains the path for the registry global blob store. For
 // now, this contains layer data, exclusively.

--- a/registry/storage/revisionstore.go
+++ b/registry/storage/revisionstore.go
@@ -106,6 +106,19 @@ func (rs *revisionStore) put(ctx context.Context, sm *schema1.SignedManifest) (d
 	return revision, nil
 }
 
+// list returns an array of digests of all found manifest revisions.
+func (rs *revisionStore) list() ([]digest.Digest, error) {
+	bl, err := rs.blobStore.list()
+	if err != nil {
+		return nil, err
+	}
+	res := make([]digest.Digest, 0, bl.Len())
+	for e := bl.Front(); e != nil; e = e.Next() {
+		res = append(res, e.Value.(digest.Digest))
+	}
+	return res, nil
+}
+
 func (rs *revisionStore) delete(ctx context.Context, revision digest.Digest) error {
 	return rs.blobStore.Delete(ctx, revision)
 }

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -27,19 +27,118 @@ type Vacuum struct {
 	ctx    context.Context
 }
 
-// RemoveBlob removes a blob from the filesystem
-func (v Vacuum) RemoveBlob(dgst string) error {
+// RemoveBlob removes a blob from the filesystem. withDirectory
+// allows to remove <hex-digest> directory containing the blob as well.
+func (v Vacuum) RemoveBlob(dgst string, withDirectory bool) error {
 	d, err := digest.ParseDigest(dgst)
 	if err != nil {
 		return err
 	}
 
-	blobPath, err := pathFor(blobDataPathSpec{digest: d})
+	var blobPath string
+	if withDirectory {
+		blobPath, err = pathFor(blobPathSpec{digest: d})
+	} else {
+		blobPath, err = pathFor(blobDataPathSpec{digest: d})
+	}
 	if err != nil {
 		return err
 	}
 	context.GetLogger(v.ctx).Infof("Deleting blob: %s", blobPath)
 	err = v.driver.Delete(v.ctx, blobPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnlinkLayer removes an entry from repository layers. withDirectory
+// allows to remove <hex-digest> directory containing the link as well.
+func (v Vacuum) UnlinkLayer(repoName string, dgst string, withDirectory bool) error {
+	d, err := digest.ParseDigest(dgst)
+	if err != nil {
+		return err
+	}
+
+	layerPath, err := pathFor(layerLinkPathSpec{name: repoName, digest: d})
+	if err != nil {
+		return err
+	}
+	if withDirectory {
+		layerPath = path.Dir(layerPath)
+	}
+	context.GetLogger(v.ctx).Infof("Unlinking layer %s", layerPath)
+	err = v.driver.Delete(v.ctx, layerPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnlinkSignature removes a link from signatures store of manifest revision.
+// withDirectory allows to remove <hex-digest> directory containing the link as
+// well.
+func (v Vacuum) UnlinkSignature(repoName string, dgst string, sdgst string, withDirectory bool) error {
+	d, err := digest.ParseDigest(dgst)
+	if err != nil {
+		return err
+	}
+	sd, err := digest.ParseDigest(sdgst)
+	if err != nil {
+		return err
+	}
+
+	sigPath, err := pathFor(manifestSignatureLinkPathSpec{
+		name:      repoName,
+		revision:  d,
+		signature: sd,
+	})
+	if err != nil {
+		return err
+	}
+	if withDirectory {
+		sigPath = path.Dir(sigPath)
+	}
+	context.GetLogger(v.ctx).Infof("Unlinking signature %s", sigPath)
+	err = v.driver.Delete(v.ctx, sigPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnlinkManifestRevision removes an entry from repository manifest revisions
+// together with signatures.
+func (v Vacuum) UnlinkManifestRevision(repoName string, dgst string) error {
+	d, err := digest.ParseDigest(dgst)
+	if err != nil {
+		return err
+	}
+
+	revPath, err := pathFor(manifestRevisionPathSpec{name: repoName, revision: d})
+	if err != nil {
+		return err
+	}
+	context.GetLogger(v.ctx).Infof("Unlinking manifest revision %s", revPath)
+	err = v.driver.Delete(v.ctx, revPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteTag removes a tag from repository with index store from the filesystem.
+func (v Vacuum) DeleteTag(repoName, tag string) error {
+	tagPath, err := pathFor(manifestTagPathSpec{name: repoName, tag: tag})
+	if err != nil {
+		return err
+	}
+	context.GetLogger(v.ctx).Infof("Deleting tag %s:%s", repoName, tag)
+	err = v.driver.Delete(v.ctx, tagPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Pruner tools removes orphaned blobs, dangling references and empty directories.

    $ pruner -h
    pruner allows to print and/or delete registry's orphaned blobs.

    Make sure that registry instance isn't running or is running in a read-only
    mode before launching this executable.

    Usage:
      <config> [flags]
    Flags:
      -c, --confirm=true: ask for confirmation before making changes
      -n, --dry-run=false: perform a trial prune with no changes to registry
      -h, --help=false: help for <config>
      -e, --remove-empty=false: remove empty repositories (containing 0 manifest revisions)
      -v, --verbose=false: turn on verbosive output
      -V, --version=false: show the version and exit

Resolves #462

Currently pruner tool doesn't check whether registry is running or not. It
expects a caller to ensure that registry instance is either stopped or running in
read-only mode. Tool also doesn't check which storage driver is used. Shall it
be enabled only for filesystems?

TODO:
 
 - write tests
 - collect information about uploads in progress or expired uploads
 - collect tag index and allow to fix dangling tag by using reference from
   index
 - decide what to do about manifests containing deleted/unlinked/dangling layers
 - rewrite signatures if missing/corrupted/unlinked