### PR TITLE
Redundant digest verification in validateBlob when pushing a new layer

### DIFF
--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -175,7 +175,8 @@ func (repo *repository) Manifests(ctx context.Context, options ...distribution.M
 
 				// TODO(stevvooe): linkPath limits this blob store to only
 				// manifests. This instance cannot be used for blob checks.
-				linkPathFns: manifestLinkPathFns,
+				linkPathFns:            manifestLinkPathFns,
+				resumableDigestEnabled: repo.resumableDigestEnabled,
 			},
 		},
 		tagStore: &tagStore{
@@ -219,8 +220,9 @@ func (repo *repository) Blobs(ctx context.Context) distribution.BlobStore {
 
 		// TODO(stevvooe): linkPath limits this blob store to only layers.
 		// This instance cannot be used for manifest checks.
-		linkPathFns:   []linkPathFunc{blobLinkPath},
-		deleteEnabled: repo.registry.deleteEnabled,
+		linkPathFns:            []linkPathFunc{blobLinkPath},
+		deleteEnabled:          repo.registry.deleteEnabled,
+		resumableDigestEnabled: repo.resumableDigestEnabled,
 	}
 }
 


### PR DESCRIPTION
The resumableDigestEnabled of blobWriter is always set to false. That causes the following lines in "github.com/docker/distribution/registry/storage/blobwriter_resumable.go" always return errResumableDigestNotAvailable

```go
func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64) error {
	if !bw.resumableDigestEnabled {
		return errResumableDigestNotAvailable
	}
        ...
}
```

And then in 

```go
func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descriptor) (distribution.Descriptor, error) 
```

it will always set fullHash=true which it will download the uploaded file to get the digest again. The performance of pushing will be impacted a lot especially with the large file on the distributed object store.

I set the resumableDigestEnabled from the registry settings when creating "linkedBlobStore" to fix the issue

Signed-off-by: Li Yi <denverdino@gmail.com>
