### PR TITLE
Clarify pagination for catalog API endpoint

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -822,7 +822,13 @@ the presence of a repository only guarantees that it is there but not that it
 is _not_ there.
 
 For registries with a large number of repositories, this response may be quite
-large. If such a response is expected, one should use pagination.
+large. If such a response is expected, one should use pagination. A registry
+may also limit the amount of responses returned even if pagination was not
+explicitly requested. In this case the `Link` header will be returned along
+with the results, and subsequent results can be obtained by following the link
+as if pagination had been initially requested.
+
+For details of the `Link` header, please see the _Pagination_ section.
 
 #### Pagination
 

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -325,7 +325,7 @@ Above, we have bytestring `C` passed into a function, `SHA256`, that returns a
 bytestring `B`, which is the hash of `C`. `D` gets the algorithm concatenated
 with the hex encoding of `B`. We then define the identifier of `C` to `ID(C)`
 as equal to `D`. A digest can be verified by independently calculating `D` and
-comparing it with identifier `ID(C)`
+comparing it with identifier `ID(C)`.
 
 #### Digest Header
 
@@ -822,7 +822,13 @@ the presence of a repository only guarantees that it is there but not that it
 is _not_ there.
 
 For registries with a large number of repositories, this response may be quite
-large. If such a response is expected, one should use pagination.
+large. If such a response is expected, one should use pagination. A registry
+may also limit the amount of responses returned even if pagination was not
+explicitly requested. In this case the `Link` header will be returned along
+with the results, and subsequent results can be obtained by following the link
+as if pagination had been initially requested.
+
+For details of the `Link` header, please see the _Pagination_ section.
 
 #### Pagination
 


### PR DESCRIPTION
This change clarifies the way the catalog endpoint returns results
when pagination was not explicitly requested.  This addresses part of issue #1190.

Signed-off-by: Patrick Devine <patrick.devine@docker.com>