### PR TITLE
De-obfuscate error message

### DIFF
--- a/registry/auth/htpasswd/access.go
+++ b/registry/auth/htpasswd/access.go
@@ -94,7 +94,7 @@ func (ch challenge) SetHeaders(w http.ResponseWriter) {
 }
 
 func (ch challenge) Error() string {
-	return fmt.Sprintf("basic authentication challenge: %#v", ch)
+	return fmt.Sprintf("basic authentication challenge for realm %q: %s", ch.realm, ch.err)
 }
 
 func init() {


### PR DESCRIPTION
Previously, this error message would stringify as a pointer address,
which isn't particularly helpful.

This change breaks out the elements of the challenge object such that
the error is appropriately represented.

Signed-off-by: Ted Reed <ted.reed@gmail.com>