### PR TITLE
Fix failing test case for URL escaping problem.

### DIFF
--- a/registry/api/v2/urls_test.go
+++ b/registry/api/v2/urls_test.go
@@ -238,7 +238,8 @@ func TestBuilderFromRequestWithPrefix(t *testing.T) {
 			base:    "https://subdomain.example.com/prefix/",
 			configHost: url.URL{
 				Scheme: "https",
-				Host:   "subdomain.example.com/prefix",
+				Host:   "subdomain.example.com",
+				Path:   "/prefix/",
 			},
 		},
 	}


### PR DESCRIPTION
When building a URL don't include path components in the host parameter.

Closes #1124

Signed-off-by: Rusty Conover <rusty@luckydinosaur.com>