### PR TITLE
Escape dollar signs

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -74,7 +74,7 @@ upstream docker-registry {
 ## The registry always sets this header.
 ## In the case of nginx performing auth, the header will be unset
 ## since nginx is auth-ing before proxying.
-map $upstream_http_docker_distribution_api_version $docker_distribution_api_version {
+map \$upstream_http_docker_distribution_api_version \$docker_distribution_api_version {
   'registry/2.0' '';
   default registry/2.0;
 }


### PR DESCRIPTION
If this example was copied and pasted, the shell would try to interpolate `$upstream_http_docker_distribution_api_version` and `$docker_distribution_api_version`.