### PR TITLE
Exported storage API functions needed for pruning

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -97,6 +97,14 @@ type BlobDeleter interface {
 	Delete(ctx context.Context, dgst digest.Digest) error
 }
 
+// BlobEnumerator allows to list blobs in storage.
+type BlobEnumerator interface {
+	// Enumerate calls ingester callback for each digest found in a blob store
+	// until the callback returns an error or the blob store is processed.
+	// io.EOF will be returned if all the digests are handled.
+	Enumerate(ctx context.Context, ingester func(digest.Digest) error) error
+}
+
 // BlobDescriptorService manages metadata about a blob by digest. Most
 // implementations will not expose such an interface explicitly. Such mappings
 // should be maintained by interacting with the BlobIngester. Hence, this is
@@ -225,9 +233,10 @@ type BlobService interface {
 }
 
 // BlobStore represent the entire suite of blob related operations. Such an
-// implementation can access, read, write, delete and serve blobs.
+// implementation can access, enumerate, read, write, delete and serve blobs.
 type BlobStore interface {
 	BlobService
 	BlobServer
+	BlobEnumerator
 	BlobDeleter
 }

--- a/manifests.go
+++ b/manifests.go
@@ -54,11 +54,10 @@ type ManifestService interface {
 	// a manifest that doesn't exist will return ErrManifestNotFound
 	Delete(ctx context.Context, dgst digest.Digest) error
 
-	// Enumerate fills 'manifests' with the manifests in this service up
-	// to the size of 'manifests' and returns 'n' for the number of entries
-	// which were filled.  'last' contains an offset in the manifest set
-	// and can be used to resume iteration.
-	//Enumerate(ctx context.Context, manifests []Manifest, last Manifest) (n int, err error)
+	// Enumerate calls ingester callback for each digest found in a blob store
+	// until the callback returns an error or the blob store is processed.
+	// io.EOF will be returned if all the digests are handled.
+	Enumerate(ctx context.Context, ingester func(digest.Digest) error) error
 }
 
 // Describable is an interface for descriptors

--- a/registry.go
+++ b/registry.go
@@ -40,6 +40,9 @@ type Namespace interface {
 	// which were filled.  'last' contains an offset in the catalog, and 'err' will be
 	// set to io.EOF if there are no more entries to obtain.
 	Repositories(ctx context.Context, repos []string, last string) (n int, err error)
+
+	// Blobs returns a reference to registry's blob service.
+	Blobs() BlobService
 }
 
 // ManifestServiceOption is a function argument for Manifest Service methods

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -509,9 +509,9 @@ func (ms *manifests) Delete(ctx context.Context, dgst digest.Digest) error {
 }
 
 // todo(richardscothern): Restore interface and implementation with merge of #1050
-/*func (ms *manifests) Enumerate(ctx context.Context, manifests []distribution.Manifest, last distribution.Manifest) (n int, err error) {
-	panic("not supported")
-}*/
+func (ms *manifests) Enumerate(ctx context.Context, ingester func(digest.Digest) error) error {
+	return distribution.ErrUnsupported
+}
 
 type blobs struct {
 	name   reference.Named
@@ -688,6 +688,10 @@ func (bs *blobs) Resume(ctx context.Context, id string) (distribution.BlobWriter
 
 func (bs *blobs) Delete(ctx context.Context, dgst digest.Digest) error {
 	return bs.statter.Clear(ctx, dgst)
+}
+
+func (bs *blobs) Enumerate(ctx context.Context, ingester func(digest.Digest) error) error {
+	return distribution.ErrUnsupported
 }
 
 type blobStatter struct {

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -182,6 +182,10 @@ func (pbs *proxyBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte,
 	return nil, distribution.ErrUnsupported
 }
 
+func (pbs *proxyBlobStore) Enumerate(ctx context.Context, ingester func(digest.Digest) error) error {
+	return distribution.ErrUnsupported
+}
+
 func (pbs *proxyBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	return distribution.ErrUnsupported
 }

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -51,6 +51,14 @@ func (sbs statsBlobStore) Create(ctx context.Context, options ...distribution.Bl
 	return sbs.blobs.Create(ctx, options...)
 }
 
+func (sbs statsBlobStore) Enumerate(ctx context.Context, ingester func(digest.Digest) error) error {
+	sbsMu.Lock()
+	sbs.stats["enumerate"]++
+	sbsMu.Unlock()
+
+	return sbs.blobs.Enumerate(ctx, ingester)
+}
+
 func (sbs statsBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
 	sbsMu.Lock()
 	sbs.stats["resume"]++

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -81,7 +81,6 @@ func (pms proxyManifestStore) Delete(ctx context.Context, dgst digest.Digest) er
 	return distribution.ErrUnsupported
 }
 
-/*func (pms proxyManifestStore) Enumerate(ctx context.Context, manifests []distribution.Manifest, last distribution.Manifest) (n int, err error) {
-	return 0, distribution.ErrUnsupported
+func (pms proxyManifestStore) Enumerate(ctx context.Context, fn func(digest.Digest) error) error {
+	return distribution.ErrUnsupported
 }
-*/

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -58,11 +58,10 @@ func (sm statsManifest) Put(ctx context.Context, manifest distribution.Manifest,
 	return sm.manifests.Put(ctx, manifest)
 }
 
-/*func (sm statsManifest) Enumerate(ctx context.Context, manifests []distribution.Manifest, last distribution.Manifest) (n int, err error) {
+func (sm statsManifest) Enumerate(ctx context.Context, fn func(digest.Digest) error) error {
 	sm.stats["enumerate"]++
-	return sm.manifests.Enumerate(ctx, manifests, last)
+	return sm.manifests.Enumerate(ctx, fn)
 }
-*/
 
 func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestEnv {
 	nameRef, err := reference.ParseNamed(name)

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -116,6 +116,11 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 	}, nil
 }
 
+// Blobs returns a blob service for local blob store.
+func (pr *proxyingRegistry) Blobs() distribution.BlobService {
+	return pr.embedded.Blobs()
+}
+
 // proxiedRepository uses proxying blob and manifest services to serve content
 // locally, or pulling it through from a remote and caching it locally if it doesn't
 // already exist

--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -2,11 +2,14 @@ package storage
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
 	"io"
 	"io/ioutil"
+	mrand "math/rand"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/docker/distribution"
@@ -137,16 +140,22 @@ func TestSimpleBlobUpload(t *testing.T) {
 		t.Fatalf("unexpected digest from uploaded layer: %q != %q", digest.NewDigest("sha256", h), sha256Digest)
 	}
 
+	checkBlobParentPath(t, ctx, driver, nil, desc.Digest, true)
+	checkBlobParentPath(t, ctx, driver, imageName, desc.Digest, true)
+
 	// Delete a blob
 	err = bs.Delete(ctx, desc.Digest)
 	if err != nil {
-		t.Fatalf("Unexpected error deleting blob")
+		t.Fatalf("Unexpected error deleting blob: %v", err)
 	}
 
 	d, err := bs.Stat(ctx, desc.Digest)
 	if err == nil {
 		t.Fatalf("unexpected non-error stating deleted blob: %v", d)
 	}
+
+	checkBlobParentPath(t, ctx, driver, nil, desc.Digest, true)
+	checkBlobParentPath(t, ctx, driver, imageName, desc.Digest, true)
 
 	switch err {
 	case distribution.ErrBlobUnknown:
@@ -487,6 +496,350 @@ func TestLayerUploadZeroLength(t *testing.T) {
 	simpleUpload(t, bs, []byte{}, digest.DigestSha256EmptyTar)
 }
 
+// TestRemoveParentsOnDelete verifies that blob store deletes a directory
+// together with blob's data or link when RemoveParentsOnDelete option is
+// applied.
+func TestRemoveBlobParentsOnDelete(t *testing.T) {
+	ctx := context.Background()
+	imageName, _ := reference.ParseNamed("foo/bar")
+	driver := inmemory.New()
+	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect, RemoveParentsOnDelete)
+	if err != nil {
+		t.Fatalf("error creating registry: %v", err)
+	}
+	repository, err := registry.Repository(ctx, imageName)
+	if err != nil {
+		t.Fatalf("unexpected error getting repo: %v", err)
+	}
+	bs := repository.Blobs(ctx)
+
+	checkBlobParentPath(t, ctx, driver, nil, digest.DigestSha256EmptyTar, false)
+	checkBlobParentPath(t, ctx, driver, imageName, digest.DigestSha256EmptyTar, false)
+
+	simpleUpload(t, bs, []byte{}, digest.DigestSha256EmptyTar)
+
+	checkBlobParentPath(t, ctx, driver, nil, digest.DigestSha256EmptyTar, true)
+	checkBlobParentPath(t, ctx, driver, imageName, digest.DigestSha256EmptyTar, true)
+
+	// Delete a layer link
+	err = bs.Delete(ctx, digest.DigestSha256EmptyTar)
+	if err != nil {
+		t.Fatalf("Unexpected error deleting blob: %v", err)
+	}
+
+	checkBlobParentPath(t, ctx, driver, nil, digest.DigestSha256EmptyTar, true)
+	checkBlobParentPath(t, ctx, driver, imageName, digest.DigestSha256EmptyTar, false)
+
+	bd, err := RegistryBlobDeleter(registry)
+	if err != nil {
+		t.Fatalf("failed to obtain blob deleter: %v", err)
+	}
+	bd.Delete(ctx, digest.DigestSha256EmptyTar)
+
+	checkBlobParentPath(t, ctx, driver, nil, digest.DigestSha256EmptyTar, false)
+	checkBlobParentPath(t, ctx, driver, imageName, digest.DigestSha256EmptyTar, false)
+}
+
+// TestBlobEnumeration checks whether enumeration of repository and registry's
+// blobs returns proper results.
+func TestBlobEnumeration(t *testing.T) {
+	ctx := context.Background()
+	imageNames := [2]reference.Named{}
+	for i, name := range []string{"foo/bar", "baz/gas"} {
+		imageNames[i], _ = reference.ParseNamed(name)
+	}
+	driver := inmemory.New()
+	reg, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
+	if err != nil {
+		t.Fatalf("error creating registry: %v", err)
+	}
+	// holds a repository objects corresponding to imageNames
+	repositories := make([]distribution.Repository, len(imageNames))
+	// holds blob store of each repository
+	blobStores := make([]distribution.BlobStore, len(imageNames))
+	for i, name := range imageNames {
+		repositories[i], err = reg.Repository(ctx, name)
+		if err != nil {
+			t.Fatalf("unexpected error getting repo: %v", err)
+		}
+		blobStores[i] = repositories[i].Blobs(ctx)
+	}
+	be, err := RegistryBlobEnumerator(reg)
+	if err != nil {
+		t.Fatalf("unexpected error getting blob enumerator: %v", err)
+	}
+
+	// doEnumeration calls Enumerate method on all repositories and registry's blob store.
+	// Additinal arguments represent expected digests for each repository defined.
+	doEnumeration := func(expectRegistryBlobs []digest.Digest, expectDigests ...[]digest.Digest) {
+		expBlobSets := make([]map[digest.Digest]struct{}, len(imageNames))
+		totalBlobSet := make(map[digest.Digest]struct{})
+		for i, dgsts := range expectDigests {
+			expBlobSets[i] = make(map[digest.Digest]struct{})
+			for _, dgst := range dgsts {
+				expBlobSets[i][dgst] = struct{}{}
+			}
+		}
+		for _, d := range expectRegistryBlobs {
+			totalBlobSet[d] = struct{}{}
+		}
+
+		dgsts := make([]digest.Digest, 0, len(totalBlobSet)+1)
+
+		for i, bs := range blobStores {
+			err := bs.Enumerate(ctx, func(dgst digest.Digest) error {
+				dgsts = append(dgsts, dgst)
+				return nil
+			})
+			if err != io.EOF {
+				t.Fatalf("expected io.EOF when enumerating blobs of repository %s, not: %v", imageNames[i], err)
+			}
+			if len(dgsts) != len(expBlobSets[i]) {
+				t.Errorf("got unexpected number of blobs in repository %s (%d != %d)", imageNames[i], len(dgsts), len(expBlobSets[i]))
+			}
+			for _, d := range dgsts {
+				if _, exists := expBlobSets[i][d]; !exists {
+					t.Errorf("received unexpected blob digest %s in repository %s", d, imageNames[i])
+				}
+				delete(expBlobSets[i], d)
+			}
+			for d := range expBlobSets[i] {
+				t.Errorf("expected digest %s not received for repository %s", d, imageNames[i])
+			}
+			dgsts = dgsts[0:0]
+		}
+
+		err := be.Enumerate(ctx, func(dgst digest.Digest) error {
+			dgsts = append(dgsts, dgst)
+			return nil
+		})
+		if err != io.EOF {
+			t.Fatalf("expected io.EOF when enumerating registry blobs, not: %v", err)
+		}
+		if len(dgsts) != len(totalBlobSet) {
+			t.Errorf("got unexpected number of blobs in registry (%d != %d)", len(dgsts), len(totalBlobSet))
+		}
+		for _, d := range dgsts {
+			if _, exists := totalBlobSet[d]; !exists {
+				t.Errorf("received unexpected blob digest %s", d)
+			}
+			delete(totalBlobSet, d)
+		}
+		for d := range totalBlobSet {
+			t.Errorf("expected digest %s not received", d)
+		}
+	}
+
+	doEnumeration(
+		[]digest.Digest{},
+		[]digest.Digest{},
+		[]digest.Digest{},
+	)
+
+	t.Logf("uploading an empty tarball to repository %s", imageNames[0])
+	simpleUpload(t, blobStores[0], []byte{}, digest.DigestSha256EmptyTar)
+
+	doEnumeration(
+		[]digest.Digest{digest.DigestSha256EmptyTar},
+		[]digest.Digest{digest.DigestSha256EmptyTar},
+		[]digest.Digest{},
+	)
+
+	t.Logf("uploading a random tarball to repository %s", imageNames[1])
+	tarballDgst := uploadRandomTarball(t, ctx, blobStores[1])
+
+	doEnumeration(
+		[]digest.Digest{digest.DigestSha256EmptyTar, tarballDgst},
+		[]digest.Digest{digest.DigestSha256EmptyTar},
+		[]digest.Digest{tarballDgst},
+	)
+
+	t.Logf("uploading a random layer to %s repository", imageNames[0])
+	layerDgst := uploadRandomLayer(t, ctx, blobStores[0])
+
+	doEnumeration(
+		[]digest.Digest{digest.DigestSha256EmptyTar, layerDgst, tarballDgst},
+		[]digest.Digest{digest.DigestSha256EmptyTar, layerDgst},
+		[]digest.Digest{tarballDgst},
+	)
+
+	// delete is performed without parent directory being deleted
+	t.Logf("deleting empty layer data from registry")
+	bd, err := RegistryBlobDeleter(reg)
+	if err != nil {
+		t.Fatalf("failed to obtain blob deleter: %v", err)
+	}
+	err = bd.Delete(ctx, digest.DigestSha256EmptyTar)
+	if err != nil {
+		t.Fatalf("unexpected error while deleting registry blob: %v", err)
+	}
+	checkBlobParentPath(t, ctx, driver, nil, digest.DigestSha256EmptyTar, true)
+	checkBlobParentPath(t, ctx, driver, imageNames[0], digest.DigestSha256EmptyTar, true)
+	checkBlobParentPath(t, ctx, driver, imageNames[1], digest.DigestSha256EmptyTar, false)
+
+	// check that deletion had no effect on digests enumerated
+	doEnumeration(
+		[]digest.Digest{digest.DigestSha256EmptyTar, layerDgst, tarballDgst},
+		[]digest.Digest{digest.DigestSha256EmptyTar, layerDgst},
+		[]digest.Digest{tarballDgst},
+	)
+
+	// set RemoveParentsOnDelete and delete the layer again
+	if r, ok := reg.(*registry); ok {
+		RemoveParentsOnDelete(r)
+	} else {
+		t.Fatalf("failed to cast registry")
+	}
+
+	repo, err := reg.Repository(ctx, imageNames[0])
+	if err != nil {
+		t.Fatalf("unexpected error getting repo: %v", err)
+	}
+	bs := repo.Blobs(ctx)
+	bd, err = RegistryBlobDeleter(reg)
+	if err != nil {
+		t.Fatalf("failed to obtain blob deleter: %v", err)
+	}
+
+	t.Logf("deleting empty layer link directory from %s repository", imageNames[0])
+	err = bs.Delete(ctx, digest.DigestSha256EmptyTar)
+	if err != nil {
+		t.Fatalf("unexpected error while deleting empty layer link: %v", err)
+	}
+	checkBlobParentPath(t, ctx, driver, nil, digest.DigestSha256EmptyTar, true)
+	checkBlobParentPath(t, ctx, driver, imageNames[0], digest.DigestSha256EmptyTar, false)
+	checkBlobParentPath(t, ctx, driver, imageNames[1], digest.DigestSha256EmptyTar, false)
+
+	// verify that blob data is still in registry's store
+	doEnumeration(
+		[]digest.Digest{digest.DigestSha256EmptyTar, layerDgst, tarballDgst},
+		[]digest.Digest{layerDgst},
+		[]digest.Digest{tarballDgst},
+	)
+
+	t.Logf("deleting empty layer directory from registry")
+	err = bd.Delete(ctx, digest.DigestSha256EmptyTar)
+	if err != nil {
+		t.Fatalf("unexpected error while deleting registry blob: %v", err)
+	}
+
+	doEnumeration(
+		[]digest.Digest{layerDgst, tarballDgst},
+		[]digest.Digest{layerDgst},
+		[]digest.Digest{tarballDgst},
+	)
+
+	checkBlobParentPath(t, ctx, driver, nil, digest.DigestSha256EmptyTar, false)
+}
+
+// TestBlobEnumeration checks whether enumeration of repository and registry's
+// blobs returns proper results when callback indicates *stop processing*.
+func TestBlobStopEnumeration(t *testing.T) {
+	const numDigests = 10
+	ctx := context.Background()
+	imageName, _ := reference.ParseNamed("foo/bar")
+	driver := inmemory.New()
+	reg, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
+	if err != nil {
+		t.Fatalf("error creating registry: %v", err)
+	}
+
+	repo, err := reg.Repository(ctx, imageName)
+	if err != nil {
+		t.Fatalf("unexpected error getting repo: %v", err)
+	}
+	bs := repo.Blobs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error getting blob enumerator: %v", err)
+	}
+	be, err := RegistryBlobEnumerator(reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digests := make([]digest.Digest, numDigests)
+	for i := 0; i < numDigests; i++ {
+		var dgst digest.Digest
+		if i%2 == 0 {
+			dgst = uploadRandomLayer(t, ctx, bs)
+			t.Logf("uploaded a new layer with digest %s", dgst.String())
+		} else {
+			dgst = uploadRandomTarball(t, ctx, bs)
+			t.Logf("uploaded a new tarsum layer with digest %s", dgst.String())
+		}
+		digests[i] = dgst
+	}
+
+	testEnum := func(be distribution.BlobEnumerator, stopAfter int, withEOF bool, allDigests []digest.Digest) {
+		ret := "error"
+		if withEOF {
+			ret = "EOF"
+		}
+		testCtx := fmt.Sprintf("%T: stopAfter=%d with %s", be, stopAfter, ret)
+
+		dgsts := []digest.Digest{}
+		err := be.Enumerate(ctx, func(dgst digest.Digest) error {
+			if err := dgst.Validate(); err != nil {
+				t.Errorf("%s: ingest callback called with invalid digest %q: %v", testCtx, dgst.String(), err)
+			}
+			if len(dgsts) >= stopAfter {
+				t.Errorf("%s: ingest callback called again after returning a request for stop (n=%d)", testCtx, len(dgsts))
+			}
+			dgsts = append(dgsts, dgst)
+			if len(dgsts) >= stopAfter {
+				if withEOF {
+					return io.EOF
+				}
+				return fmt.Errorf("don't call us again")
+			}
+			return nil
+		})
+
+		if err == io.EOF && len(dgsts) < len(allDigests) {
+			t.Errorf("%s: got unexpected io.EOF", testCtx)
+		} else if len(dgsts) > len(allDigests) && err != io.EOF {
+			t.Errorf("%s: expected io.EOF, got: %v", testCtx, err)
+		}
+
+		if len(dgsts) != stopAfter {
+			t.Errorf("%s: ingest function called %d times instead of %d", testCtx, len(dgsts), stopAfter)
+		}
+
+		dgstSet := map[digest.Digest]struct{}{}
+		for _, d := range allDigests {
+			if _, exists := dgstSet[d]; exists {
+				t.Errorf("%s: received duplicate digest %q", testCtx, d.String())
+			}
+			dgstSet[d] = struct{}{}
+		}
+
+		for _, dgst := range allDigests {
+			delete(dgstSet, dgst)
+		}
+
+		for dgst := range dgstSet {
+			t.Errorf("%s: got unexpected digest %q", testCtx, dgst.String())
+		}
+	}
+
+	// enumerate linked blob store
+	testEnum(bs, 10, true, digests)
+	testEnum(bs, 4, true, digests)
+	testEnum(bs, 1, true, digests)
+
+	testEnum(bs, 10, false, digests)
+	testEnum(bs, 4, false, digests)
+	testEnum(bs, 1, false, digests)
+
+	testEnum(be, 10, true, digests)
+	testEnum(be, 4, true, digests)
+	testEnum(be, 1, true, digests)
+
+	testEnum(be, 10, false, digests)
+	testEnum(be, 4, false, digests)
+	testEnum(be, 1, false, digests)
+}
+
 func simpleUpload(t *testing.T, bs distribution.BlobIngester, blob []byte, expectedDigest digest.Digest) {
 	ctx := context.Background()
 	wr, err := bs.Create(ctx)
@@ -565,4 +918,107 @@ func addBlob(ctx context.Context, bs distribution.BlobIngester, desc distributio
 	}
 
 	return wr.Commit(ctx, desc)
+}
+
+func createRandomData() (io.ReadSeeker, int64, error) {
+	fileSize := mrand.Int63n(1<<20) + 1<<20
+
+	randomData := make([]byte, fileSize)
+	// Fill up the buffer with some random data.
+	n, err := rand.Read(randomData)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to fill buffer with random data: %v", err)
+	}
+	if n != len(randomData) {
+		return nil, 0, fmt.Errorf("short read creating random reader: %v bytes != %v bytes", n, len(randomData))
+	}
+
+	return bytes.NewReader(randomData), fileSize, nil
+}
+
+func uploadRandomLayer(t *testing.T, ctx context.Context, bi distribution.BlobIngester) digest.Digest {
+	dr, size, err := createRandomData()
+	if err != nil {
+		t.Fatalf("failed to create random file: %v", err)
+	}
+
+	h := sha256.New()
+	rd := io.TeeReader(dr, h)
+	blobUpload, err := bi.Create(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error starting layer upload: %s", err)
+	}
+	nn, err := io.Copy(blobUpload, rd)
+	if err != nil {
+		t.Fatalf("unexpected error uploading layer data: %v", err)
+	}
+	if nn != size {
+		t.Fatalf("layer data write incomplete")
+	}
+	dgst := digest.NewDigest("sha256", h)
+	_, err = blobUpload.Commit(ctx, distribution.Descriptor{Digest: dgst})
+	if err != nil {
+		t.Fatalf("unexpected error finishing layer upload: %v", err)
+	}
+	return dgst
+}
+
+func uploadRandomTarball(t *testing.T, ctx context.Context, bi distribution.BlobIngester) digest.Digest {
+	randomDataReader, tarSumStr, err := testutil.CreateRandomTarFile()
+	if err != nil {
+		t.Fatalf("error creating random reader: %v", err)
+	}
+	dgst := digest.Digest(tarSumStr)
+	if err != nil {
+		t.Fatalf("error allocating upload store: %v", err)
+	}
+
+	randomLayerSize, err := seekerSize(randomDataReader)
+	if err != nil {
+		t.Fatalf("error getting seeker size for random layer: %v", err)
+	}
+
+	_, err = addBlob(ctx, bi, distribution.Descriptor{
+		Digest:    dgst,
+		MediaType: "application/octet-stream",
+		Size:      randomLayerSize,
+	}, randomDataReader)
+	if err != nil {
+		t.Fatalf("failed to add blob: %v", err)
+	}
+	return dgst
+}
+
+// checkBlobParentPath asserts that a directory containing blob's link or data
+// does (not) exist. If repoName is given, link path in _layers directory of
+// that repository will be checked. Registry's blob store will be checked
+// otherwise.
+func checkBlobParentPath(t *testing.T, ctx context.Context, driver *inmemory.Driver, repo reference.Named, dgst digest.Digest, expectExistent bool) {
+	var (
+		blobPath string
+		err      error
+	)
+
+	if repo != nil {
+		blobPath, err = pathFor(layerLinkPathSpec{name: repo.Name(), digest: dgst})
+		if err != nil {
+			t.Fatalf("failed to get layer link path for repo=%s, digest=%s: %v", repo.Name(), dgst.String(), err)
+		}
+		blobPath = path.Dir(blobPath)
+	} else {
+		blobPath, err = pathFor(blobPathSpec{digest: dgst})
+		if err != nil {
+			t.Fatalf("failed to get blob path for digest %s: %v", dgst.String(), err)
+		}
+	}
+
+	parentExists, err := exists(ctx, driver, blobPath)
+	if err != nil {
+		t.Fatalf("failed to check whether path %s exists: %v", blobPath, err)
+	}
+	if expectExistent && !parentExists {
+		t.Errorf("expected blob path %s to exist", blobPath)
+	} else if !expectExistent && parentExists {
+		t.Errorf("expected blob path %s not to exist", blobPath)
+	}
 }

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -1,6 +1,9 @@
 package storage
 
 import (
+	"io"
+	"path"
+
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
@@ -12,11 +15,17 @@ import (
 // intentionally a leaky abstraction, providing utility methods that support
 // creating and traversing backend links.
 type blobStore struct {
-	driver  driver.StorageDriver
-	statter distribution.BlobStatter
+	driver        driver.StorageDriver
+	statter       distribution.BlobDescriptorService
+	deleteEnabled bool
+	// Causes directory containing blob's data to be removed recursively upon
+	// Delete.
+	removeParentsOnDelete bool
 }
 
-var _ distribution.BlobProvider = &blobStore{}
+var _ distribution.BlobService = &blobStore{}
+var _ distribution.BlobEnumerator = &blobStore{}
+var _ distribution.BlobDeleter = &blobStore{}
 
 // Get implements the BlobReadService.Get call.
 func (bs *blobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
@@ -83,6 +92,64 @@ func (bs *blobStore) Put(ctx context.Context, mediaType string, p []byte) (distr
 		MediaType: "application/octet-stream",
 		Digest:    dgst,
 	}, bs.driver.PutContent(ctx, bp, p)
+}
+
+func (bs *blobStore) Enumerate(ctx context.Context, ingest func(digest.Digest) error) error {
+	context.GetLogger(ctx).Debug("(*blobStore).Enumerate")
+	rootPath := path.Join(storagePathRoot, storagePathVersion, "blobs")
+
+	walkFn, err := makeBlobStoreWalkFunc(rootPath, true, ingest)
+	if err != nil {
+		return err
+	}
+
+	err = Walk(ctx, bs.driver, rootPath, walkFn)
+	if err != nil {
+		switch err.(type) {
+		case driver.PathNotFoundError:
+			return io.EOF
+		}
+		if err == ErrFinishedWalk {
+			return nil
+		}
+		return err
+	}
+
+	return io.EOF
+}
+
+func (bs *blobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	return nil, distribution.ErrUnsupported
+}
+
+func (bs *blobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	return nil, distribution.ErrUnsupported
+}
+
+func (bs *blobStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	var (
+		blobPath string
+		err      error
+	)
+	if !bs.deleteEnabled {
+		return distribution.ErrUnsupported
+	}
+
+	if bs.removeParentsOnDelete {
+		blobPath, err = pathFor(blobPathSpec{digest: dgst})
+	} else {
+		blobPath, err = pathFor(blobDataPathSpec{digest: dgst})
+	}
+	if err != nil {
+		return err
+	}
+
+	context.GetLogger(ctx).Infof("Deleting blob path: %s", blobPath)
+	return bs.driver.Delete(ctx, blobPath)
+}
+
+func (bs *blobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	return bs.statter.Stat(ctx, dgst)
 }
 
 // path returns the canonical path for the blob identified by digest. The blob

--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -10,11 +10,6 @@ import (
 	"github.com/docker/distribution/registry/storage/driver"
 )
 
-// ErrFinishedWalk is used when the called walk function no longer wants
-// to accept any more values.  This is used for pagination when the
-// required number of repos have been found.
-var ErrFinishedWalk = errors.New("finished walk")
-
 // Returns a list, or partial list, of repositories in the registry.
 // Because it's a quite expensive operation, it should only be used when building up
 // an initial set of repositories.
@@ -30,15 +25,15 @@ func (reg *registry) Repositories(ctx context.Context, repos []string, last stri
 		return 0, err
 	}
 
-	err = Walk(ctx, reg.blobStore.driver, root, func(fileInfo driver.FileInfo) error {
+	err = WalkSortedChildren(ctx, reg.blobStore.driver, root, func(fileInfo driver.FileInfo) error {
 		filePath := fileInfo.Path()
 
 		// lop the base path off
 		repoPath := filePath[len(root)+1:]
 
 		_, file := path.Split(repoPath)
-		if file == "_layers" {
-			repoPath = strings.TrimSuffix(repoPath, "/_layers")
+		if file == layersDirectory {
+			repoPath = strings.TrimSuffix(repoPath, "/"+layersDirectory)
 			if repoPath > last {
 				foundRepos = append(foundRepos, repoPath)
 			}

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -2,7 +2,9 @@ package storage
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/docker/distribution"
@@ -16,6 +18,10 @@ import (
 // linkPathFunc describes a function that can resolve a link based on the
 // repository name and digest.
 type linkPathFunc func(name string, dgst digest.Digest) (string, error)
+
+// blobsRootPathFunc describes a function that can resolve a root directory of
+// blob links based on the repository name.
+type blobsRootPathFunc func(name string) (string, error)
 
 // linkedBlobStore provides a full BlobService that namespaces the blobs to a
 // given repository. Effectively, it manages the links in a given repository
@@ -37,6 +43,10 @@ type linkedBlobStore struct {
 	// removed an the blob links folder should be merged. The first entry is
 	// treated as the "canonical" link location and will be used for writes.
 	linkPathFns []linkPathFunc
+
+	// blobsRootPathFns functions the same way for blob root directories as
+	// linkPathFns for blob links.
+	blobsRootPathFns []blobsRootPathFunc
 }
 
 var _ distribution.BlobStore = &linkedBlobStore{}
@@ -218,22 +228,12 @@ func (lbs *linkedBlobStore) Resume(ctx context.Context, id string) (distribution
 }
 
 func (lbs *linkedBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	context.GetLogger(ctx).Debug("(*linkedBlobStore).Delete")
 	if !lbs.deleteEnabled {
 		return distribution.ErrUnsupported
 	}
 
-	// Ensure the blob is available for deletion
-	_, err := lbs.blobAccessController.Stat(ctx, dgst)
-	if err != nil {
-		return err
-	}
-
-	err = lbs.blobAccessController.Clear(ctx, dgst)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return lbs.blobAccessController.Clear(ctx, dgst)
 }
 
 func (lbs *linkedBlobStore) mount(ctx context.Context, sourceRepo reference.Named, dgst digest.Digest) (distribution.Descriptor, error) {
@@ -311,6 +311,42 @@ func (lbs *linkedBlobStore) linkBlob(ctx context.Context, canonical distribution
 	return nil
 }
 
+func (lbs *linkedBlobStore) Enumerate(ctx context.Context, ingest func(digest.Digest) error) error {
+	context.GetLogger(ctx).Debug("(*linkedBlobStore).Enumerate")
+	allProcessed := true
+
+	for _, pathFn := range lbs.blobsRootPathFns {
+		rootPath, err := pathFn(lbs.repository.Name().Name())
+		if err != nil {
+			return err
+		}
+
+		walkFn, err := makeBlobStoreWalkFunc(rootPath, false, ingest)
+		if err != nil {
+			return err
+		}
+
+		err = WalkSortedChildren(ctx, lbs.driver, rootPath, walkFn)
+		if err != nil {
+			switch err.(type) {
+			case driver.PathNotFoundError:
+			default:
+				if err != ErrFinishedWalk {
+					return err
+				}
+				// ErrFinishedWalk meens caller don't want us to continue
+				allProcessed = false
+			}
+		}
+	}
+
+	if allProcessed {
+		return io.EOF
+	}
+
+	return nil
+}
+
 type linkedBlobStatter struct {
 	*blobStore
 	repository distribution.Repository
@@ -322,6 +358,10 @@ type linkedBlobStatter struct {
 	// removed an the blob links folder should be merged. The first entry is
 	// treated as the "canonical" link location and will be used for writes.
 	linkPathFns []linkPathFunc
+
+	// Causes directory containing blob's data to be removed recursively upon
+	// Clear.
+	removeParentsOnDelete bool
 }
 
 var _ distribution.BlobDescriptorService = &linkedBlobStatter{}
@@ -339,6 +379,7 @@ func (lbs *linkedBlobStatter) Stat(ctx context.Context, dgst digest.Digest) (dis
 		target, err = lbs.resolveWithLinkFunc(ctx, dgst, linkPathFn)
 
 		if err == nil {
+			resolveErr = nil
 			break // success!
 		}
 
@@ -366,6 +407,8 @@ func (lbs *linkedBlobStatter) Stat(ctx context.Context, dgst digest.Digest) (dis
 }
 
 func (lbs *linkedBlobStatter) Clear(ctx context.Context, dgst digest.Digest) (err error) {
+	resolveErr := distribution.ErrBlobUnknown
+
 	// clear any possible existence of a link described in linkPathFns
 	for _, linkPathFn := range lbs.linkPathFns {
 		blobLinkPath, err := linkPathFn(lbs.repository.Name().Name(), dgst)
@@ -373,7 +416,11 @@ func (lbs *linkedBlobStatter) Clear(ctx context.Context, dgst digest.Digest) (er
 			return err
 		}
 
-		err = lbs.blobStore.driver.Delete(ctx, blobLinkPath)
+		pth := blobLinkPath
+		if lbs.removeParentsOnDelete {
+			pth = path.Dir(blobLinkPath)
+		}
+		err = lbs.blobStore.driver.Delete(ctx, pth)
 		if err != nil {
 			switch err := err.(type) {
 			case driver.PathNotFoundError:
@@ -382,9 +429,10 @@ func (lbs *linkedBlobStatter) Clear(ctx context.Context, dgst digest.Digest) (er
 				return err
 			}
 		}
+		resolveErr = nil
 	}
 
-	return nil
+	return resolveErr
 }
 
 // resolveTargetWithFunc allows us to read a link to a resource with different
@@ -409,7 +457,18 @@ func blobLinkPath(name string, dgst digest.Digest) (string, error) {
 	return pathFor(layerLinkPathSpec{name: name, digest: dgst})
 }
 
+// blobsRootPath provides the path to the root of blob links, also known as
+// layers.
+func blobsRootPath(name string) (string, error) {
+	return pathFor(layersPathSpec{name: name})
+}
+
 // manifestRevisionLinkPath provides the path to the manifest revision link.
 func manifestRevisionLinkPath(name string, dgst digest.Digest) (string, error) {
 	return pathFor(manifestRevisionLinkPathSpec{name: name, revision: dgst})
+}
+
+// manifestRevisionsPath provides the path to the manifest revisions directory.
+func manifestRevisionsPath(name string) (string, error) {
+	return pathFor(manifestRevisionsPathSpec{name: name})
 }

--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -72,7 +72,7 @@ func getOutstandingUploads(ctx context.Context, driver storageDriver.StorageDriv
 		_, file := path.Split(filePath)
 		if file[0] == '_' {
 			// Reserved directory
-			inUploadDir = (file == "_uploads")
+			inUploadDir = (file == uploadsDirectory)
 
 			if fileInfo.IsDir() && !inUploadDir {
 				return ErrSkipDir

--- a/registry/storage/walk.go
+++ b/registry/storage/walk.go
@@ -3,10 +3,19 @@ package storage
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
+	"strings"
 
+	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
 	storageDriver "github.com/docker/distribution/registry/storage/driver"
+)
+
+var (
+	reTarsumPrefix = regexp.MustCompile(`^tarsum(?:/(\w+))?`)
+	reDigestPath   = regexp.MustCompile(fmt.Sprintf(`^([^/]+)/(?:\w{%d}/)?(\w+)$`, multilevelHexPrefixLength))
 )
 
 // ErrSkipDir is used as a return value from onFileFunc to indicate that
@@ -14,20 +23,42 @@ import (
 // as an error by any function.
 var ErrSkipDir = errors.New("skip this directory")
 
+// ErrFinishedWalk is used when the called walk function no longer wants
+// to accept any more values.  This is used for pagination when the
+// required number of items have been found.
+var ErrFinishedWalk = errors.New("finished walk")
+
 // WalkFn is called once per file by Walk
 // If the returned error is ErrSkipDir and fileInfo refers
 // to a directory, the directory will not be entered and Walk
 // will continue the traversal.  Otherwise Walk will return
 type WalkFn func(fileInfo storageDriver.FileInfo) error
 
-// Walk traverses a filesystem defined within driver, starting
-// from the given path, calling f on each file
-func Walk(ctx context.Context, driver storageDriver.StorageDriver, from string, f WalkFn) error {
+// WalkChildrenFilter transforms a list of directory children during a
+// walk before before it's recursively traversed.
+type WalkChildrenFilter func([]string) []string
+
+// walkChildrenSortedFilter causes Walk to process entries in a lexicographical
+// order.
+func walkChildrenSortedFilter(children []string) []string {
+	sort.Stable(sort.StringSlice(children))
+	return children
+}
+
+// walkChildrenNoFilter is an identity filter for directory children.
+func walkChildrenNoFilter(children []string) []string {
+	return children
+}
+
+// WalkWithChildrenFilter traverses a filesystem defined within driver,
+// starting from the given path, calling f on each file. Given filter will be
+// called on a list of directory children before beeing recursively processed.
+func WalkWithChildrenFilter(ctx context.Context, driver storageDriver.StorageDriver, from string, filter WalkChildrenFilter, f WalkFn) error {
 	children, err := driver.List(ctx, from)
 	if err != nil {
 		return err
 	}
-	sort.Stable(sort.StringSlice(children))
+	filter(children)
 	for _, child := range children {
 		// TODO(stevvooe): Calling driver.Stat for every entry is quite
 		// expensive when running against backends with a slow Stat
@@ -44,7 +75,7 @@ func Walk(ctx context.Context, driver storageDriver.StorageDriver, from string, 
 		}
 
 		if fileInfo.IsDir() && !skipDir {
-			if err := Walk(ctx, driver, child, f); err != nil {
+			if err := WalkWithChildrenFilter(ctx, driver, child, filter, f); err != nil {
 				return err
 			}
 		}
@@ -52,8 +83,109 @@ func Walk(ctx context.Context, driver storageDriver.StorageDriver, from string, 
 	return nil
 }
 
+// Walk traverses a filesystem defined within driver, starting
+// from the given path, calling f on each file.
+func Walk(ctx context.Context, driver storageDriver.StorageDriver, from string, f WalkFn) error {
+	return WalkWithChildrenFilter(ctx, driver, from, walkChildrenNoFilter, f)
+}
+
+// WalkSortedChildren traverses a filesystem defined within driver, starting
+// from the given path, calling f on each file in lexicographical order.
+func WalkSortedChildren(ctx context.Context, driver storageDriver.StorageDriver, from string, f WalkFn) error {
+	return WalkWithChildrenFilter(ctx, driver, from, walkChildrenSortedFilter, f)
+}
+
 // pushError formats an error type given a path and an error
 // and pushes it to a slice of errors
 func pushError(errors []error, path string, err error) []error {
 	return append(errors, fmt.Errorf("%s: %s", path, err))
+}
+
+// makeBlobStoreWalkFunc returns a function for walking a blob store at
+// particular rootPath. The returned function calls a given ingest callback on
+// each digest found. The blob store is expected to have following layout:
+//
+//     if multilevel is true:
+//       <rootPath>/<alg>/<prefix>/<digest>
+//       <rootPath>/tarsum/<version>/<alg>/<prefix>/<digest>
+//     otherwise:
+//       <rootPath>/<alg>/<digest>
+//       <rootPath>/tarsum/<version>/<alg>/<digest>
+func makeBlobStoreWalkFunc(rootPath string, multilevel bool, ingest func(digest.Digest) error) (WalkFn, error) {
+	var (
+		// number of slashes in a path to a full digest directory under a rootPath
+		blobRefPathSepCount       int
+		blobTarsumRefPathSepCount int
+	)
+
+	if multilevel {
+		// <alg>/<prefix>/<digest>
+		blobRefPathSepCount = 2
+		// tarsum/<version>/<alg>/<prefix>/<digest>
+		blobTarsumRefPathSepCount = 4
+	} else {
+		// <alg>/<digest>
+		blobRefPathSepCount = 1
+		// tarsum/<version>/<alg>/<digest>
+		blobTarsumRefPathSepCount = 3
+	}
+
+	return func(fi storageDriver.FileInfo) error {
+		if !fi.IsDir() {
+			// ignore files
+			return nil
+		}
+
+		// trim <from>/ prefix
+		pth := strings.TrimPrefix(strings.TrimPrefix(fi.Path(), rootPath), "/")
+		sepCount := strings.Count(pth, "/")
+
+		if sepCount < blobRefPathSepCount {
+			// don't try to process short paths
+			return nil
+		}
+
+		alg := ""
+		tarsumParts := reTarsumPrefix.FindStringSubmatch(pth)
+		isTarsum := len(tarsumParts) > 0
+		if sepCount > blobTarsumRefPathSepCount || (!isTarsum && sepCount > blobRefPathSepCount) {
+			// too many path components
+			return ErrSkipDir
+		}
+
+		if len(tarsumParts) > 0 {
+			alg = "tarsum." + tarsumParts[1] + "+"
+			// trim "tarsum/<version>/" prefix from path
+			pth = strings.TrimPrefix(pth[len(tarsumParts[0]):], "/")
+		}
+
+		digestParts := reDigestPath.FindStringSubmatch(pth)
+		if len(digestParts) > 0 {
+			alg += digestParts[1]
+			dgstHex := digestParts[2]
+			dgst := digest.NewDigestFromHex(alg, dgstHex)
+			// append only valid digests
+			if err := dgst.Validate(); err == nil {
+				err := ingest(dgst)
+				if err != nil {
+					return ErrFinishedWalk
+				}
+			}
+			return ErrSkipDir
+		}
+
+		return nil
+	}, nil
+}
+
+// enumerateAllBlobs is a utility function that returns all the blob digests
+// found in given blob store. It should be used with care because of memory and
+// time complexity.
+func enumerateAllBlobs(be distribution.BlobEnumerator, ctx context.Context) ([]digest.Digest, error) {
+	res := []digest.Digest{}
+	err := be.Enumerate(ctx, func(dgst digest.Digest) error {
+		res = append(res, dgst)
+		return nil
+	})
+	return res, err
 }


### PR DESCRIPTION
Extended following interfaces for `Enumerate` method:

- `ManifestService`

Added new interface:

- `BlobEnumerator`

New registry option:

- `RemoveParentsOnDelete` causes parent directory of blob's data or link
  to be deleted together as well during `Delete`. This speeds up lookups
  and enumeration and retrieves back storage inodes.

New manifest service options:

- `EnumerateOrphanedManifestRevisions`
- `EnumerateAllManifestRevisions`

Partially resolves #462
It's a stripped down version of #1032.