### PR TITLE
Handle deletion of nested objects properly

### DIFF
--- a/registry/storage/driver/swift/swift_test.go
+++ b/registry/storage/driver/swift/swift_test.go
@@ -134,7 +134,6 @@ func TestEmptyRootList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating content: %v", err)
 	}
-	defer rootedDriver.Delete(ctx, filename)
 
 	keys, err := emptyRootDriver.List(ctx, "/")
 	for _, path := range keys {
@@ -148,5 +147,25 @@ func TestEmptyRootList(t *testing.T) {
 		if !storagedriver.PathRegexp.MatchString(path) {
 			t.Fatalf("unexpected string in path: %q != %q", path, storagedriver.PathRegexp)
 		}
+	}
+
+	// Create an object with a path nested under the existing object
+	err = rootedDriver.PutContent(ctx, filename+"/file1", contents)
+	if err != nil {
+		t.Fatalf("unexpected error creating content: %v", err)
+	}
+
+	err = rootedDriver.Delete(ctx, filename)
+	if err != nil {
+		t.Fatalf("failed to delete: %v", err)
+	}
+
+	keys, err = rootedDriver.List(ctx, "/")
+	if err != nil {
+		t.Fatalf("failed to list objects after deletion: %v", err)
+	}
+
+	if len(keys) != 0 {
+		t.Fatal("delete did not remove nested objects")
 	}
 }


### PR DESCRIPTION
The current code has a discrepancy in behavior depending whether bulk
deletion is supported by the remote endpoint or not.

Given two objects `a` and `a/b` in the object store:

- Without bulk deletion support, Delete("a") first deletes `a/b`, then
  `a`.

- With bulk deletion support, Delete("a") only deletes `a/b`.

This commit fixes the behavior so that both objects are deleted in both
cases.

The swift unit test is updated to cover this case. Note that this
coverage was added to the swift unit test rather than the generic driver
testsuite because the test case is not applicable to all storage
drivers. For example, with the filesystem driver it's not possible to
have a file underneath another file.