### PR TITLE
Docs: replace emoji with regular warning

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -148,7 +148,7 @@ Except for registries running on secure local networks, registries should always
 
 The simplest way to achieve access restriction is through basic authentication (this is very similar to other web servers' basic authentication mechanism).
 
-:warning: You **cannot** use authentication with an insecure registry. You have to [configure TLS first](#running-a-domain-registry) for this to work.
+> **Warning**: You **cannot** use authentication with an insecure registry. You have to [configure TLS first](#running-a-domain-registry) for this to work.
 
 First create a password file with one entry for the user "testuser", with password "testpassword":
 
@@ -213,7 +213,7 @@ registry:
     - /path/auth:/auth
 ```
 
-:warning: replace `/path` by whatever directory that holds your `certs` and `auth` folder from above.
+> **Warning**: replace `/path` by whatever directory that holds your `certs` and `auth` folder from above.
 
 You can then start your registry with a simple
 

--- a/docs/insecure.md
+++ b/docs/insecure.md
@@ -14,7 +14,7 @@ You have to understand the downsides in doing so, and the extra burden in config
 
 ## Deploying a plain HTTP registry
 
-> :warning: it's not possible to use an insecure registry with basic authentication
+> **Warning**: it's not possible to use an insecure registry with basic authentication
 
 This basically tells Docker to entirely disregard security for your registry.
 
@@ -32,7 +32,7 @@ This basically tells Docker to entirely disregard security for your registry.
   
 ## Using self-signed certificates
 
-> :warning: using this along with basic authentication requires to **also** trust the certificate into the OS cert store for some versions of docker (see below)
+> **Warning**: using this along with basic authentication requires to **also** trust the certificate into the OS cert store for some versions of docker (see below)
 
 Generate your own certificate:
 


### PR DESCRIPTION
The docs don't render emoji, so replaced the `:warning:` with a `**Warning**:` to keep the formatting consistent with `**Note**:` used in other parts of the docs.

Fixes https://github.com/docker/docker/issues/17281