### PR TITLE
registry/storage: close filereader after allocation

### DIFF
--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -227,6 +227,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 			if err != nil {
 				return distribution.Descriptor{}, err
 			}
+			defer fr.Close()
 
 			tr := io.TeeReader(fr, digester.Hash())
 

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -91,6 +91,7 @@ func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64) error {
 		if err != nil {
 			return err
 		}
+		defer fr.Close()
 
 		if _, err = fr.Seek(int64(h.Len()), os.SEEK_SET); err != nil {
 			return fmt.Errorf("unable to seek to layer reader offset %d: %s", h.Len(), err)


### PR DESCRIPTION
Possibly addresses #1116.

Signed-off-by: Stephen J Day <stephen.day@docker.com>