### PR TITLE
credentials info in proxy shouldn't limited to hub

### DIFF
--- a/registry/proxy/proxyauth.go
+++ b/registry/proxy/proxyauth.go
@@ -19,7 +19,7 @@ type credentials struct {
 }
 
 func (c credentials) Basic(u *url.URL) (string, string) {
-	up := c.creds[u.String()]
+	up := c.creds[tokenURL]
 
 	return up.username, up.password
 }


### PR DESCRIPTION
Currently only when registry is configured as a pull through cache to docker hub registry, password and username will be send in http authorization header

Instead the credentials should apply to any registry whether it's docker hub registry or another private registry.