### PR TITLE
Slightly better error package performance.

### DIFF
--- a/registry/client/blob_writer_test.go
+++ b/registry/client/blob_writer_test.go
@@ -94,7 +94,7 @@ func TestUploadReadFrom(t *testing.T) {
 								"detail": "more detail"
 							}
 						]
-					} `),
+					}`),
 			},
 		},
 		// Test 400 invalid json


### PR DESCRIPTION
By doing two things:

1. Stop generating structs that are immediately garbage collected.
2. Delay message formatting until it's actually used.

BEFORE:
```
$ go test -bench . github.com/docker/distribution/registry/api/errcode
PASS
BenchmarkErrorWithArgs-12	 1000000	      1447 ns/op
BenchmarkErrorSerial-12  	  500000	      3490 ns/op
ok  	github.com/docker/distribution/registry/api/errcode	3.281s
```
AFTER:
```
$ go test -bench . github.com/docker/distribution/registry/api/errcode
PASS
BenchmarkErrorWithArgs-12	10000000	       122 ns/op
BenchmarkErrorSerial-12  	 1000000	      1284 ns/op
ok  	github.com/docker/distribution/registry/api/errcode	2.637s
```
Signed-off-by: David Calavera <david.calavera@gmail.com>