### PR TITLE
Remove unused blobstore code

### DIFF
--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -127,16 +127,6 @@ func (bs *blobStore) readlink(ctx context.Context, path string) (digest.Digest, 
 	return linked, nil
 }
 
-// resolve reads the digest link at path and returns the blob store path.
-func (bs *blobStore) resolve(ctx context.Context, path string) (string, error) {
-	dgst, err := bs.readlink(ctx, path)
-	if err != nil {
-		return "", err
-	}
-
-	return bs.path(dgst)
-}
-
 type blobStatter struct {
 	driver driver.StorageDriver
 }


### PR DESCRIPTION
Function `blobStore:resolve` seems not to be used anymore.

It uses function `linkedBlobStatter:resolveWithLinkFunc` now.

So, I think the unused function code may be removed.

Thanks.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>