### PR TITLE
Manifest Verification

### DIFF
--- a/manifest/schema1/manifest_test.go
+++ b/manifest/schema1/manifest_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 type testEnv struct {
-	name, tag string
-	manifest  *Manifest
-	signed    *SignedManifest
-	pk        libtrust.PrivateKey
+	name, tag     string
+	invalidSigned *SignedManifest
+	signed        *SignedManifest
+	pk            libtrust.PrivateKey
 }
 
 func TestManifestMarshaling(t *testing.T) {
@@ -42,6 +42,7 @@ func TestManifestUnmarshaling(t *testing.T) {
 	if !reflect.DeepEqual(&signed, env.signed) {
 		t.Fatalf("manifests are different after unmarshaling: %v != %v", signed, env.signed)
 	}
+
 }
 
 func TestManifestVerification(t *testing.T) {
@@ -69,6 +70,12 @@ func TestManifestVerification(t *testing.T) {
 	if !found {
 		t.Fatalf("expected public key, %v, not found in verified keys: %v", publicKey, publicKeys)
 	}
+
+	// Check that an invalid manifest fails verification
+	_, err = Verify(env.invalidSigned)
+	if err != nil {
+		t.Fatalf("Invalid manifest should not pass Verify()")
+	}
 }
 
 func genEnv(t *testing.T) *testEnv {
@@ -79,7 +86,7 @@ func genEnv(t *testing.T) *testEnv {
 
 	name, tag := "foo/bar", "test"
 
-	m := Manifest{
+	invalid := Manifest{
 		Versioned: SchemaVersion,
 		Name:      name,
 		Tag:       tag,
@@ -93,16 +100,37 @@ func genEnv(t *testing.T) *testEnv {
 		},
 	}
 
-	sm, err := Sign(&m, pk)
+	valid := Manifest{
+		Versioned: SchemaVersion,
+		Name:      name,
+		Tag:       tag,
+		FSLayers: []FSLayer{
+			{
+				BlobSum: "asdf",
+			},
+		},
+		History: []History{
+			{
+				V1Compatibility: "",
+			},
+		},
+	}
+
+	sm, err := Sign(&valid, pk)
+	if err != nil {
+		t.Fatalf("error signing manifest: %v", err)
+	}
+
+	invalidSigned, err := Sign(&invalid, pk)
 	if err != nil {
 		t.Fatalf("error signing manifest: %v", err)
 	}
 
 	return &testEnv{
-		name:     name,
-		tag:      tag,
-		manifest: &m,
-		signed:   sm,
-		pk:       pk,
+		name:          name,
+		tag:           tag,
+		invalidSigned: invalidSigned,
+		signed:        sm,
+		pk:            pk,
 	}
 }

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -131,6 +131,9 @@ func checkExerciseRepository(t *testing.T, repository distribution.Repository) {
 		m.FSLayers = append(m.FSLayers, schema1.FSLayer{
 			BlobSum: dgst,
 		})
+		m.History = append(m.History, schema1.History{
+			V1Compatibility: "",
+		})
 
 		// Then fetch the blobs
 		if rc, err := blobs.Open(ctx, dgst); err != nil {

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -110,6 +110,11 @@ func (ms *manifestStore) verifyManifest(ctx context.Context, mnfst *schema1.Sign
 		errs = append(errs, fmt.Errorf("repository name does not match manifest name"))
 	}
 
+	if len(mnfst.History) != len(mnfst.FSLayers) {
+		errs = append(errs, fmt.Errorf("mismatched history and fslayer cardinality %d != %d",
+			len(mnfst.History), len(mnfst.FSLayers)))
+	}
+
 	if _, err := schema1.Verify(mnfst); err != nil {
 		switch err {
 		case libtrust.ErrMissingSignatureKey, libtrust.ErrInvalidJSONContent, libtrust.ErrMissingSignatureKey:

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -98,6 +98,10 @@ func TestManifestStorage(t *testing.T) {
 		m.FSLayers = append(m.FSLayers, schema1.FSLayer{
 			BlobSum: dgst,
 		})
+		m.History = append(m.History, schema1.History{
+			V1Compatibility: "",
+		})
+
 	}
 
 	pk, err := libtrust.GenerateECP256PrivateKey()


### PR DESCRIPTION
Before materializing a schema1 manifest from JSON, ensure that contains equal
length History and FSLayer arrays.

This is required to prevent malformed manifests being put to the registry and
failing external verification checks.

Closes #1153 

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>