### PR TITLE
Fix headers in documentation

### DIFF
--- a/docs/apache.md
+++ b/docs/apache.md
@@ -8,17 +8,17 @@ keywords = ["registry, on-prem, images, tags, repository, distribution, authenti
 
 # Authenticating proxy with apache
 
-## Use-case
+## Use-case
 
 People already relying on an apache proxy to authenticate their users to other services might want to leverage it and have Registry communications tunneled through the same pipeline.
 
 Usually, that includes enterprise setups using LDAP/AD on the backend and a SSO mechanism fronting their internal http portal.
 
-### Alternatives
+### Alternatives
 
 If you just want authentication for your registry, and are happy maintaining users access separately, you should really consider sticking with the native [basic auth registry feature](deploying.md#native-basic-auth). 
 
-### Solution
+### Solution
 
 With the method presented here, you implement basic authentication for docker engines in a reverse proxy that sits in front of your registry.
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -6,13 +6,13 @@ keywords = ["registry, on-prem, images, tags, repository, distribution, build, r
 +++
 <![end-metadata]-->
 
-# Building the registry source
+# Building the registry source
 
 ## Use-case
 
 This is useful if you intend to actively work on the registry.
 
-### Alternatives
+### Alternatives
 
 Most people should use the [official Registry docker image](https://hub.docker.com/r/library/registry/).
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -9,17 +9,17 @@ keywords = ["registry, on-prem, images, tags, repository, distribution, nginx, p
 # Authenticating proxy with nginx
 
 
-## Use-case
+## Use-case
 
 People already relying on a nginx proxy to authenticate their users to other services might want to leverage it and have Registry communications tunneled through the same pipeline.
 
 Usually, that includes enterprise setups using LDAP/AD on the backend and a SSO mechanism fronting their internal http portal.
 
-### Alternatives
+### Alternatives
 
 If you just want authentication for your registry, and are happy maintaining users access separately, you should really consider sticking with the native [basic auth registry feature](deploying.md#native-basic-auth).
 
-### Solution
+### Solution
 
 With the method presented here, you implement basic authentication for docker engines in a reverse proxy that sits in front of your registry.
 
@@ -87,7 +87,7 @@ server {
   ssl_certificate /etc/nginx/conf.d/domain.crt;
   ssl_certificate_key /etc/nginx/conf.d/domain.key;
 
-  # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+  # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
   ssl_protocols TLSv1.1 TLSv1.2;
   ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
   ssl_prefer_server_ciphers on;

--- a/docs/osx-setup-guide.md
+++ b/docs/osx-setup-guide.md
@@ -12,13 +12,13 @@ keywords = ["registry, on-prem, images, tags, repository, distribution, OS X, re
 
 This is useful if you intend to run a registry server natively on OS X.
 
-### Alternatives
+### Alternatives
 
 You can start a VM on OS X, and deploy your registry normally as a container using Docker inside that VM.
 
 The simplest road to get there is traditionally to use the [docker Toolbox](https://www.docker.com/toolbox), or [docker-machine](https://docs.docker.com/machine/), which usually relies on the [boot2docker](http://boot2docker.io/) iso inside a VirtualBox VM.
 
-### Solution
+### Solution
 
 Using the method described here, you install and compile your own from the git repository and run it as an OS X agent.
 
@@ -26,7 +26,7 @@ Using the method described here, you install and compile your own from the git r
 
 Production services operation on OS X is out of scope of this document. Be sure you understand well these aspects before considering going to production with this.
 
-## Setup golang on your machine
+## Setup golang on your machine
 
 If you know, safely skip to the next section.
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -12,7 +12,7 @@ You will find here a list of "recipes", end-to-end scenarios for exotic or other
 
 Most users are not expected to have a use for these.
 
-## Requirements
+## Requirements
 
 You should have followed entirely the basic [deployment guide](deploying.md).
 


### PR DESCRIPTION
These headers were rendered as body text because there was no space, but a "tab" after the `#`.

Took me a few minutes to find out why they didn't render as header, haha