### PR TITLE
Print error msg on failed HTTP token request

### DIFF
--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -240,7 +240,8 @@ func (th *tokenHandler) fetchToken(params map[string]string) (token *tokenRespon
 	defer resp.Body.Close()
 
 	if !client.SuccessStatus(resp.StatusCode) {
-		return nil, fmt.Errorf("token auth attempt for registry: %s request failed with status: %d %s", req.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
+		err := client.HandleErrorResponse(resp)
+		return nil, fmt.Errorf("token auth attempt for registry: %s request failed with status: %d %s: %q", req.URL, resp.StatusCode, http.StatusText(resp.StatusCode), err)
 	}
 
 	decoder := json.NewDecoder(resp.Body)

--- a/registry/client/blob_writer.go
+++ b/registry/client/blob_writer.go
@@ -33,7 +33,7 @@ func (hbu *httpBlobUpload) handleErrorResponse(resp *http.Response) error {
 	if resp.StatusCode == http.StatusNotFound {
 		return distribution.ErrBlobUploadUnknown
 	}
-	return handleErrorResponse(resp)
+	return HandleErrorResponse(resp)
 }
 
 func (hbu *httpBlobUpload) ReadFrom(r io.Reader) (n int64, err error) {

--- a/registry/client/errors.go
+++ b/registry/client/errors.go
@@ -47,7 +47,10 @@ func parseHTTPErrorResponse(r io.Reader) error {
 	return errors
 }
 
-func handleErrorResponse(resp *http.Response) error {
+// HandleErrorResponse returns an error for an unsuccessful HTTP response code
+// (in the range 400 - 499 inclusive). Response code outside of the range will
+// return with an error with unexpected HTTP status.
+func HandleErrorResponse(resp *http.Response) error {
 	if resp.StatusCode == 401 {
 		err := parseHTTPErrorResponse(resp.Body)
 		if uErr, ok := err.(*UnexpectedHTTPResponseError); ok {

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -91,7 +91,7 @@ func (r *registry) Repositories(ctx context.Context, entries []string, last stri
 			returnErr = io.EOF
 		}
 	} else {
-		return 0, handleErrorResponse(resp)
+		return 0, HandleErrorResponse(resp)
 	}
 
 	return numFilled, returnErr
@@ -213,7 +213,7 @@ func (ms *manifests) Tags() ([]string, error) {
 
 		return tagsResponse.Tags, nil
 	}
-	return nil, handleErrorResponse(resp)
+	return nil, HandleErrorResponse(resp)
 }
 
 func (ms *manifests) Exists(dgst digest.Digest) (bool, error) {
@@ -238,7 +238,7 @@ func (ms *manifests) ExistsByTag(tag string) (bool, error) {
 	} else if resp.StatusCode == http.StatusNotFound {
 		return false, nil
 	}
-	return false, handleErrorResponse(resp)
+	return false, HandleErrorResponse(resp)
 }
 
 func (ms *manifests) Get(dgst digest.Digest) (*schema1.SignedManifest, error) {
@@ -297,7 +297,7 @@ func (ms *manifests) GetByTag(tag string, options ...distribution.ManifestServic
 		}
 		return &sm, nil
 	}
-	return nil, handleErrorResponse(resp)
+	return nil, HandleErrorResponse(resp)
 }
 
 func (ms *manifests) Put(m *schema1.SignedManifest) error {
@@ -323,7 +323,7 @@ func (ms *manifests) Put(m *schema1.SignedManifest) error {
 		// TODO(dmcgowan): make use of digest header
 		return nil
 	}
-	return handleErrorResponse(resp)
+	return HandleErrorResponse(resp)
 }
 
 func (ms *manifests) Delete(dgst digest.Digest) error {
@@ -345,7 +345,7 @@ func (ms *manifests) Delete(dgst digest.Digest) error {
 	if SuccessStatus(resp.StatusCode) {
 		return nil
 	}
-	return handleErrorResponse(resp)
+	return HandleErrorResponse(resp)
 }
 
 type blobs struct {
@@ -401,7 +401,7 @@ func (bs *blobs) Open(ctx context.Context, dgst digest.Digest) (distribution.Rea
 			if resp.StatusCode == http.StatusNotFound {
 				return distribution.ErrBlobUnknown
 			}
-			return handleErrorResponse(resp)
+			return HandleErrorResponse(resp)
 		}), nil
 }
 
@@ -457,7 +457,7 @@ func (bs *blobs) Create(ctx context.Context) (distribution.BlobWriter, error) {
 			location:  location,
 		}, nil
 	}
-	return nil, handleErrorResponse(resp)
+	return nil, HandleErrorResponse(resp)
 }
 
 func (bs *blobs) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
@@ -505,7 +505,7 @@ func (bs *blobStatter) Stat(ctx context.Context, dgst digest.Digest) (distributi
 	} else if resp.StatusCode == http.StatusNotFound {
 		return distribution.Descriptor{}, distribution.ErrBlobUnknown
 	}
-	return distribution.Descriptor{}, handleErrorResponse(resp)
+	return distribution.Descriptor{}, HandleErrorResponse(resp)
 }
 
 func buildCatalogValues(maxEntries int, last string) url.Values {
@@ -542,7 +542,7 @@ func (bs *blobStatter) Clear(ctx context.Context, dgst digest.Digest) error {
 	if SuccessStatus(resp.StatusCode) {
 		return nil
 	}
-	return handleErrorResponse(resp)
+	return HandleErrorResponse(resp)
 }
 
 func (bs *blobStatter) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {


### PR DESCRIPTION
In the case of a failed HTTP auth token request, in addition to the current message that is returned, also return the error message in the response. This is to provide the user with a more descriptive message about what went wrong.

Signed-off-by: Kenny Leung <kleung@google.com>