### PR TITLE
unused routes variable

### DIFF
--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -14,15 +14,6 @@ const (
 	RouteNameCatalog         = "catalog"
 )
 
-var allEndpoints = []string{
-	RouteNameManifest,
-	RouteNameCatalog,
-	RouteNameTags,
-	RouteNameBlob,
-	RouteNameBlobUpload,
-	RouteNameBlobUploadChunk,
-}
-
 // Router builds a gorilla router with named routes for the various API
 // methods. This can be used directly by both server implementations and
 // clients.


### PR DESCRIPTION
This PR removes unused routes variable of `allEndpoints`.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>