### PR TITLE
storage: enforce sorted traversal during Walk

### DIFF
--- a/registry/storage/walk.go
+++ b/registry/storage/walk.go
@@ -38,7 +38,9 @@ func Walk(ctx context.Context, driver storageDriver.StorageDriver, from string, 
 		}
 
 		if fileInfo.IsDir() && !skipDir {
-			Walk(ctx, driver, child, f)
+			if err := Walk(ctx, driver, child, f); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/registry/storage/walk.go
+++ b/registry/storage/walk.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/docker/distribution/context"
 	storageDriver "github.com/docker/distribution/registry/storage/driver"
@@ -26,7 +27,12 @@ func Walk(ctx context.Context, driver storageDriver.StorageDriver, from string, 
 	if err != nil {
 		return err
 	}
+	sort.Stable(sort.StringSlice(children))
 	for _, child := range children {
+		// TODO(stevvooe): Calling driver.Stat for every entry is quite
+		// expensive when running against backends with a slow Stat
+		// implementation, such as s3. This is very likely a serious
+		// performance bottleneck.
 		fileInfo, err := driver.Stat(ctx, child)
 		if err != nil {
 			return err

--- a/registry/storage/walk_test.go
+++ b/registry/storage/walk_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/docker/distribution/context"
@@ -73,6 +74,7 @@ func TestWalkErrors(t *testing.T) {
 
 func TestWalk(t *testing.T) {
 	d, expected, ctx := testFS(t)
+	var traversed []string
 	err := Walk(ctx, d, "/", func(fileInfo driver.FileInfo) error {
 		filePath := fileInfo.Path()
 		filetype, ok := expected[filePath]
@@ -90,11 +92,17 @@ func TestWalk(t *testing.T) {
 			}
 		}
 		delete(expected, filePath)
+		traversed = append(traversed, filePath)
 		return nil
 	})
 	if len(expected) > 0 {
 		t.Errorf("Missed files in walk: %q", expected)
 	}
+
+	if !sort.StringsAreSorted(traversed) {
+		t.Errorf("result should be sorted: %v", traversed)
+	}
+
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/registry/storage/walk_test.go
+++ b/registry/storage/walk_test.go
@@ -41,10 +41,12 @@ func TestWalkErrors(t *testing.T) {
 		t.Error("Expected invalid root err")
 	}
 
+	errEarlyExpected := fmt.Errorf("Early termination")
+
 	err = Walk(ctx, d, "/", func(fileInfo driver.FileInfo) error {
 		// error on the 2nd file
 		if fileInfo.Path() == "/a/b" {
-			return fmt.Errorf("Early termination")
+			return errEarlyExpected
 		}
 		delete(expected, fileInfo.Path())
 		return nil
@@ -52,8 +54,12 @@ func TestWalkErrors(t *testing.T) {
 	if len(expected) != fileCount-1 {
 		t.Error("Walk failed to terminate with error")
 	}
-	if err != nil {
-		t.Error(err.Error())
+	if err != errEarlyExpected {
+		if err == nil {
+			t.Fatalf("expected an error due to early termination")
+		} else {
+			t.Error(err.Error())
+		}
 	}
 
 	err = Walk(ctx, d, "/nonexistant", func(fileInfo driver.FileInfo) error {


### PR DESCRIPTION
This ensures sorted order of elements encountered during walk. This open up a number of optimizations for the catalog API, in addition to other enumeration methods.

The error propagation for Walk has also been fixed.

Attempts to address issues in #1190.