### PR TITLE
fix docker registry tag to generate password file well.

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -153,7 +153,7 @@ The simplest way to achieve access restriction is through basic authentication (
 First create a password file with one entry for the user "testuser", with password "testpassword":
 
     mkdir auth
-    docker run --entrypoint htpasswd registry:2 -Bbn testuser testpassword > auth/htpasswd
+    docker run --entrypoint htpasswd registry:2.1 -Bbn testuser testpassword > auth/htpasswd
 
 Make sure you stopped your registry from the previous step, then start it again:
 


### PR DESCRIPTION
Generating BCrypt hash password file with htpasswd fails when I doing like followings as guide.

```
$ docker run --entrypoint htpasswd registry:2 -Bbn testuser testpassword > auth/htpasswd
exec: "htpasswd": executable file not found in $PATH
Error response from daemon: Cannot start container 98ae3908b66bbcec417180e9d2b972ae578ef26ca79e56b9539936a3845ead61: [8] System error: exec: "htpasswd": executable file not found in $PATH
```

I don't know what is changed exactly on tag 2 of docker registry image, but it works well with tag 2.1.

Signed-off-by: Sungho Moon sungho.moon@navercorp.com