### PR TITLE
Fixed some spelling and removed an unused function 

### DIFF
--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -220,15 +220,3 @@ func appendValuesURL(u *url.URL, values ...url.Values) *url.URL {
 	u.RawQuery = merged.Encode()
 	return u
 }
-
-// appendValues appends the parameters to the url. Panics if the string is not
-// a url.
-func appendValues(u string, values ...url.Values) string {
-	up, err := url.Parse(u)
-
-	if err != nil {
-		panic(err) // should never happen
-	}
-
-	return appendValuesURL(up, values...).String()
-}

--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -220,3 +220,15 @@ func appendValuesURL(u *url.URL, values ...url.Values) *url.URL {
 	u.RawQuery = merged.Encode()
 	return u
 }
+
+// appendValues appends the parameters to the url. Panics if the string is not
+// a url.
+func appendValues(u string, values ...url.Values) string {
+	up, err := url.Parse(u)
+
+	if err != nil {
+		panic(err) // should never happen
+	}
+
+	return appendValuesURL(up, values...).String()
+}

--- a/registry/auth/auth.go
+++ b/registry/auth/auth.go
@@ -40,7 +40,7 @@ import (
 )
 
 // UserInfo carries information about
-// an autenticated/authorized client.
+// an authenticated/authorized client.
 type UserInfo struct {
 	Name string
 }
@@ -112,7 +112,7 @@ func (uic userInfoContext) Value(key interface{}) interface{} {
 }
 
 // InitFunc is the type of an AccessController factory function and is used
-// to register the constructor for different AccesController backends.
+// to register the constructor for different AccessController backends.
 type InitFunc func(options map[string]interface{}) (AccessController, error)
 
 var accessControllers map[string]InitFunc

--- a/registry/auth/htpasswd/htpasswd.go
+++ b/registry/auth/htpasswd/htpasswd.go
@@ -36,8 +36,8 @@ func (htpasswd *htpasswd) authenticateUser(username string, password string) err
 		return ErrAuthenticationFailure
 	}
 
-	err := bcrypt.CompareHashAndPassword([]byte(credentials), []byte(password))
-	if err != nil {
+
+	if err := bcrypt.CompareHashAndPassword([]byte(credentials), []byte(password)); err != nil {
 		return ErrAuthenticationFailure
 	}
 

--- a/registry/auth/htpasswd/htpasswd.go
+++ b/registry/auth/htpasswd/htpasswd.go
@@ -35,9 +35,8 @@ func (htpasswd *htpasswd) authenticateUser(username string, password string) err
 
 		return ErrAuthenticationFailure
 	}
-
-
-	if err := bcrypt.CompareHashAndPassword([]byte(credentials), []byte(password)); err != nil {
+	err := bcrypt.CompareHashAndPassword([]byte(credentials), []byte(password))
+	if err != nil {
 		return ErrAuthenticationFailure
 	}
 

--- a/registry/auth/htpasswd/htpasswd.go
+++ b/registry/auth/htpasswd/htpasswd.go
@@ -35,8 +35,8 @@ func (htpasswd *htpasswd) authenticateUser(username string, password string) err
 
 		return ErrAuthenticationFailure
 	}
-	err := bcrypt.CompareHashAndPassword([]byte(credentials), []byte(password))
-	if err != nil {
+
+	if err := bcrypt.CompareHashAndPassword([]byte(credentials), []byte(password)); err != nil {
 		return ErrAuthenticationFailure
 	}
 

--- a/registry/auth/token/accesscontroller.go
+++ b/registry/auth/token/accesscontroller.go
@@ -127,7 +127,7 @@ type accessController struct {
 }
 
 // tokenAccessOptions is a convenience type for handling
-// options to the contstructor of an accessController.
+// options to the constructor of an accessController.
 type tokenAccessOptions struct {
 	realm          string
 	issuer         string

--- a/registry/client/auth/authchallenge.go
+++ b/registry/client/auth/authchallenge.go
@@ -29,7 +29,7 @@ type ChallengeManager interface {
 
 	// AddResponse adds the response to the challenge
 	// manager. The challenges will be parsed out of
-	// the WWW-Authenicate headers and added to the
+	// the WWW-Authenticate headers and added to the
 	// URL which was produced the response. If the
 	// response was authorized, any challenges for the
 	// endpoint will be cleared.

--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -16,9 +16,9 @@ import (
 )
 
 // AuthenticationHandler is an interface for authorizing a request from
-// params from a "WWW-Authenicate" header for a single scheme.
+// params from a "WWW-Authenticate" header for a single scheme.
 type AuthenticationHandler interface {
-	// Scheme returns the scheme as expected from the "WWW-Authenicate" header.
+	// Scheme returns the scheme as expected from the "WWW-Authenticate" header.
 	Scheme() string
 
 	// AuthorizeRequest adds the authorization header to a request (if needed)
@@ -128,7 +128,7 @@ type realClock struct{}
 // Now implements clock
 func (realClock) Now() time.Time { return time.Now() }
 
-// NewTokenHandler creates a new AuthenicationHandler which supports
+// NewTokenHandler creates a new AuthenticationHandler which supports
 // fetching tokens from a remote token server.
 func NewTokenHandler(transport http.RoundTripper, creds CredentialStore, scope string, actions ...string) AuthenticationHandler {
 	return newTokenHandler(transport, creds, realClock{}, scope, actions...)
@@ -279,7 +279,7 @@ type basicHandler struct {
 	creds CredentialStore
 }
 
-// NewBasicHandler creaters a new authentiation handler which adds
+// NewBasicHandler creates a new authentication handler which adds
 // basic authentication credentials to a request.
 func NewBasicHandler(creds CredentialStore) AuthenticationHandler {
 	return &basicHandler{

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -52,7 +52,7 @@ type registry struct {
 	context context.Context
 }
 
-// Repositories returns a lexigraphically sorted catalog given a base URL.  The 'entries' slice will be filled up to the size
+// Repositories returns a lexicographically sorted catalog given a base URL.  The 'entries' slice will be filled up to the size
 // of the slice, starting at the value provided in 'last'.  The number of entries will be returned along with io.EOF if there
 // are no more entries
 func (r *registry) Repositories(ctx context.Context, entries []string, last string) (int, error) {

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -867,7 +867,7 @@ func applyStorageMiddleware(driver storagedriver.StorageDriver, middlewares []co
 
 // uploadPurgeDefaultConfig provides a default configuration for upload
 // purging to be used in the absence of configuration in the
-// confifuration file
+// configuration file
 func uploadPurgeDefaultConfig() map[interface{}]interface{} {
 	config := map[interface{}]interface{}{}
 	config["enabled"] = true

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -48,7 +48,7 @@ const (
 // The storage backend layout is broken up into a content-addressable blob
 // store and repositories. The content-addressable blob store holds most data
 // throughout the backend, keyed by algorithm and digests of the underlying
-// content. Access to the blob store is controled through links from the
+// content. Access to the blob store is controlled through links from the
 // repository to blobstore.
 //
 // A repository is made up of layers, manifests and tags. The layers component
@@ -301,7 +301,7 @@ type manifestRevisionLinkPathSpec struct {
 
 func (manifestRevisionLinkPathSpec) pathSpec() {}
 
-// manifestSignaturesPathSpec decribes the path components for the directory
+// manifestSignaturesPathSpec describes the path components for the directory
 // containing all the signatures for the target blob. Entries are named with
 // the underlying key id.
 type manifestSignaturesPathSpec struct {
@@ -311,7 +311,7 @@ type manifestSignaturesPathSpec struct {
 
 func (manifestSignaturesPathSpec) pathSpec() {}
 
-// manifestSignatureLinkPathSpec decribes the path components used to look up
+// manifestSignatureLinkPathSpec describes the path components used to look up
 // a signature file by the hash of its blob.
 type manifestSignatureLinkPathSpec struct {
 	name      string


### PR DESCRIPTION
that could be problematic. `url.Parse` fails with a single `%` character and would panic unnecessarily
 
Signed-off-by: Levi Gross <levi@levigross.com>