### PR TITLE
use the scheme and host from x-forward-proto and x-forward-host if the…

### DIFF
--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -204,7 +204,9 @@ func (cr clonedRoute) URL(pairs ...string) (*url.URL, error) {
 		routeURL.Path = routeURL.Path[1:]
 	}
 
-	return cr.root.ResolveReference(routeURL), nil
+	url := cr.root.ResolveReference(routeURL)
+	url.Scheme = cr.root.Scheme
+	return url, nil
 }
 
 // appendValuesURL appends the parameters to the url.


### PR DESCRIPTION
…y exits and correct the scheme for Location header during image upload

Signed-off-by: yuzou <zouyu7@huawei.com>