### PR TITLE
README: fix formatting of docker-registry link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 The Docker toolset to pack, ship, store, and deliver content.
 
 This repository's main product is the Docker Registry 2.0 implementation
-for storing and distributing Docker images. It supersedes the [docker/docker-
-registry](https://github.com/docker/docker-registry) project with a new API
-design, focused around security and performance.
+for storing and distributing Docker images. It supersedes the
+[docker/docker-registry](https://github.com/docker/docker-registry)
+project with a new API design, focused around security and performance.
 
 <img src="https://www.docker.com/sites/default/files/oyster-registry-3.png" width=200px/>
 


### PR DESCRIPTION
Superfluous space in the name was bothering me.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>