### PR TITLE
Correct unmarshal order for SignedManifest

### DIFF
--- a/manifest/schema1/manifest.go
+++ b/manifest/schema1/manifest.go
@@ -62,15 +62,20 @@ type SignedManifest struct {
 
 // UnmarshalJSON populates a new ImageManifest struct from JSON data.
 func (sm *SignedManifest) UnmarshalJSON(b []byte) error {
+	sm.Raw = make([]byte, len(b), len(b))
+	copy(sm.Raw, b)
+
+	p, err := sm.Payload()
+	if err != nil {
+		return err
+	}
+
 	var manifest Manifest
-	if err := json.Unmarshal(b, &manifest); err != nil {
+	if err := json.Unmarshal(p, &manifest); err != nil {
 		return err
 	}
 
 	sm.Manifest = manifest
-	sm.Raw = make([]byte, len(b), len(b))
-	copy(sm.Raw, b)
-
 	return nil
 }
 

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -163,7 +163,7 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 			for _, verificationError := range err {
 				switch verificationError := verificationError.(type) {
 				case distribution.ErrManifestBlobUnknown:
-					imh.Errors = append(imh.Errors, v2.ErrorCodeBlobUnknown.WithDetail(verificationError.Digest))
+					imh.Errors = append(imh.Errors, v2.ErrorCodeManifestBlobUnknown.WithDetail(verificationError.Digest))
 				case distribution.ErrManifestUnverified:
 					imh.Errors = append(imh.Errors, v2.ErrorCodeManifestUnverified)
 				default:


### PR DESCRIPTION
To ensure that we only unmarshal the verified payload into the contained
manifest, we first copy the entire incoming buffer into Raw and then unmarshal
only the Payload portion of the incoming bytes. If the contents is later
verified, the caller can then be sure that the contents of the Manifest fields
can be trusted.