### PR TITLE
Improve consistence to delete manifest

### DIFF
--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -70,7 +70,28 @@ func (ms *manifestStore) Put(manifest *schema1.SignedManifest) error {
 // Delete removes the revision of the specified manfiest.
 func (ms *manifestStore) Delete(dgst digest.Digest) error {
 	context.GetLogger(ms.ctx).Debug("(*manifestStore).Delete")
-	return ms.revisionStore.delete(ms.ctx, dgst)
+
+	if !ms.revisionStore.blobStore.deleteEnabled {
+		return distribution.ErrUnsupported
+	}
+
+	// Ensure the blob is available for deletion
+	_, err := ms.revisionStore.blobStore.blobAccessController.Stat(ms.ctx, dgst)
+	if err != nil {
+		return err
+	}
+
+	m, err := ms.revisionStore.get(ms.ctx, dgst)
+	if err != nil {
+		return err
+	}
+
+	err = ms.revisionStore.delete(ms.ctx, dgst)
+	if err != nil {
+		return err
+	}
+
+	return ms.tagStore.delete(m.Tag)
 }
 
 func (ms *manifestStore) Tags() ([]string, error) {


### PR DESCRIPTION
Currently, deleting manifest uses `manifestStore.Delete` function.
However, it only delete revision link, and its tag blob link files still exist.
It leads problem that user can still view the deleted tag in tags list.
I think tag blob links should be deleted consistently. We can add `tagStore.delete` to `manifestStore.Delete` to do it.
This PR is only for resolving a consistence, and there are still improvement need to do for soft deleting.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>