### PR TITLE
Ensure read after write for segments

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -86,7 +86,7 @@
 		},
 		{
 			"ImportPath": "github.com/ncw/swift",
-			"Rev": "ca8cbbde50d4e12dd8ad70b1bd66589ae98efc5c"
+			"Rev": "c54732e87b0b283d1baf0a18db689d0aea460ba3"
 		},
 		{
 			"ImportPath": "github.com/noahdesu/go-ceph/rados",

--- a/Godeps/_workspace/src/github.com/ncw/swift/README.md
+++ b/Godeps/_workspace/src/github.com/ncw/swift/README.md
@@ -132,3 +132,5 @@ Contributors
 - Dai HaoJun <haojun.dai@hp.com>
 - Hua Wang <wanghua.humble@gmail.com>
 - Fabian Ruff <fabian@progra.de>
+- Arturo Reuschenbach Puncernau <reuschenbach@gmail.com>
+- Petr Kotek <petr.kotek@bigcommerce.com>

--- a/Godeps/_workspace/src/github.com/ncw/swift/auth.go
+++ b/Godeps/_workspace/src/github.com/ncw/swift/auth.go
@@ -156,6 +156,7 @@ func (auth *v2Auth) Request(c *Connection) (*http.Request, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
 	return req, nil
 }
 

--- a/Godeps/_workspace/src/github.com/ncw/swift/auth_v3.go
+++ b/Godeps/_workspace/src/github.com/ncw/swift/auth_v3.go
@@ -177,6 +177,7 @@ func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
 	return req, nil
 }
 

--- a/Godeps/_workspace/src/github.com/ncw/swift/swifttest/server.go
+++ b/Godeps/_workspace/src/github.com/ncw/swift/swifttest/server.go
@@ -443,7 +443,7 @@ func (objr objectResource) get(a *action) interface{} {
 			if obj, ok := item.(*object); ok {
 				length := len(obj.data)
 				size += length
-				sum.Write([]byte(components[0] + "/" + obj.name + "\n"))
+				sum.Write([]byte(hex.EncodeToString(obj.checksum)))
 				if start >= cursor+length {
 					continue
 				}
@@ -668,24 +668,42 @@ func (s *SwiftServer) serveHTTP(w http.ResponseWriter, req *http.Request) {
 		panic(notAuthorized())
 	}
 
+	if req.URL.String() == "/info" {
+		jsonMarshal(w, &swift.SwiftInfo{
+			"swift": map[string]interface{}{
+				"version": "1.2",
+			},
+			"tempurl": map[string]interface{}{
+				"methods": []string{"GET", "HEAD", "PUT"},
+			},
+		})
+		return
+	}
+
 	r = s.resourceForURL(req.URL)
 
 	key := req.Header.Get("x-auth-token")
-	if key == "" {
-		secretKey := ""
-		signature := req.URL.Query().Get("temp_url_sig")
-		expires := req.URL.Query().Get("temp_url_expires")
+	signature := req.URL.Query().Get("temp_url_sig")
+	expires := req.URL.Query().Get("temp_url_expires")
+	if key == "" && signature != "" && expires != "" {
 		accountName, _, _, _ := s.parseURL(req.URL)
+		secretKey := ""
 		if account, ok := s.Accounts[accountName]; ok {
 			secretKey = account.meta.Get("X-Account-Meta-Temp-Url-Key")
 		}
 
-		mac := hmac.New(sha1.New, []byte(secretKey))
-		body := fmt.Sprintf("%s\n%s\n%s", req.Method, expires, req.URL.Path)
-		mac.Write([]byte(body))
-		expectedSignature := hex.EncodeToString(mac.Sum(nil))
+		get_hmac := func(method string) string {
+			mac := hmac.New(sha1.New, []byte(secretKey))
+			body := fmt.Sprintf("%s\n%s\n%s", method, expires, req.URL.Path)
+			mac.Write([]byte(body))
+			return hex.EncodeToString(mac.Sum(nil))
+		}
 
-		if signature != expectedSignature {
+		if req.Method == "HEAD" {
+			if signature != get_hmac("GET") && signature != get_hmac("POST") && signature != get_hmac("PUT") {
+				panic(notAuthorized())
+			}
+		} else if signature != get_hmac(req.Method) {
 			panic(notAuthorized())
 		}
 	} else {

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -20,6 +20,7 @@ package swift
 
 import (
 	"bytes"
+	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/tls"
@@ -51,6 +52,12 @@ const defaultChunkSize = 20 * 1024 * 1024
 
 // minChunkSize defines the minimum size of a segment
 const minChunkSize = 1 << 20
+
+// readAfterWriteTimeout defines the time we wait before an object appears after having been uploaded
+var readAfterWriteTimeout = 15 * time.Second
+
+// readAfterWriteWait defines the time to sleep between two retries
+var readAfterWriteWait = 200 * time.Millisecond
 
 // Parameters A struct that encapsulates all of the driver parameters after all values have been set
 type Parameters struct {
@@ -252,6 +259,7 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	partNumber := 1
 	chunkSize := int64(d.ChunkSize)
 	zeroBuf := make([]byte, d.ChunkSize)
+	hash := md5.New()
 
 	getSegment := func() string {
 		return fmt.Sprintf("%s/%016d", segmentPath, partNumber)
@@ -292,18 +300,13 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 		return 0, err
 	}
 
-	if createManifest {
-		if err := d.createManifest(path, d.Container+"/"+segmentPath); err != nil {
-			return 0, err
-		}
-	}
-
 	// First, we skip the existing segments that are not modified by this call
 	for i := range segments {
 		if offset < cursor+segments[i].Bytes {
 			break
 		}
 		cursor += segments[i].Bytes
+		hash.Write([]byte(segments[i].Hash))
 		partNumber++
 	}
 
@@ -312,7 +315,7 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	if offset >= currentLength {
 		for offset-currentLength >= chunkSize {
 			// Insert a block a zero
-			_, err := d.Conn.ObjectPut(d.Container, getSegment(), bytes.NewReader(zeroBuf), false, "", d.getContentType(), nil)
+			headers, err := d.Conn.ObjectPut(d.Container, getSegment(), bytes.NewReader(zeroBuf), false, "", d.getContentType(), nil)
 			if err != nil {
 				if err == swift.ObjectNotFound {
 					return 0, storagedriver.PathNotFoundError{Path: getSegment()}
@@ -321,6 +324,7 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 			}
 			currentLength += chunkSize
 			partNumber++
+			hash.Write([]byte(headers["Etag"]))
 		}
 
 		cursor = currentLength
@@ -355,13 +359,23 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 			return false, bytesRead, err
 		}
 
-		n, err := io.Copy(currentSegment, multi)
+		segmentHash := md5.New()
+		writer := io.MultiWriter(currentSegment, segmentHash)
+
+		n, err := io.Copy(writer, multi)
 		if err != nil {
 			return false, bytesRead, err
 		}
 
 		if n > 0 {
-			defer currentSegment.Close()
+			defer func() {
+				closeError := currentSegment.Close()
+				if err != nil {
+					err = closeError
+				}
+				hexHash := hex.EncodeToString(segmentHash.Sum(nil))
+				hash.Write([]byte(hexHash))
+			}()
 			bytesRead += n - max(0, offset-cursor)
 		}
 
@@ -379,7 +393,7 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 					return false, bytesRead, err
 				}
 
-				_, copyErr := io.Copy(currentSegment, file)
+				_, copyErr := io.Copy(writer, file)
 
 				if err := file.Close(); err != nil {
 					if err == swift.ObjectNotFound {
@@ -414,7 +428,35 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 		}
 	}
 
-	return bytesRead, nil
+	for ; partNumber < len(segments); partNumber++ {
+		hash.Write([]byte(segments[partNumber].Hash))
+	}
+
+	if createManifest {
+		if err := d.createManifest(path, d.Container+"/"+segmentPath); err != nil {
+			return 0, err
+		}
+	}
+
+	expectedHash := hex.EncodeToString(hash.Sum(nil))
+	waitingTime := readAfterWriteWait
+	endTime := time.Now().Add(readAfterWriteTimeout)
+	for {
+		var infos swift.Object
+		if infos, _, err = d.Conn.Object(d.Container, d.swiftPath(path)); err == nil {
+			if strings.Trim(infos.Hash, "\"") == expectedHash {
+				return bytesRead, nil
+			}
+			err = fmt.Errorf("Timeout expired while waiting for segments of %s to show up", path)
+		}
+		if time.Now().Add(waitingTime).After(endTime) {
+			break
+		}
+		time.Sleep(waitingTime)
+		waitingTime *= 2
+	}
+
+	return bytesRead, err
 }
 
 // Stat retrieves the FileInfo for the given path, including the current size


### PR DESCRIPTION
When a manifest has been uploaded, some segments of this manifest may not appear in the object listing yet. The manifest would then report a wrong size. To avoid this, we check that a segment appears after it has been created.

Signed-off-by: Sylvain Baubeau <sbaubeau@redhat.com>

