### PR TITLE
Small doc fixes found by the linkchecker

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -7,7 +7,7 @@ RUN svn checkout https://github.com/docker/machine/trunk/docs /docs/content/mach
 RUN svn checkout https://github.com/docker/distribution/trunk/docs /docs/content/registry
 RUN svn checkout https://github.com/kitematic/kitematic/trunk/docs /docs/content/kitematic
 RUN svn checkout https://github.com/docker/tutorials/trunk/docs /docs/content/tutorials
-RUN svn checkout https://github.com/docker/opensource/trunk/docs /docs/content
+RUN svn checkout https://github.com/docker/opensource/trunk/docs /docs/content/opensource
 
 ENV PROJECT=registry
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -21,4 +21,4 @@ If you want to report a bug:
 - be sure to first read about [how to contribute](https://github.com/docker/distribution/blob/master/CONTRIBUTING.md)
 - you can then do so on the [GitHub project bugtracker](https://github.com/docker/distribution/issues)
 
-You can also find out more about the Docker's project [Getting Help resources](https://docs.docker.com/project/get-help).
+You can also find out more about the Docker's project [Getting Help resources](https://docs.docker.com/opensource/get-help/).

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -3,6 +3,7 @@
 title = "HTTP API V2"
 description = "Specification for the Registry API."
 keywords = ["registry, on-prem, images, tags, repository, distribution, api, advanced"]
+aliases = ["/registry/spec/"]
 [menu.main]
 parent="smn_registry_ref"
 +++

--- a/docs/spec/auth/index.md
+++ b/docs/spec/auth/index.md
@@ -1,0 +1,14 @@
+<!--[metadata]>
++++
+title = "Docker Regidtry Token Authentication"
+description = "Docker Registry v2 authentication schema"
+keywords = ["registry, on-prem, images, tags, repository, distribution, authentication, advanced"]
+[menu.main]
+parent="smn_registry_ref"
++++
+<![end-metadata]-->
+
+# Docker Registry v2 authentication
+
+See the [Token Authentication Specification](token.md) and
+[Token Authentication Implementation](jwt.md) for more information.

--- a/docs/storagedrivers.md
+++ b/docs/storagedrivers.md
@@ -3,6 +3,7 @@
 title = "Storage Drivers"
 description = "Explains how to use storage drivers"
 keywords = ["registry, on-prem, images, tags, repository, distribution, storage drivers, advanced"]
+aliases = ["/registry/storage-drivers/"]
 [menu.main]
 parent="smn_registry_ref"
 +++


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

The documentation needs an `index.md` or alias for each output dir - idk enough about the content here, so I've given examples of each.

@moxiegirl 