### PR TITLE
Fix empty delete requests with Swift fs driver

### DIFF
--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -587,7 +587,7 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 		return err
 	}
 
-	if d.BulkDeleteSupport {
+	if len(objects) > 0 && d.BulkDeleteSupport {
 		filenames := make([]string, len(objects))
 		for i, obj := range objects {
 			filenames[i] = obj.Name


### PR DESCRIPTION
The Delete method lists objects under the given path and tries to delete
all of them with a bulk delete request. If the path has no objects
underneath it, the body of this request will be empty, which causes
HTTP-level issues. Specifically, Go's HTTP client senses the empty
request buffer and doesn't include a Content-Length, which causes the
Swift server to fail the request.

This commit fixes the problem by avoiding sending empty bulk delete
requests. This is the correct thing to do anyway, since there's no
reason to request deletion of zero objects.