### PR TITLE
Formatting content digest calculation to avoid copyright symbols

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -290,10 +290,11 @@ portion. The _algorithm_ identifies the methodology used to calculate the
 digest. The _hex_ portion is the hex-encoded result of the hash.
 
 We define a _digest_ string to match the following grammar:
-
-  digest      := algorithm ":" hex
-  algorithm   := /[A-Fa-f0-9_+.-]+/
-  hex         := /[A-Fa-f0-9]+/
+```
+digest      := algorithm ":" hex
+algorithm   := /[A-Fa-f0-9_+.-]+/
+hex         := /[A-Fa-f0-9]+/
+```
 
 Some examples of _digests_ include the following:
 
@@ -313,7 +314,6 @@ uniqueness of the _digest_ but some canonicalization may be performed to
 ensure consistent identifiers.
 
 Let's use a simple example in pseudo-code to demonstrate a digest calculation:
-
 ```
 let C = 'a small string'
 let B = sha256(C)
@@ -321,11 +321,11 @@ let D = 'sha256:' + EncodeHex(B)
 let ID(C) = D
 ```
 
-Above, we have bytestring _C_ passed into a function, _SHA256_, that returns a
-bytestring B, which is the hash of _C_. _D_ gets the algorithm concatenated
-with the hex encoding of _B_. We then define the identifier of _C_ to _ID(C)_
-as equal to _D_. A digest can be verified by independently calculating _D_ and
-comparing it with identifier _ID(C)_
+Above, we have bytestring `C` passed into a function, `SHA256`, that returns a
+bytestring `B`, which is the hash of `C`. `D` gets the algorithm concatenated
+with the hex encoding of `B`. We then define the identifier of `C` to `ID(C)`
+as equal to `D`. A digest can be verified by independently calculating `D` and
+comparing it with identifier `ID(C)`.
 
 #### Digest Header
 

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -290,10 +290,11 @@ portion. The _algorithm_ identifies the methodology used to calculate the
 digest. The _hex_ portion is the hex-encoded result of the hash.
 
 We define a _digest_ string to match the following grammar:
-
-  digest      := algorithm ":" hex
-  algorithm   := /[A-Fa-f0-9_+.-]+/
-  hex         := /[A-Fa-f0-9]+/
+```
+digest      := algorithm ":" hex
+algorithm   := /[A-Fa-f0-9_+.-]+/
+hex         := /[A-Fa-f0-9]+/
+```
 
 Some examples of _digests_ include the following:
 
@@ -313,7 +314,6 @@ uniqueness of the _digest_ but some canonicalization may be performed to
 ensure consistent identifiers.
 
 Let's use a simple example in pseudo-code to demonstrate a digest calculation:
-
 ```
 let C = 'a small string'
 let B = sha256(C)
@@ -321,11 +321,11 @@ let D = 'sha256:' + EncodeHex(B)
 let ID(C) = D
 ```
 
-Above, we have bytestring _C_ passed into a function, _SHA256_, that returns a
-bytestring B, which is the hash of _C_. _D_ gets the algorithm concatenated
-with the hex encoding of _B_. We then define the identifier of _C_ to _ID(C)_
-as equal to _D_. A digest can be verified by independently calculating _D_ and
-comparing it with identifier _ID(C)_
+Above, we have bytestring `C` passed into a function, `SHA256`, that returns a
+bytestring `B`, which is the hash of `C`. `D` gets the algorithm concatenated
+with the hex encoding of `B`. We then define the identifier of `C` to `ID(C)`
+as equal to `D`. A digest can be verified by independently calculating `D` and
+comparing it with identifier `ID(C)`
 
 #### Digest Header
 


### PR DESCRIPTION
 - resolves #1197

New look:
<img width="721" alt="screen shot 2015-11-23 at 13 00 40" src="https://cloud.githubusercontent.com/assets/13337345/11349692/52cb90e6-91e2-11e5-8e7f-6f4b4946eb4b.png">
