### PR TITLE
Correct the default setting of s3's "secure" parameter in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -600,7 +600,7 @@ This storage backend uses Amazon's Simple Storage Service (S3).
     </td>
     <td>
       Indicates whether to use HTTPS instead of HTTP. A boolean value. The
-      default is false.
+      default is <code>true</code>.
     </td>
   </tr>
     <tr>


### PR DESCRIPTION
This defaults to true in the code, but the doc claimed it defaults to
false.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>