### PR TITLE
[registry/auth] Update access controller interface

### DIFF
--- a/cmd/registry-api-descriptor-template/main.go
+++ b/cmd/registry-api-descriptor-template/main.go
@@ -53,6 +53,7 @@ func main() {
 		ErrorDescriptors: append(errcode.GetErrorCodeGroup("registry.api.v2"),
 			// The following are part of the specification but provided by errcode default.
 			errcode.ErrorCodeUnauthorized.Descriptor(),
+			errcode.ErrorCodeDenied.Descriptor(),
 			errcode.ErrorCodeUnsupported.Descriptor()),
 	}
 

--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -33,14 +33,26 @@ var (
 		HTTPStatusCode: http.StatusMethodNotAllowed,
 	})
 
-	// ErrorCodeUnauthorized is returned if a request is not authorized.
+	// ErrorCodeUnauthorized is returned if a request requires
+	// authentication.
 	ErrorCodeUnauthorized = Register("errcode", ErrorDescriptor{
 		Value:   "UNAUTHORIZED",
-		Message: "access to the requested resource is not authorized",
-		Description: `The access controller denied access for the operation on
-		a resource. Often this will be accompanied by a 401 Unauthorized
-		response status.`,
+		Message: "authentication required",
+		Description: `The access controller was unable to authenticate
+		the client. Often this will be accompanied by a
+		Www-Authenticate HTTP response header indicating how to
+		authenticate.`,
 		HTTPStatusCode: http.StatusUnauthorized,
+	})
+
+	// ErrorCodeDenied is returned if a client does not have sufficient
+	// permission to perform an action.
+	ErrorCodeDenied = Register("errcode", ErrorDescriptor{
+		Value:   "DENIED",
+		Message: "requested access to the resource is denied",
+		Description: `The access controller denied access for the
+		operation on a resource.`,
+		HTTPStatusCode: http.StatusForbidden,
 	})
 
 	// ErrorCodeUnavailable provides a common error to report unavialability

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -111,45 +111,67 @@ var (
 		},
 	}
 
-	unauthorizedResponse = ResponseDescriptor{
-		Description: "The client does not have access to the repository.",
+	unauthorizedResponseDescriptor = ResponseDescriptor{
+		Name:        "Authentication Required",
 		StatusCode:  http.StatusUnauthorized,
+		Description: "The client is not authenticated.",
 		Headers: []ParameterDescriptor{
 			authChallengeHeader,
 			{
 				Name:        "Content-Length",
 				Type:        "integer",
-				Description: "Length of the JSON error response body.",
+				Description: "Length of the JSON response body.",
 				Format:      "<length>",
 			},
 		},
-		ErrorCodes: []errcode.ErrorCode{
-			errcode.ErrorCodeUnauthorized,
-		},
 		Body: BodyDescriptor{
 			ContentType: "application/json; charset=utf-8",
-			Format:      unauthorizedErrorsBody,
+			Format:      errorsBody,
+		},
+		ErrorCodes: []errcode.ErrorCode{
+			errcode.ErrorCodeUnauthorized,
 		},
 	}
 
-	unauthorizedResponsePush = ResponseDescriptor{
-		Description: "The client does not have access to push to the repository.",
-		StatusCode:  http.StatusUnauthorized,
+	repositoryNotFoundResponseDescriptor = ResponseDescriptor{
+		Name:        "No Such Repository Error",
+		StatusCode:  http.StatusNotFound,
+		Description: "The repository is not known to the registry.",
 		Headers: []ParameterDescriptor{
-			authChallengeHeader,
 			{
 				Name:        "Content-Length",
 				Type:        "integer",
-				Description: "Length of the JSON error response body.",
+				Description: "Length of the JSON response body.",
 				Format:      "<length>",
 			},
 		},
+		Body: BodyDescriptor{
+			ContentType: "application/json; charset=utf-8",
+			Format:      errorsBody,
+		},
 		ErrorCodes: []errcode.ErrorCode{
-			errcode.ErrorCodeUnauthorized,
+			ErrorCodeNameUnknown,
+		},
+	}
+
+	deniedResponseDescriptor = ResponseDescriptor{
+		Name:        "Access Denied",
+		StatusCode:  http.StatusForbidden,
+		Description: "The client does not have required access to the repository.",
+		Headers: []ParameterDescriptor{
+			{
+				Name:        "Content-Length",
+				Type:        "integer",
+				Description: "Length of the JSON response body.",
+				Format:      "<length>",
+			},
 		},
 		Body: BodyDescriptor{
 			ContentType: "application/json; charset=utf-8",
-			Format:      unauthorizedErrorsBody,
+			Format:      errorsBody,
+		},
+		ErrorCodes: []errcode.ErrorCode{
+			errcode.ErrorCodeDenied,
 		},
 	}
 )
@@ -345,7 +367,7 @@ var routeDescriptors = []RouteDescriptor{
 		Name:        RouteNameBase,
 		Path:        "/v2/",
 		Entity:      "Base",
-		Description: `Base V2 API route. Typically, this can be used for lightweight version checks and to validate registry authorization.`,
+		Description: `Base V2 API route. Typically, this can be used for lightweight version checks and to validate registry authentication.`,
 		Methods: []MethodDescriptor{
 			{
 				Method:      "GET",
@@ -364,23 +386,10 @@ var routeDescriptors = []RouteDescriptor{
 						},
 						Failures: []ResponseDescriptor{
 							{
-								Description: "The client is not authorized to access the registry.",
-								StatusCode:  http.StatusUnauthorized,
-								Headers: []ParameterDescriptor{
-									authChallengeHeader,
-								},
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
-								},
-								ErrorCodes: []errcode.ErrorCode{
-									errcode.ErrorCodeUnauthorized,
-								},
-							},
-							{
 								Description: "The registry does not implement the V2 API.",
 								StatusCode:  http.StatusNotFound,
 							},
+							unauthorizedResponseDescriptor,
 						},
 					},
 				},
@@ -432,28 +441,9 @@ var routeDescriptors = []RouteDescriptor{
 							},
 						},
 						Failures: []ResponseDescriptor{
-							{
-								StatusCode:  http.StatusNotFound,
-								Description: "The repository is not known to the registry.",
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
-								},
-								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeNameUnknown,
-								},
-							},
-							{
-								StatusCode:  http.StatusUnauthorized,
-								Description: "The client does not have access to the repository.",
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
-								},
-								ErrorCodes: []errcode.ErrorCode{
-									errcode.ErrorCodeUnauthorized,
-								},
-							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 					{
@@ -487,28 +477,9 @@ var routeDescriptors = []RouteDescriptor{
 							},
 						},
 						Failures: []ResponseDescriptor{
-							{
-								StatusCode:  http.StatusNotFound,
-								Description: "The repository is not known to the registry.",
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
-								},
-								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeNameUnknown,
-								},
-							},
-							{
-								StatusCode:  http.StatusUnauthorized,
-								Description: "The client does not have access to the repository.",
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
-								},
-								ErrorCodes: []errcode.ErrorCode{
-									errcode.ErrorCodeUnauthorized,
-								},
-							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 				},
@@ -560,29 +531,9 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
-							{
-								StatusCode:  http.StatusUnauthorized,
-								Description: "The client does not have access to the repository.",
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
-								},
-								ErrorCodes: []errcode.ErrorCode{
-									errcode.ErrorCodeUnauthorized,
-								},
-							},
-							{
-								Description: "The named manifest is not known to the registry.",
-								StatusCode:  http.StatusNotFound,
-								ErrorCodes: []errcode.ErrorCode{
-									ErrorCodeNameUnknown,
-									ErrorCodeManifestUnknown,
-								},
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
-								},
-							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 				},
@@ -637,17 +588,9 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUnknown,
 								},
 							},
-							{
-								StatusCode:  http.StatusUnauthorized,
-								Description: "The client does not have permission to push to the repository.",
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
-								},
-								ErrorCodes: []errcode.ErrorCode{
-									errcode.ErrorCodeUnauthorized,
-								},
-							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 							{
 								Name:        "Missing Layer(s)",
 								Description: "One or more layers may be missing during a manifest upload. If so, the missing layers will be enumerated in the error response.",
@@ -668,25 +611,6 @@ var routeDescriptors = []RouteDescriptor{
         ...
     ]
 }`,
-								},
-							},
-							{
-								StatusCode: http.StatusUnauthorized,
-								Headers: []ParameterDescriptor{
-									authChallengeHeader,
-									{
-										Name:        "Content-Length",
-										Type:        "integer",
-										Description: "Length of the JSON error response body.",
-										Format:      "<length>",
-									},
-								},
-								ErrorCodes: []errcode.ErrorCode{
-									errcode.ErrorCodeUnauthorized,
-								},
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
 								},
 							},
 							{
@@ -733,25 +657,9 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
-							{
-								StatusCode: http.StatusUnauthorized,
-								Headers: []ParameterDescriptor{
-									authChallengeHeader,
-									{
-										Name:        "Content-Length",
-										Type:        "integer",
-										Description: "Length of the JSON error response body.",
-										Format:      "<length>",
-									},
-								},
-								ErrorCodes: []errcode.ErrorCode{
-									errcode.ErrorCodeUnauthorized,
-								},
-								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
-									Format:      errorsBody,
-								},
-							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 							{
 								Name:        "Unknown Manifest",
 								Description: "The specified `name` or `reference` are unknown to the registry and the delete was unable to proceed. Clients can assume the manifest was already deleted if this response is returned.",
@@ -845,7 +753,6 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
-							unauthorizedResponse,
 							{
 								Description: "The blob, identified by `name` and `digest`, is unknown to the registry.",
 								StatusCode:  http.StatusNotFound,
@@ -858,6 +765,9 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUnknown,
 								},
 							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 					{
@@ -914,7 +824,6 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
-							unauthorizedResponse,
 							{
 								StatusCode: http.StatusNotFound,
 								ErrorCodes: []errcode.ErrorCode{
@@ -930,6 +839,9 @@ var routeDescriptors = []RouteDescriptor{
 								Description: "The range specification cannot be satisfied for the requested content. This can happen when the range is not formatted correctly or if the range is outside of the valid size of the content.",
 								StatusCode:  http.StatusRequestedRangeNotSatisfiable,
 							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 				},
@@ -993,6 +905,9 @@ var routeDescriptors = []RouteDescriptor{
 									errcode.ErrorCodeUnsupported,
 								},
 							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 				},
@@ -1066,7 +981,6 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeNameInvalid,
 								},
 							},
-							unauthorizedResponsePush,
 							{
 								Name:        "Not allowed",
 								Description: "Blob upload is not allowed because the registry is configured as a pull-through cache or for some other reason",
@@ -1075,6 +989,9 @@ var routeDescriptors = []RouteDescriptor{
 									errcode.ErrorCodeUnsupported,
 								},
 							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 					{
@@ -1118,7 +1035,9 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeNameInvalid,
 								},
 							},
-							unauthorizedResponsePush,
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 				},
@@ -1177,7 +1096,6 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
-							unauthorizedResponse,
 							{
 								Description: "The upload is unknown to the registry. The upload must be restarted.",
 								StatusCode:  http.StatusNotFound,
@@ -1189,6 +1107,9 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 				},
@@ -1249,7 +1170,6 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
-							unauthorizedResponsePush,
 							{
 								Description: "The upload is unknown to the registry. The upload must be restarted.",
 								StatusCode:  http.StatusNotFound,
@@ -1261,6 +1181,9 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 					{
@@ -1328,7 +1251,6 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
-							unauthorizedResponsePush,
 							{
 								Description: "The upload is unknown to the registry. The upload must be restarted.",
 								StatusCode:  http.StatusNotFound,
@@ -1344,6 +1266,9 @@ var routeDescriptors = []RouteDescriptor{
 								Description: "The `Content-Range` specification cannot be accepted, either because it does not overlap with the current progress or it is invalid.",
 								StatusCode:  http.StatusRequestedRangeNotSatisfiable,
 							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 				},
@@ -1420,7 +1345,6 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
-							unauthorizedResponsePush,
 							{
 								Description: "The upload is unknown to the registry. The upload must be restarted.",
 								StatusCode:  http.StatusNotFound,
@@ -1432,6 +1356,9 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 				},
@@ -1474,7 +1401,6 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
-							unauthorizedResponse,
 							{
 								Description: "The upload is unknown to the registry. The client may ignore this error and assume the upload has been deleted.",
 								StatusCode:  http.StatusNotFound,
@@ -1486,6 +1412,9 @@ var routeDescriptors = []RouteDescriptor{
 									Format:      errorsBody,
 								},
 							},
+							unauthorizedResponseDescriptor,
+							repositoryNotFoundResponseDescriptor,
+							deniedResponseDescriptor,
 						},
 					},
 				},

--- a/registry/auth/auth.go
+++ b/registry/auth/auth.go
@@ -1,9 +1,9 @@
 // Package auth defines a standard interface for request access controllers.
 //
 // An access controller has a simple interface with a single `Authorized`
-// method which checks that a given request is authorized to perform one or
-// more actions on one or more resources. This method should return a non-nil
-// error if the request is not authorized.
+// method which checks that a given context is authorized to perform one or
+// more actions on a resource. This method should return a non-nil
+// error if the context is not authorized.
 //
 // An implementation registers its access controller by name with a constructor
 // which accepts an options map for configuring the access controller.
@@ -15,14 +15,26 @@
 //
 // 		func updateOrder(w http.ResponseWriter, r *http.Request) {
 //			orderNumber := r.FormValue("orderNumber")
-//			resource := auth.Resource{Type: "customerOrder", Name: orderNumber}
-// 			access := auth.Access{Resource: resource, Action: "update"}
+//			order := auth.Resource{Type: "customerOrder", Name: orderNumber}
 //
-// 			if ctx, err := accessController.Authorized(ctx, access); err != nil {
-//				if challenge, ok := err.(auth.Challenge) {
-//					// Let the challenge write the response.
-//					challenge.ServeHTTP(w, r)
-//				} else {
+//			// Is the client authorized to update the order?
+//			if ctx, err := accessController.Authorized(ctx, order, "update"); err != nil {
+//				switch err := err.(type) {
+//				case auth.AuthenticationChallenge:
+//					// Let the error set a challenge header.
+//					err.SetChallengeHeaders(w.Header())
+//					w.WriteHeader(http.StatusUnauthorized)
+//					w.Write([]byte(err.AuthenticationErrorDetails()))
+//					return
+//				case auth.PermissionDenied:
+//					if err.ResourceHidden() {
+//						w.WriteHeader(http.StatusNotFound)
+//						return
+//					}
+//					w.WriteHeader(http.StatusForbidden)
+//					w.Write([]byte(err.AuthorizationErrorDetails()))
+//					return
+//				default:
 //					// Some other error.
 //				}
 //			}
@@ -49,40 +61,67 @@ type Resource struct {
 	Name string
 }
 
-// Access describes a specific action that is
-// requested or allowed for a given resource.
-type Access struct {
-	Resource
-	Action string
-}
-
-// Challenge is a special error type which is used for HTTP 401 Unauthorized
-// responses and is able to write the response with WWW-Authenticate challenge
-// header values based on the error.
-type Challenge interface {
+// AuthenticationChallenge is a special error type which is used to indicate
+// that a client either has invalid authentication credentials or, if the
+// client is not authenticated, should attempt to authenticate in order to
+// access the requested resource. A type which implements this interface is
+// able to set HTTP Www-Authenticate challenge response header values based on
+// the error.
+// Note: HTTP status code "401 Unauthorized" is used semantically to indicate
+// that the client is "Unauthenticated". To indicate that the client is in fact
+// unauthorized (despite being authenticated), an access controller should
+// return an error implementing the PermissionDenied interface.
+type AuthenticationChallenge interface {
 	error
 
-	// SetHeaders prepares the request to conduct a challenge response by
-	// adding the an HTTP challenge header on the response message. Callers
-	// are expected to set the appropriate HTTP status code (e.g. 401)
+	// AuthenticationErrorDetails should return a JSON-serializable object
+	// detailing the authentication error, e.g., authentication required,
+	// invalid username/password, expired token, invalid signature, etc.
+	AuthenticationErrorDetails() interface{}
+
+	// SetChallengeHeaders prepares an authentication challenge response by
+	// setting one or more HTTP Www-Authenticate challenge headers. Callers
+	// are expected to set the appropriate HTTP status code (i.e., 401)
 	// themselves.
-	SetHeaders(w http.ResponseWriter)
+	SetChallengeHeaders(h http.Header)
 }
 
-// AccessController controls access to registry resources based on a request
-// and required access levels for a request. Implementations can support both
-// complete denial and http authorization challenges.
+// PermissionDenied is a special error type which is used to indicate that a
+// client is not authorized to access the requested resource.
+type PermissionDenied interface {
+	error
+
+	// AuthorizationErrorDetails should return a JSON-serializable object
+	// detailing the authorization error, e.g., user is not authorized to
+	// push, etc. It is the caller's responsibility to include these
+	// details in an HTTP 403 Forbidden response.
+	AuthorizationErrorDetails() interface{}
+
+	// ResourceHidden should return whether the existence of the requested
+	// resource should be exposed to the client. If true, the caller MUST
+	// return an HTTP 404 Not Found response in lieu of a 403 Forbidden or
+	// 401 Unauthorized response so as to not leak the existince of the
+	// resource to the client.
+	ResourceHidden() bool
+}
+
+// AccessController controls access to a registry resource based on a request
+// context and the attempted actions being performed on that resource.
+// Implementations must validate complete authorization or indicate
+// authentication or authorization errors through the AuthenticationChallenge
+// and PermissionDenied error interfaces.
 type AccessController interface {
-	// Authorized returns a non-nil error if the context is granted access and
-	// returns a new authorized context. If one or more Access structs are
-	// provided, the requested access will be compared with what is available
-	// to the context. The given context will contain a "http.request" key with
-	// a `*http.Request` value. If the error is non-nil, access should always
-	// be denied. The error may be of type Challenge, in which case the caller
-	// may have the Challenge handle the request or choose what action to take
-	// based on the Challenge header or response status. The returned context
-	// object should have a "auth.user" value set to a UserInfo struct.
-	Authorized(ctx context.Context, access ...Access) (context.Context, error)
+	// Authorized returns a nil error if the context is granted access and
+	// returns a new authorized context. If one or more action strings are
+	// provided, the requested access will be compared with what is
+	// available to the context. The given context will contain a
+	// "http.request" key with a `*http.Request` value. If the error is
+	// non-nil, access should always be denied. The returned error may
+	// implement the AuthenticationChallenge or PermissionDenied interface
+	// in which case the caller should take the appropriate action based on
+	// the error. The returned context object should have a "auth.user"
+	// value set to a UserInfo struct.
+	Authorized(ctx context.Context, resource Resource, actions ...string) (context.Context, error)
 }
 
 // WithUser returns a context with the authorized user info.

--- a/registry/auth/htpasswd/access.go
+++ b/registry/auth/htpasswd/access.go
@@ -55,7 +55,7 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 	return &accessController{realm: realm.(string), htpasswd: h}, nil
 }
 
-func (ac *accessController) Authorized(ctx context.Context, accessRecords ...auth.Access) (context.Context, error) {
+func (ac *accessController) Authorized(ctx context.Context, resource auth.Resource, actions ...string) (context.Context, error) {
 	req, err := context.GetRequest(ctx)
 	if err != nil {
 		return nil, err
@@ -86,11 +86,16 @@ type challenge struct {
 	err   error
 }
 
-var _ auth.Challenge = challenge{}
+var _ auth.AuthenticationChallenge = challenge{}
 
-// SetHeaders sets the basic challenge header on the response.
-func (ch challenge) SetHeaders(w http.ResponseWriter) {
-	w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", ch.realm))
+// SetChallengeHeaders sets the basic challenge header on the response.
+func (ch challenge) SetChallengeHeaders(h http.Header) {
+	h.Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", ch.realm))
+}
+
+// AuthenticationErrorDetails is no different than the Error() method.
+func (ch challenge) AuthenticationErrorDetails() interface{} {
+	return ch.Error()
 }
 
 func (ch challenge) Error() string {

--- a/registry/auth/htpasswd/access_test.go
+++ b/registry/auth/htpasswd/access_test.go
@@ -44,11 +44,11 @@ func TestBasicAccessController(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithRequest(ctx, r)
-		authCtx, err := accessController.Authorized(ctx)
+		authCtx, err := accessController.Authorized(ctx, auth.Resource{})
 		if err != nil {
 			switch err := err.(type) {
-			case auth.Challenge:
-				err.SetHeaders(w)
+			case auth.AuthenticationChallenge:
+				err.SetChallengeHeaders(w.Header())
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			default:

--- a/registry/auth/silly/access.go
+++ b/registry/auth/silly/access.go
@@ -42,7 +42,7 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 
 // Authorized simply checks for the existence of the authorization header,
 // responding with a bearer challenge if it doesn't exist.
-func (ac *accessController) Authorized(ctx context.Context, accessRecords ...auth.Access) (context.Context, error) {
+func (ac *accessController) Authorized(ctx context.Context, resource auth.Resource, actions ...string) (context.Context, error) {
 	req, err := context.GetRequest(ctx)
 	if err != nil {
 		return nil, err
@@ -54,15 +54,12 @@ func (ac *accessController) Authorized(ctx context.Context, accessRecords ...aut
 			service: ac.service,
 		}
 
-		if len(accessRecords) > 0 {
-			var scopes []string
-			for _, access := range accessRecords {
-				scopes = append(scopes, fmt.Sprintf("%s:%s:%s", access.Type, access.Resource.Name, access.Action))
-			}
-			challenge.scope = strings.Join(scopes, " ")
+		combinedActions := strings.Join(actions, ",")
+		if combinedActions != "" {
+			challenge.scope = fmt.Sprintf("%s:%s:%s", resource.Type, resource.Name, combinedActions)
 		}
 
-		return nil, &challenge
+		return nil, challenge
 	}
 
 	return auth.WithUser(ctx, auth.UserInfo{Name: "silly"}), nil
@@ -74,17 +71,22 @@ type challenge struct {
 	scope   string
 }
 
-var _ auth.Challenge = challenge{}
+var _ auth.AuthenticationChallenge = challenge{}
 
 // SetHeaders sets a simple bearer challenge on the response.
-func (ch challenge) SetHeaders(w http.ResponseWriter) {
+func (ch challenge) SetChallengeHeaders(h http.Header) {
 	header := fmt.Sprintf("Bearer realm=%q,service=%q", ch.realm, ch.service)
 
 	if ch.scope != "" {
 		header = fmt.Sprintf("%s,scope=%q", header, ch.scope)
 	}
 
-	w.Header().Set("WWW-Authenticate", header)
+	h.Set("WWW-Authenticate", header)
+}
+
+// AuthenticationErrorDetails is no different than the Error() method.
+func (ch challenge) AuthenticationErrorDetails() interface{} {
+	return ch.Error()
 }
 
 func (ch challenge) Error() string {

--- a/registry/auth/silly/access_test.go
+++ b/registry/auth/silly/access_test.go
@@ -17,11 +17,11 @@ func TestSillyAccessController(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(nil, "http.request", r)
-		authCtx, err := ac.Authorized(ctx)
+		authCtx, err := ac.Authorized(ctx, auth.Resource{})
 		if err != nil {
 			switch err := err.(type) {
-			case auth.Challenge:
-				err.SetHeaders(w)
+			case auth.AuthenticationChallenge:
+				err.SetChallengeHeaders(w.Header())
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			default:

--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -16,105 +16,87 @@ import (
 	"github.com/docker/libtrust"
 )
 
-// accessSet maps a typed, named resource to
-// a set of actions requested or authorized.
-type accessSet map[auth.Resource]actionSet
-
-// newAccessSet constructs an accessSet from
-// a variable number of auth.Access items.
-func newAccessSet(accessItems ...auth.Access) accessSet {
-	accessSet := make(accessSet, len(accessItems))
-
-	for _, access := range accessItems {
-		resource := auth.Resource{
-			Type: access.Type,
-			Name: access.Name,
-		}
-
-		set, exists := accessSet[resource]
-		if !exists {
-			set = newActionSet()
-			accessSet[resource] = set
-		}
-
-		set.add(access.Action)
-	}
-
-	return accessSet
-}
-
-// contains returns whether or not the given access is in this accessSet.
-func (s accessSet) contains(access auth.Access) bool {
-	actionSet, ok := s[access.Resource]
-	if ok {
-		return actionSet.contains(access.Action)
-	}
-
-	return false
-}
-
-// scopeParam returns a collection of scopes which can
-// be used for a WWW-Authenticate challenge parameter.
+// scopeParam returns a scope parameter which can be
+// used in a WWW-Authenticate challenge header.
 // See https://tools.ietf.org/html/rfc6750#section-3
-func (s accessSet) scopeParam() string {
-	scopes := make([]string, 0, len(s))
-
-	for resource, actionSet := range s {
-		actions := strings.Join(actionSet.keys(), ",")
-		scopes = append(scopes, fmt.Sprintf("%s:%s:%s", resource.Type, resource.Name, actions))
+func scopeParam(resource auth.Resource, actions actionSet) string {
+	combinedActions := strings.Join(actions.keys(), ",")
+	if combinedActions == "" {
+		return ""
 	}
 
-	return strings.Join(scopes, " ")
+	return fmt.Sprintf("%s:%s:%s", resource.Type, resource.Name, combinedActions)
 }
 
-// Errors used and exported by this package.
-var (
-	ErrInsufficientScope = errors.New("insufficient scope")
-	ErrTokenRequired     = errors.New("authorization token required")
-)
+var errTokenRequired = errors.New("authorization token required")
 
-// authChallenge implements the auth.Challenge interface.
-type authChallenge struct {
-	err       error
-	realm     string
-	service   string
-	accessSet accessSet
+// verificationError implements the auth.AuthenticationChallenge interface.
+type verificationError struct {
+	err      error
+	realm    string
+	service  string
+	resource auth.Resource
+	actions  actionSet
 }
 
-var _ auth.Challenge = authChallenge{}
+var _ auth.AuthenticationChallenge = &verificationError{}
 
-// Error returns the internal error string for this authChallenge.
-func (ac authChallenge) Error() string {
-	return ac.err.Error()
-}
-
-// Status returns the HTTP Response Status Code for this authChallenge.
-func (ac authChallenge) Status() int {
-	return http.StatusUnauthorized
+// Error returns the internal error string for this verificationError.
+func (ve *verificationError) Error() string {
+	return ve.err.Error()
 }
 
 // challengeParams constructs the value to be used in
 // the WWW-Authenticate response challenge header.
 // See https://tools.ietf.org/html/rfc6750#section-3
-func (ac authChallenge) challengeParams() string {
-	str := fmt.Sprintf("Bearer realm=%q,service=%q", ac.realm, ac.service)
+func (ve *verificationError) challengeParams() string {
+	str := fmt.Sprintf("Bearer realm=%q,service=%q", ve.realm, ve.service)
 
-	if scope := ac.accessSet.scopeParam(); scope != "" {
+	if scope := scopeParam(ve.resource, ve.actions); scope != "" {
 		str = fmt.Sprintf("%s,scope=%q", str, scope)
 	}
 
-	if ac.err == ErrInvalidToken || ac.err == ErrMalformedToken {
-		str = fmt.Sprintf("%s,error=%q", str, "invalid_token")
-	} else if ac.err == ErrInsufficientScope {
-		str = fmt.Sprintf("%s,error=%q", str, "insufficient_scope")
+	if ve.err != errTokenRequired {
+		str = fmt.Sprintf("%s,error=%q,error_description=%q", str, "invalid token", ve.err.Error())
 	}
 
 	return str
 }
 
-// SetChallenge sets the WWW-Authenticate value for the response.
-func (ac authChallenge) SetHeaders(w http.ResponseWriter) {
-	w.Header().Add("WWW-Authenticate", ac.challengeParams())
+// AuthenticationErrorDetails is no different than the regular Error method.
+func (ve *verificationError) AuthenticationErrorDetails() interface{} {
+	return ve.Error()
+}
+
+// SetChallengeHeaders sets the WWW-Authenticate value for the response.
+func (ve *verificationError) SetChallengeHeaders(h http.Header) {
+	h.Add("WWW-Authenticate", ve.challengeParams())
+}
+
+// authorizationError implements the auth.PermissionDenied interface.
+type authorizationError struct {
+	resource         auth.Resource
+	requestedActions actionSet
+	grantedActions   actionSet
+}
+
+var _ auth.PermissionDenied = &authorizationError{}
+
+// Error returns a string describing this authorizationError.
+func (ae *authorizationError) Error() string {
+	return fmt.Sprintf("requested access: %q authorized access: %q", scopeParam(ae.resource, ae.requestedActions), scopeParam(ae.resource, ae.grantedActions))
+}
+
+// AuthorizationErrorDetails is no different than the regular Error method.
+func (ae *authorizationError) AuthorizationErrorDetails() interface{} {
+	return ae.Error()
+}
+
+// ResourceHidden returns whether the existence of the requested resource
+// should be exposed to the client. If the client was granted no actions to the
+// requested resource then it should be hidden.
+func (ae *authorizationError) ResourceHidden() bool {
+	return len(ae.grantedActions.stringSet) == 0
 }
 
 // accessController implements the auth.AccessController interface.
@@ -212,12 +194,16 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 
 // Authorized handles checking whether the given request is authorized
 // for actions on resources described by the given access items.
-func (ac *accessController) Authorized(ctx context.Context, accessItems ...auth.Access) (context.Context, error) {
-	challenge := &authChallenge{
-		realm:     ac.realm,
-		service:   ac.service,
-		accessSet: newAccessSet(accessItems...),
-	}
+func (ac *accessController) Authorized(ctx context.Context, resource auth.Resource, actions ...string) (context.Context, error) {
+	var (
+		requestedActions = newActionSet(actions...)
+		verificationErr  = &verificationError{
+			realm:    ac.realm,
+			service:  ac.service,
+			resource: resource,
+			actions:  requestedActions,
+		}
+	)
 
 	req, err := context.GetRequest(ctx)
 	if err != nil {
@@ -227,35 +213,39 @@ func (ac *accessController) Authorized(ctx context.Context, accessItems ...auth.
 	parts := strings.Split(req.Header.Get("Authorization"), " ")
 
 	if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
-		challenge.err = ErrTokenRequired
-		return nil, challenge
+		verificationErr.err = errTokenRequired
+		return nil, verificationErr
 	}
 
 	rawToken := parts[1]
 
 	token, err := NewToken(rawToken)
 	if err != nil {
-		challenge.err = err
-		return nil, challenge
+		verificationErr.err = err
+		return nil, verificationErr
 	}
 
 	verifyOpts := VerifyOptions{
-		TrustedIssuers:    []string{ac.issuer},
-		AcceptedAudiences: []string{ac.service},
+		TrustedIssuers:    newStringSet(ac.issuer),
+		AcceptedAudiences: newStringSet(ac.service),
 		Roots:             ac.rootCerts,
 		TrustedKeys:       ac.trustedKeys,
 	}
 
 	if err = token.Verify(verifyOpts); err != nil {
-		challenge.err = err
-		return nil, challenge
+		verificationErr.err = err
+		return nil, verificationErr
 	}
 
-	accessSet := token.accessSet()
-	for _, access := range accessItems {
-		if !accessSet.contains(access) {
-			challenge.err = ErrInsufficientScope
-			return nil, challenge
+	grantedActions := token.accessSet()[resource]
+	for requestedAction := range requestedActions.stringSet {
+		if !grantedActions.contains(requestedAction) {
+			// The client is not granted access to perform this
+			// action.
+			return nil, &authorizationError{
+				requestedActions: requestedActions,
+				grantedActions:   grantedActions,
+			}
 		}
 	}
 

--- a/registry/auth/token/util.go
+++ b/registry/auth/token/util.go
@@ -45,14 +45,3 @@ func newActionSet(actions ...string) actionSet {
 func (s actionSet) contains(action string) bool {
 	return s.stringSet.contains("*") || s.stringSet.contains(action)
 }
-
-// contains returns true if q is found in ss.
-func contains(ss []string, q string) bool {
-	for _, s := range ss {
-		if s == q {
-			return true
-		}
-	}
-
-	return false
-}

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
-	"github.com/docker/distribution/registry/auth"
 	_ "github.com/docker/distribution/registry/auth/silly"
 	"github.com/docker/distribution/registry/storage"
 	memorycache "github.com/docker/distribution/registry/storage/cache/memory"
@@ -187,7 +186,7 @@ func TestNewApp(t *testing.T) {
 	defer req.Body.Close()
 
 	if req.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("unexpected status code during request: %v", err)
+		t.Fatalf("unexpected status code during request: got %d, expected %d", req.StatusCode, http.StatusUnauthorized)
 	}
 
 	if req.Header.Get("Content-Type") != "application/json; charset=utf-8" {
@@ -214,68 +213,25 @@ func TestNewApp(t *testing.T) {
 	}
 }
 
-// Test the access record accumulator
-func TestAppendAccessRecords(t *testing.T) {
-	repo := "testRepo"
+// Test the access control action accumulator.
+func TestGetRequiredRepoActions(t *testing.T) {
+	expectedPullActions := []string{"pull"}
+	expectedPushActions := []string{"pull", "push"}
+	expectedAllActions := []string{"*"}
 
-	expectedResource := auth.Resource{
-		Type: "repository",
-		Name: repo,
-	}
-
-	expectedPullRecord := auth.Access{
-		Resource: expectedResource,
-		Action:   "pull",
-	}
-	expectedPushRecord := auth.Access{
-		Resource: expectedResource,
-		Action:   "push",
-	}
-	expectedAllRecord := auth.Access{
-		Resource: expectedResource,
-		Action:   "*",
+	expectedMethodActions := map[string][]string{
+		"HEAD":   expectedPullActions,
+		"GET":    expectedPullActions,
+		"POST":   expectedPushActions,
+		"PUT":    expectedPushActions,
+		"PATCH":  expectedPushActions,
+		"DELETE": expectedAllActions,
 	}
 
-	records := []auth.Access{}
-	result := appendAccessRecords(records, "GET", repo)
-	expectedResult := []auth.Access{expectedPullRecord}
-	if ok := reflect.DeepEqual(result, expectedResult); !ok {
-		t.Fatalf("Actual access record differs from expected")
+	for method, expectedActions := range expectedMethodActions {
+		result := getRequiredRepoActions(method)
+		if ok := reflect.DeepEqual(result, expectedActions); !ok {
+			t.Fatalf("Actual required %q actions (%q) differs from expected (%q)", method, result, expectedActions)
+		}
 	}
-
-	records = []auth.Access{}
-	result = appendAccessRecords(records, "HEAD", repo)
-	expectedResult = []auth.Access{expectedPullRecord}
-	if ok := reflect.DeepEqual(result, expectedResult); !ok {
-		t.Fatalf("Actual access record differs from expected")
-	}
-
-	records = []auth.Access{}
-	result = appendAccessRecords(records, "POST", repo)
-	expectedResult = []auth.Access{expectedPullRecord, expectedPushRecord}
-	if ok := reflect.DeepEqual(result, expectedResult); !ok {
-		t.Fatalf("Actual access record differs from expected")
-	}
-
-	records = []auth.Access{}
-	result = appendAccessRecords(records, "PUT", repo)
-	expectedResult = []auth.Access{expectedPullRecord, expectedPushRecord}
-	if ok := reflect.DeepEqual(result, expectedResult); !ok {
-		t.Fatalf("Actual access record differs from expected")
-	}
-
-	records = []auth.Access{}
-	result = appendAccessRecords(records, "PATCH", repo)
-	expectedResult = []auth.Access{expectedPullRecord, expectedPushRecord}
-	if ok := reflect.DeepEqual(result, expectedResult); !ok {
-		t.Fatalf("Actual access record differs from expected")
-	}
-
-	records = []auth.Access{}
-	result = appendAccessRecords(records, "DELETE", repo)
-	expectedResult = []auth.Access{expectedAllRecord}
-	if ok := reflect.DeepEqual(result, expectedResult); !ok {
-		t.Fatalf("Actual access record differs from expected")
-	}
-
 }


### PR DESCRIPTION
Rename Challenge error interface to AuthenticationChallenge.
Introduce PermissionDenied error for indicating insufficient access.

Remove 'Access' type to simplify 'Authorized' calls to use only a
single resource with multiple actions.

Relies on #1033 

Fixes #749
Fixes #967 