### PR TITLE
Fixes so that nginx will start

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -65,6 +65,12 @@ mkdir -p data
 
 # This is the main nginx configuration you will use
 cat <<EOF > auth/nginx.conf
+events {
+    worker_connections  1024;
+}
+
+http {
+
 upstream docker-registry {
   server registry:5000;
 }
@@ -109,10 +115,11 @@ server {
     proxy_read_timeout                  900;
   }
 }
+}
 EOF
 
 # Now, create a password file for "testuser" and "testpassword"
-docker run --entrypoint htpasswd httpd:2.4 -bn testuser testpassword > auth/nginx.htpasswd
+docker run --rm --entrypoint htpasswd  registry:2 -bn testuser testpassword > auth/nginx.htpasswd
 
 # Copy over your certificate files
 cp domain.crt auth
@@ -128,14 +135,15 @@ nginx:
   links:
     - registry:registry
   volumes:
-    - `pwd`/auth/:/etc/nginx/conf.d
+    - ./auth:/etc/nginx/conf.d
+    - ./auth/nginx.conf:/etc/nginx/nginx.conf:ro
 
 registry:
   image: registry:2
   ports:
     - 127.0.0.1:5000:5000
   volumes:
-    - `pwd`/data:/var/lib/registry
+    - ./data:/var/lib/registry
 EOF
 ```
 
@@ -145,9 +153,9 @@ Now, start your stack:
 
     docker-compose up -d
 
-Login with a "push" authorized user (using `testuserpush` and `testpasswordpush`), then tag and push your first image:
+Login with a "push" authorized user (using `testuser` and `testpassword`), then tag and push your first image:
 
-    docker login myregistrydomain.com:5043
+    docker login -p=testuser -u=testpassword -e=root@example.ch myregistrydomain.com:5043
     docker tag ubuntu myregistrydomain.com:5043/test
     docker push myregistrydomain.com:5043/test
     docker pull myregistrydomain.com:5043/test

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -143,7 +143,7 @@ registry:
   ports:
     - 127.0.0.1:5000:5000
   volumes:
-    - ./data:/var/lib/registry
+    - `pwd`./data:/var/lib/registry
 EOF
 ```
 


### PR DESCRIPTION
Trying to get this example to work, so changes were needed to this doc:
 . some initial lines needed in the nginx config to allow it to start.
 . the composer config for nginx needed to mounts the nginx config explicitly. One cannot use "pwd" in the yaml either
 . one should use htpasswd from registry2 and opposed to the httpd image?
 . the example user on the htpasswd and login lines did not match up

However, login does not yet work on my test system. (SSL+cert is fine, have verified with curl -v). 
"unable to ping registry endpoint https://registry.myfqdn.net:5043/v0/
v2 ping attempt failed with error: Get https://registry.myfqdn.net:5043/v2/: Forbidden

Tried adding the "-B" option to htpasswd (for bcrypt), same login error.

(env: using latest registry2 + docker 1.8.2 on ubuntu 14.04)
Is this PR an appropriate way to document a working example?