### PR TITLE
Remove duplicate dependency definition

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -86,7 +86,7 @@
 		},
 		{
 			"ImportPath": "github.com/ncw/swift",
-			"Rev": "22c8fa9fb5ba145b4d4e2cebb027e84b1a7b1296"
+			"Rev": "ca8cbbde50d4e12dd8ad70b1bd66589ae98efc5c"
 		},
 		{
 			"ImportPath": "github.com/noahdesu/go-ceph/rados",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -102,10 +102,6 @@
 			"Rev": "5644820622454e71517561946e3d94b9f9db6842"
 		},
 		{
-			"ImportPath": "github.com/ncw/swift",
-			"Rev": "ca8cbbde50d4e12dd8ad70b1bd66589ae98efc5c"
-		},
-		{
 			"ImportPath": "github.com/stevvooe/resumable",
 			"Rev": "51ad44105773cafcbe91927f70ac68e1bf78f8b4"
 		},


### PR DESCRIPTION
The "github.com/ncw/swift" package was declared twice in the Godeps.json and has been since 540e3f1433d89cabc7612bb224c828d34b4f00ef.