### PR TITLE
Consider HTTP host configuration when creating notifications

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -377,14 +377,20 @@ func (app *App) configureEvents(configuration *configuration.Configuration) {
 	app.events.sink = notifications.NewBroadcaster(sinks...)
 
 	// Populate registry event source
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = configuration.HTTP.Addr
+	var hostname string
+	if configuration.HTTP.Host != "" {
+		hostname = configuration.HTTP.Host
 	} else {
-		// try to pick the port off the config
-		_, port, err := net.SplitHostPort(configuration.HTTP.Addr)
-		if err == nil {
-			hostname = net.JoinHostPort(hostname, port)
+		var err error
+		hostname, err = os.Hostname()
+		if err != nil {
+			hostname = configuration.HTTP.Addr
+		} else {
+			// try to pick the port off the config
+			_, port, err := net.SplitHostPort(configuration.HTTP.Addr)
+			if err == nil {
+				hostname = net.JoinHostPort(hostname, port)
+			}
 		}
 	}
 


### PR DESCRIPTION
Use the HTTP host value specified by the user when building notification events. This value has now a higher priority when building the "source" part of the event notifications.

This is required when running the registry behind a web server like Apache. Without this code all the notifications would have the source set to "registry.example.com:5000" or "127.0.0.1:5000" instead of the FQDN exposed by Apache (i.e. "registry.example.com"). We found that issue when working on a special deployment scenario of Portus (see [here](https://github.com/SUSE/Portus/wiki/Portus-and-Docker-registry-on-the-same-FQDN-using-sub-URI) for more details).

I would like to hear your opinion about this PR. If you like the change I can look into extending the test suite.