### PR TITLE
Manifest interface refactor

### DIFF
--- a/manifests.go
+++ b/manifests.go
@@ -21,10 +21,6 @@ type Manifest interface {
 	// the mediatype. // TODO(richardscothern): make mediatype its
 	// own function?
 	Payload() (mediatype string, payload []byte, err error)
-
-	// Reference returns the tag for this manifest.  This is for convenience
-	// and is not necessarily part of the manifest schema
-	Tag() reference.Tagged
 }
 
 // ManifestBuilder creates a manifest allowing one to include dependencies.
@@ -47,8 +43,6 @@ type ManifestBuilder interface {
 	AddConstituent(dependency Descriptor) error
 }
 
-type OnManifestFunc func(Manifest)
-
 // ManifestService describes operations on image manifests.
 type ManifestService interface {
 	// Exists returns true if the manifest exists.
@@ -64,6 +58,9 @@ type ManifestService interface {
 	// a manifest that doesn't exist will return ErrManifestNotFound
 	Delete(ctx context.Context, dgst digest.Digest) error
 
-	// Foreach allows iterating through all Manifests in the service
-	Foreach(ctx context.Context, f OnManifestFunc) error
+	// Enumerate fills 'manifests' with the manifests in this service up
+	// to the size of 'manifests' and returns 'n' for the number of entries
+	// which were filled.  'last' contains an offset in the manifest set
+	// and can be used to resume iteration.
+	Enumerate(ctx context.Context, manifests []Manifest, last Manifest) (n int, err error)
 }

--- a/manifests.go
+++ b/manifests.go
@@ -1,0 +1,69 @@
+package distribution
+
+import (
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
+)
+
+// Manifest represents a registry object specifying a target and a set of constituents
+type Manifest interface {
+	// Target returns a descriptor for the configuration of this manifest.  This
+	// may return a nil descriptor if none exists for this manifest.
+	Target() Descriptor
+
+	// Constituents returns a list of objects which make up this manifest.
+	// The dependencies are strictly ordered from base to head. A constituent
+	// is anything which can be represented by a distribution.Descriptor
+	Constituents() []Descriptor
+
+	// Payload provides the serialized format of the manifest, in addition to
+	// the mediatype. // TODO(richardscothern): make mediatype its
+	// own function?
+	Payload() (mediatype string, payload []byte, err error)
+
+	// Reference returns the tag for this manifest.  This is for convenience
+	// and is not necessarily part of the manifest schema
+	Tag() reference.Tagged
+}
+
+// ManifestBuilder creates a manifest allowing one to include dependencies.
+// Instances can be obtained from a version-specific manifest package.  Manifest
+// specific data is passed into the function which creates the builder.
+type ManifestBuilder interface {
+	// Build creates the manifest from his builder.
+	Build() (Manifest, error)
+
+	// Constituents returns a list of objects which have been added to this
+	// builder. The dependencies are returned in the order they were added,
+	// which should be from base to head.
+	Constituents() []Descriptor
+
+	// AddConstituent includes the given object in the manifest after any
+	// existing dependencies. If the add fails, such as when adding an
+	// unsupported dependency, an error may be returned.  Constituent isn't
+	// a great name but correctly describes history/layer pairs (schema v1),
+	// Manifests (schema v2 manifest list) and layers (schema v2 image manifest)
+	AddConstituent(dependency Descriptor) error
+}
+
+type OnManifestFunc func(Manifest)
+
+// ManifestService describes operations on image manifests.
+type ManifestService interface {
+	// Exists returns true if the manifest exists.
+	Exists(ctx context.Context, dgst digest.Digest) (bool, error)
+
+	// Get retrieves the manifest specified by the given digest
+	Get(ctx context.Context, dgst digest.Digest) (Manifest, error)
+
+	// Put creates or updates the given manifest returning the manifest digest
+	Put(ctx context.Context, manifest Manifest) (digest.Digest, error)
+
+	// Delete removes the manifest specified by the given digest. Deleting
+	// a manifest that doesn't exist will return ErrManifestNotFound
+	Delete(ctx context.Context, dgst digest.Digest) error
+
+	// Foreach allows iterating through all Manifests in the service
+	Foreach(ctx context.Context, f OnManifestFunc) error
+}

--- a/manifests.go
+++ b/manifests.go
@@ -6,20 +6,20 @@ import (
 	"github.com/docker/distribution/reference"
 )
 
-// Manifest represents a registry object specifying a target and a set of constituents
+// Manifest represents a registry object specifying a set of
+// references and an optional target
 type Manifest interface {
 	// Target returns a descriptor for the configuration of this manifest.  This
-	// may return a nil descriptor if none exists for this manifest.
+	// may return a nil descriptor if a target is not applicable for the given manifest.
 	Target() Descriptor
 
-	// Constituents returns a list of objects which make up this manifest.
-	// The dependencies are strictly ordered from base to head. A constituent
+	// References returns a list of objects which make up this manifest.
+	// The references are strictly ordered from base to head. A reference
 	// is anything which can be represented by a distribution.Descriptor
-	Constituents() []Descriptor
+	References() []Descriptor
 
 	// Payload provides the serialized format of the manifest, in addition to
-	// the mediatype. // TODO(richardscothern): make mediatype its
-	// own function?
+	// the mediatype.
 	Payload() (mediatype string, payload []byte, err error)
 }
 
@@ -30,17 +30,15 @@ type ManifestBuilder interface {
 	// Build creates the manifest from his builder.
 	Build() (Manifest, error)
 
-	// Constituents returns a list of objects which have been added to this
+	// References returns a list of objects which have been added to this
 	// builder. The dependencies are returned in the order they were added,
 	// which should be from base to head.
-	Constituents() []Descriptor
+	References() []Descriptor
 
-	// AddConstituent includes the given object in the manifest after any
+	// AppendReference includes the given object in the manifest after any
 	// existing dependencies. If the add fails, such as when adding an
-	// unsupported dependency, an error may be returned.  Constituent isn't
-	// a great name but correctly describes history/layer pairs (schema v1),
-	// Manifests (schema v2 manifest list) and layers (schema v2 image manifest)
-	AddConstituent(dependency Descriptor) error
+	// unsupported dependency, an error may be returned.
+	AppendReference(dependency Descriptor) error
 }
 
 // ManifestService describes operations on image manifests.

--- a/registry.go
+++ b/registry.go
@@ -70,46 +70,6 @@ type Repository interface {
 // way instances are created to better reflect internal dependency
 // relationships.
 
-// ManifestService provides operations on image manifests.
-type ManifestService interface {
-	// Exists returns true if the manifest exists.
-	Exists(dgst digest.Digest) (bool, error)
-
-	// Get retrieves the identified by the digest, if it exists.
-	Get(dgst digest.Digest) (*schema1.SignedManifest, error)
-
-	// Delete removes the manifest, if it exists.
-	Delete(dgst digest.Digest) error
-
-	// Put creates or updates the manifest.
-	Put(manifest *schema1.SignedManifest) error
-
-	// TODO(stevvooe): The methods after this message should be moved to a
-	// discrete TagService, per active proposals.
-
-	// Tags lists the tags under the named repository.
-	Tags() ([]string, error)
-
-	// ExistsByTag returns true if the manifest exists.
-	ExistsByTag(tag string) (bool, error)
-
-	// GetByTag retrieves the named manifest, if it exists.
-	GetByTag(tag string, options ...ManifestServiceOption) (*schema1.SignedManifest, error)
-
-	// TODO(stevvooe): There are several changes that need to be done to this
-	// interface:
-	//
-	//	1. Allow explicit tagging with Tag(digest digest.Digest, tag string)
-	//	2. Support reading tags with a re-entrant reader to avoid large
-	//       allocations in the registry.
-	//	3. Long-term: Provide All() method that lets one scroll through all of
-	//       the manifest entries.
-	//	4. Long-term: break out concept of signing from manifests. This is
-	//       really a part of the distribution sprint.
-	//	5. Long-term: Manifest should be an interface. This code shouldn't
-	//       really be concerned with the storage format.
-}
-
 // SignatureService provides operations on signatures.
 type SignatureService interface {
 	// Get retrieves all of the signature blobs for the specified digest.

--- a/tags.go
+++ b/tags.go
@@ -5,8 +5,6 @@ import (
 	"github.com/docker/distribution/reference"
 )
 
-type OnTagFunc func(reference.Tagged)
-
 // TagService provides access to information about tagged objects.
 type TagService interface {
 	// Get retrieves the descriptor identified by the tag. Some
@@ -22,6 +20,9 @@ type TagService interface {
 	// Untag removes the given tag association
 	Untag(ctx context.Context, ref reference.Tagged) error
 
-	// Foreach allows iterating through all tags in the service
-	Foreach(ctx context.Context, f OnTagFunc) error
+	// Enumerate fills 'refs' with a lexigraphically sorted set of tags up to
+	// the size of 'refs' and returns 'n' for the number of entries which were
+	// filled.  'last' contains an offset in the tag set and can be used to resume
+	// iteration.
+	Enumerate(ctx context.Context, refs []reference.Tagged, last reference.Tagged) (n int, err error)
 }

--- a/tags.go
+++ b/tags.go
@@ -25,4 +25,7 @@ type TagService interface {
 	// filled.  'last' contains an offset in the tag set and can be used to resume
 	// iteration.
 	Enumerate(ctx context.Context, refs []reference.Tagged, last reference.Tagged) (n int, err error)
+
+	// Lookup returns the set of tags referencing the given digest
+	Lookup(ctx context.Context, digest digest.Descriptor) ([]reference.Tagged, error)
 }

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,27 @@
+package distribution
+
+import (
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/reference"
+)
+
+type OnTagFunc func(reference.Tagged)
+
+// TagService provides access to information about tagged objects.
+type TagService interface {
+	// Get retrieves the descriptor identified by the tag. Some
+	// implementations may differentiate between "trusted" tags and
+	// "untrusted" tags. If a tag is "untrusted", the mapping will be returned
+	// as an ErrTagUntrusted error, with the target descriptor.
+	Get(ctx context.Context, ref reference.Tagged) (Descriptor, error)
+
+	// Tag associates the tag with the provided descriptor, updating the
+	// current association, if needed.
+	Tag(ctx context.Context, ref reference.Tagged, desc Descriptor) error
+
+	// Untag removes the given tag association
+	Untag(ctx context.Context, ref reference.Tagged) error
+
+	// Foreach allows iterating through all tags in the service
+	Foreach(ctx context.Context, f OnTagFunc) error
+}


### PR DESCRIPTION
Carry @stevvooe's branch to refactor Manifest interfaces within the registry.

Add a generic Manifest interface to represent manifests in the registry.

Add a ManifestBuilder to construct Manifest objects.  Concrete manifest builders
will exist for each manifest type and implementations will contain manifest
specific data used to build a manifest.

Move tag functionality to a seperate TagService and update ManifestService
to use the new interfaces.

Signature functionality will be retained for backwards compatibility, but isn't
represented in this change.  All signature related code for Schema1 V2 manifest
will exists in a specific SignedManifestStore implementation (not shown).

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>