### PR TITLE
Use correct regexp in reference.WithTag

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -213,7 +213,7 @@ func WithName(name string) (Named, error) {
 // WithTag combines the name from "name" and the tag from "tag" to form a
 // reference incorporating both the name and the tag.
 func WithTag(name Named, tag string) (NamedTagged, error) {
-	if !anchoredNameRegexp.MatchString(tag) {
+	if !anchoredTagRegexp.MatchString(tag) {
 		return nil, ErrTagInvalidFormat
 	}
 	return taggedReference{

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -417,6 +417,11 @@ func TestWithTag(t *testing.T) {
 			tag:      "tag4",
 			combined: "test.com:8000/foo:tag4",
 		},
+		{
+			name:     "test.com:8000/foo",
+			tag:      "TAG5",
+			combined: "test.com:8000/foo:TAG5",
+		},
 	}
 	for _, testcase := range testcases {
 		failf := func(format string, v ...interface{}) {


### PR DESCRIPTION
This was using a different regexp from the intended one. This meant that
tags with uppercase characters were not accepted.