### PR TITLE
remove scheme & host from uploadURL during layer upload.

### DIFF
--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -174,6 +174,12 @@ func (ub *URLBuilder) BuildBlobUploadChunkURL(name, uuid string, values ...url.V
 		return "", err
 	}
 
+	//when upload layer, distrubiton will return the response with upload URL in Location header,
+	//the upload URL should not contain the scheme and host.
+	//clear the scheme and host from the upload URL.
+	uploadURL.Scheme = ""
+	uploadURL.Host = ""
+
 	return appendValuesURL(uploadURL, values...).String(), nil
 }
 


### PR DESCRIPTION
Before update data of layer, distribution will return the uploadURL in Location to the client. And the uploadURL should not contain the scheme and host according to 'https://github.com/docker/distribution/blob/master/docs/spec/api.md'. 
The Location should be like 'Location: /v2/<name>/blobs/uploads/<uuid>'
But currently, the Location contains both the scheme and host, this is caused by the function 'func (r *Route) URL(pairs ...string)' of 'gorilla/mux' which append the scheme and host by default.

This change is to remove the scheme and host from uploadURL before it is set to Location header.
