### PR TITLE
Usability improvements for reference package

### DIFF
--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -253,7 +253,7 @@ func TestSplitHostname(t *testing.T) {
 			t.Fail()
 		}
 
-		named, err := ParseNamed(testcase.input)
+		named, err := WithName(testcase.input)
 		if err != nil {
 			failf("error parsing name: %s", err)
 		}
@@ -424,7 +424,7 @@ func TestWithTag(t *testing.T) {
 			t.Fail()
 		}
 
-		named, err := ParseNamed(testcase.name)
+		named, err := WithName(testcase.name)
 		if err != nil {
 			failf("error parsing name: %s", err)
 		}
@@ -466,7 +466,7 @@ func TestWithDigest(t *testing.T) {
 			t.Fail()
 		}
 
-		named, err := ParseNamed(testcase.name)
+		named, err := WithName(testcase.name)
 		if err != nil {
 			failf("error parsing name: %s", err)
 		}


### PR DESCRIPTION
Various improvements motivated by early real-world use in engine code
under development:

- Make `WithDigest` return `Canonical`, since the return value always
  has a name and a digest.

- Introduce a `NamedTagged` type, which can be used for strongly typing
  cases where something must have a name and a tag. It provides a
  more useful return type for `WithTag`, since its return value always has
  both a name and a tag.

- Rename `ParseNamed` to `WithName`, and create a
  `ParseNamed` that accepts tags and digests (returning a `Named` type).
  The new `ParseNamed` makes code using the reference package much less
  verbose, since typical use cases require a name, and this is an
  additional type assertion and error case after every `Parse` call.

Signed-off-by: Aaron Lehmann <aaron.lehmann@docker.com>