### PR TITLE
Fix: Double underscore, hyphen and dot in names

### DIFF
--- a/registry/api/v2/names.go
+++ b/registry/api/v2/names.go
@@ -18,7 +18,7 @@ const (
 // RepositoryNameComponentRegexp restricts registry path component names to
 // start with at least one letter or number, with following parts able to
 // be separated by one period, dash or underscore.
-var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[._-][a-z0-9]+)*`)
+var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[._-]{1,2}[a-z0-9]+)*`)
 
 // RepositoryNameComponentAnchoredRegexp is the version of
 // RepositoryNameComponentRegexp which must completely match the content


### PR DESCRIPTION
Increase backwards compatibility for name regex by allowing double underscore, dot and hyphen without allowing crazy names like this------is---my----image.

See previous discussion here: https://github.com/docker/docker/issues/16117

Regex change here: http://regexr.com/3bsog or here: http://play.golang.org/p/rvzNY62O0D

Even though this is a major version of the api (v1->v2) this regex addition breaks BC in a minor docker version 1.6 -> 1.7.

I think allowing double underscore/hyphen/dot is a good compromise, and could be reverted to single for docker 2.0 where BC breaks are to be expected.