### PR TITLE
Remove unnecessary stat from blob Get method

### DIFF
--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -377,11 +377,7 @@ func (bs *blobs) Stat(ctx context.Context, dgst digest.Digest) (distribution.Des
 }
 
 func (bs *blobs) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
-	desc, err := bs.Stat(ctx, dgst)
-	if err != nil {
-		return nil, err
-	}
-	reader, err := bs.Open(ctx, desc.Digest)
+	reader, err := bs.Open(ctx, dgst)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This calls Stat before Open, which should be unnecessary because Open
can handle the case of a nonexistent blob. Removing the Stat saves a
round trip.

This is similar to the removal of stat in Open in #1226.