### PR TITLE
Swift static large objects

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -121,7 +121,7 @@
 		},
 		{
 			"ImportPath": "github.com/ncw/swift",
-			"Rev": "c54732e87b0b283d1baf0a18db689d0aea460ba3"
+			"Rev": "fe65c35e47350c4c4c1e50f1d98a4b27904ff374"
 		},
 		{
 			"ImportPath": "github.com/noahdesu/go-ceph/rados",


### PR DESCRIPTION
Static large objects are very similar to Dynamic Large Object (DLO) in that it enables the user to upload many objects concurrently and afterwards download them as a single object. It is different in that it does not rely on eventually consistent container listings to do so.
