### PR TITLE
Add github IDs to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,8 +1,8 @@
 Solomon Hykes <solomon@docker.com> (@shykes)
 Olivier Gambier <olivier@docker.com> (@dmp42)
 Stephen Day <stephen.day@docker.com> (@stevvooe)
-Derek McGowan <derek@mcgstyle.net>
-Richard Scothern <richard.scothern@gmail.com>
-Aaron Lehmann <aaron.lehmann@docker.com>
+Derek McGowan <derek@mcgstyle.net> (@dmcgowan)
+Richard Scothern <richard.scothern@gmail.com> (@richardscothern)
+Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 
 


### PR DESCRIPTION
Signed-off-by: Richard Scothern <richard.scothern@gmail.com>