### PR TITLE
Use reference package internally

### DIFF
--- a/notifications/bridge_test.go
+++ b/notifications/bridge_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
 
 	"github.com/docker/libtrust"
 
@@ -38,14 +39,14 @@ var (
 )
 
 func TestEventBridgeManifestPulled(t *testing.T) {
-
 	l := createTestEnv(t, testSinkFn(func(events ...Event) error {
 		checkCommonManifest(t, EventActionPull, events...)
 
 		return nil
 	}))
 
-	if err := l.ManifestPulled(repo, sm); err != nil {
+	repoRef, _ := reference.ParseNamed(repo)
+	if err := l.ManifestPulled(repoRef, sm); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
 }
@@ -57,7 +58,8 @@ func TestEventBridgeManifestPushed(t *testing.T) {
 		return nil
 	}))
 
-	if err := l.ManifestPushed(repo, sm); err != nil {
+	repoRef, _ := reference.ParseNamed(repo)
+	if err := l.ManifestPushed(repoRef, sm); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
 }
@@ -69,7 +71,8 @@ func TestEventBridgeManifestDeleted(t *testing.T) {
 		return nil
 	}))
 
-	if err := l.ManifestDeleted(repo, sm); err != nil {
+	repoRef, _ := reference.ParseNamed(repo)
+	if err := l.ManifestDeleted(repoRef, sm); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
 }
@@ -106,7 +109,8 @@ func checkCommonManifest(t *testing.T, action string, events ...Event) {
 		t.Fatalf("unexpected event action: %q != %q", event.Action, action)
 	}
 
-	u, err := ub.BuildManifestURL(repo, dgst.String())
+	repoRef, _ := reference.ParseNamed(repo)
+	u, err := ub.BuildManifestURL(repoRef, dgst.String())
 	if err != nil {
 		t.Fatalf("error building expected url: %v", err)
 	}

--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -8,28 +8,29 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/reference"
 )
 
 // ManifestListener describes a set of methods for listening to events related to manifests.
 type ManifestListener interface {
-	ManifestPushed(repo string, sm *schema1.SignedManifest) error
-	ManifestPulled(repo string, sm *schema1.SignedManifest) error
+	ManifestPushed(repo reference.Named, sm *schema1.SignedManifest) error
+	ManifestPulled(repo reference.Named, sm *schema1.SignedManifest) error
 
 	// TODO(stevvooe): Please note that delete support is still a little shaky
 	// and we'll need to propagate these in the future.
 
-	ManifestDeleted(repo string, sm *schema1.SignedManifest) error
+	ManifestDeleted(repo reference.Named, sm *schema1.SignedManifest) error
 }
 
 // BlobListener describes a listener that can respond to layer related events.
 type BlobListener interface {
-	BlobPushed(repo string, desc distribution.Descriptor) error
-	BlobPulled(repo string, desc distribution.Descriptor) error
+	BlobPushed(repo reference.Named, desc distribution.Descriptor) error
+	BlobPulled(repo reference.Named, desc distribution.Descriptor) error
 
 	// TODO(stevvooe): Please note that delete support is still a little shaky
 	// and we'll need to propagate these in the future.
 
-	BlobDeleted(repo string, desc distribution.Descriptor) error
+	BlobDeleted(repo reference.Named, desc distribution.Descriptor) error
 }
 
 // Listener combines all repository events into a single interface.

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/storage"
 	"github.com/docker/distribution/registry/storage/cache/memory"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
@@ -27,7 +28,8 @@ func TestListener(t *testing.T) {
 		ops: make(map[string]int),
 	}
 
-	repository, err := registry.Repository(ctx, "foo/bar")
+	repoRef, _ := reference.ParseNamed("foo/bar")
+	repository, err := registry.Repository(ctx, repoRef)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
 	}
@@ -55,33 +57,33 @@ type testListener struct {
 	ops map[string]int
 }
 
-func (tl *testListener) ManifestPushed(repo string, sm *schema1.SignedManifest) error {
+func (tl *testListener) ManifestPushed(repo reference.Named, sm *schema1.SignedManifest) error {
 	tl.ops["manifest:push"]++
 
 	return nil
 }
 
-func (tl *testListener) ManifestPulled(repo string, sm *schema1.SignedManifest) error {
+func (tl *testListener) ManifestPulled(repo reference.Named, sm *schema1.SignedManifest) error {
 	tl.ops["manifest:pull"]++
 	return nil
 }
 
-func (tl *testListener) ManifestDeleted(repo string, sm *schema1.SignedManifest) error {
+func (tl *testListener) ManifestDeleted(repo reference.Named, sm *schema1.SignedManifest) error {
 	tl.ops["manifest:delete"]++
 	return nil
 }
 
-func (tl *testListener) BlobPushed(repo string, desc distribution.Descriptor) error {
+func (tl *testListener) BlobPushed(repo reference.Named, desc distribution.Descriptor) error {
 	tl.ops["layer:push"]++
 	return nil
 }
 
-func (tl *testListener) BlobPulled(repo string, desc distribution.Descriptor) error {
+func (tl *testListener) BlobPulled(repo reference.Named, desc distribution.Descriptor) error {
 	tl.ops["layer:pull"]++
 	return nil
 }
 
-func (tl *testListener) BlobDeleted(repo string, desc distribution.Descriptor) error {
+func (tl *testListener) BlobDeleted(repo reference.Named, desc distribution.Descriptor) error {
 	tl.ops["layer:delete"]++
 	return nil
 }
@@ -99,7 +101,7 @@ func checkExerciseRepository(t *testing.T, repository distribution.Repository) {
 		Versioned: manifest.Versioned{
 			SchemaVersion: 1,
 		},
-		Name: repository.Name(),
+		Name: repository.Name().String(),
 		Tag:  tag,
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -4,6 +4,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/reference"
 )
 
 // Scope defines the set of items that match a namespace.
@@ -34,7 +35,7 @@ type Namespace interface {
 	// Repository should return a reference to the named repository. The
 	// registry may or may not have the repository but should always return a
 	// reference.
-	Repository(ctx context.Context, name string) (Repository, error)
+	Repository(ctx context.Context, name reference.Named) (Repository, error)
 
 	// Repositories fills 'repos' with a lexigraphically sorted catalog of repositories
 	// up to the size of 'repos' and returns the value 'n' for the number of entries
@@ -49,7 +50,7 @@ type ManifestServiceOption func(ManifestService) error
 // Repository is a named collection of manifests and layers.
 type Repository interface {
 	// Name returns the name of the repository.
-	Name() string
+	Name() reference.Named
 
 	// Manifests returns a reference to this repository's manifest service.
 	// with the supplied options applied.

--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
 	"github.com/gorilla/mux"
 )
 
@@ -113,10 +114,10 @@ func (ub *URLBuilder) BuildCatalogURL(values ...url.Values) (string, error) {
 }
 
 // BuildTagsURL constructs a url to list the tags in the named repository.
-func (ub *URLBuilder) BuildTagsURL(name string) (string, error) {
+func (ub *URLBuilder) BuildTagsURL(name reference.Named) (string, error) {
 	route := ub.cloneRoute(RouteNameTags)
 
-	tagsURL, err := route.URL("name", name)
+	tagsURL, err := route.URL("name", name.String())
 	if err != nil {
 		return "", err
 	}
@@ -126,10 +127,10 @@ func (ub *URLBuilder) BuildTagsURL(name string) (string, error) {
 
 // BuildManifestURL constructs a url for the manifest identified by name and
 // reference. The argument reference may be either a tag or digest.
-func (ub *URLBuilder) BuildManifestURL(name, reference string) (string, error) {
+func (ub *URLBuilder) BuildManifestURL(name reference.Named, reference string) (string, error) {
 	route := ub.cloneRoute(RouteNameManifest)
 
-	manifestURL, err := route.URL("name", name, "reference", reference)
+	manifestURL, err := route.URL("name", name.String(), "reference", reference)
 	if err != nil {
 		return "", err
 	}
@@ -138,10 +139,10 @@ func (ub *URLBuilder) BuildManifestURL(name, reference string) (string, error) {
 }
 
 // BuildBlobURL constructs the url for the blob identified by name and dgst.
-func (ub *URLBuilder) BuildBlobURL(name string, dgst digest.Digest) (string, error) {
+func (ub *URLBuilder) BuildBlobURL(name reference.Named, dgst digest.Digest) (string, error) {
 	route := ub.cloneRoute(RouteNameBlob)
 
-	layerURL, err := route.URL("name", name, "digest", dgst.String())
+	layerURL, err := route.URL("name", name.String(), "digest", dgst.String())
 	if err != nil {
 		return "", err
 	}
@@ -151,10 +152,10 @@ func (ub *URLBuilder) BuildBlobURL(name string, dgst digest.Digest) (string, err
 
 // BuildBlobUploadURL constructs a url to begin a blob upload in the
 // repository identified by name.
-func (ub *URLBuilder) BuildBlobUploadURL(name string, values ...url.Values) (string, error) {
+func (ub *URLBuilder) BuildBlobUploadURL(name reference.Named, values ...url.Values) (string, error) {
 	route := ub.cloneRoute(RouteNameBlobUpload)
 
-	uploadURL, err := route.URL("name", name)
+	uploadURL, err := route.URL("name", name.String())
 	if err != nil {
 		return "", err
 	}
@@ -166,10 +167,10 @@ func (ub *URLBuilder) BuildBlobUploadURL(name string, values ...url.Values) (str
 // including any url values. This should generally not be used by clients, as
 // this url is provided by server implementations during the blob upload
 // process.
-func (ub *URLBuilder) BuildBlobUploadChunkURL(name, uuid string, values ...url.Values) (string, error) {
+func (ub *URLBuilder) BuildBlobUploadChunkURL(name reference.Named, uuid string, values ...url.Values) (string, error) {
 	route := ub.cloneRoute(RouteNameBlobUploadChunk)
 
-	uploadURL, err := route.URL("name", name, "uuid", uuid)
+	uploadURL, err := route.URL("name", name.String(), "uuid", uuid)
 	if err != nil {
 		return "", err
 	}

--- a/registry/api/v2/urls_test.go
+++ b/registry/api/v2/urls_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/docker/distribution/reference"
 )
 
 type urlBuilderTestCase struct {
@@ -13,6 +15,7 @@ type urlBuilderTestCase struct {
 }
 
 func makeURLBuilderTestCases(urlBuilder *URLBuilder) []urlBuilderTestCase {
+	fooBarRef, _ := reference.ParseNamed("foo/bar")
 	return []urlBuilderTestCase{
 		{
 			description:  "test base url",
@@ -23,35 +26,35 @@ func makeURLBuilderTestCases(urlBuilder *URLBuilder) []urlBuilderTestCase {
 			description:  "test tags url",
 			expectedPath: "/v2/foo/bar/tags/list",
 			build: func() (string, error) {
-				return urlBuilder.BuildTagsURL("foo/bar")
+				return urlBuilder.BuildTagsURL(fooBarRef)
 			},
 		},
 		{
 			description:  "test manifest url",
 			expectedPath: "/v2/foo/bar/manifests/tag",
 			build: func() (string, error) {
-				return urlBuilder.BuildManifestURL("foo/bar", "tag")
+				return urlBuilder.BuildManifestURL(fooBarRef, "tag")
 			},
 		},
 		{
 			description:  "build blob url",
 			expectedPath: "/v2/foo/bar/blobs/tarsum.v1+sha256:abcdef0123456789",
 			build: func() (string, error) {
-				return urlBuilder.BuildBlobURL("foo/bar", "tarsum.v1+sha256:abcdef0123456789")
+				return urlBuilder.BuildBlobURL(fooBarRef, "tarsum.v1+sha256:abcdef0123456789")
 			},
 		},
 		{
 			description:  "build blob upload url",
 			expectedPath: "/v2/foo/bar/blobs/uploads/",
 			build: func() (string, error) {
-				return urlBuilder.BuildBlobUploadURL("foo/bar")
+				return urlBuilder.BuildBlobUploadURL(fooBarRef)
 			},
 		},
 		{
 			description:  "build blob upload url with digest and size",
 			expectedPath: "/v2/foo/bar/blobs/uploads/?digest=tarsum.v1%2Bsha256%3Aabcdef0123456789&size=10000",
 			build: func() (string, error) {
-				return urlBuilder.BuildBlobUploadURL("foo/bar", url.Values{
+				return urlBuilder.BuildBlobUploadURL(fooBarRef, url.Values{
 					"size":   []string{"10000"},
 					"digest": []string{"tarsum.v1+sha256:abcdef0123456789"},
 				})
@@ -61,14 +64,14 @@ func makeURLBuilderTestCases(urlBuilder *URLBuilder) []urlBuilderTestCase {
 			description:  "build blob upload chunk url",
 			expectedPath: "/v2/foo/bar/blobs/uploads/uuid-part",
 			build: func() (string, error) {
-				return urlBuilder.BuildBlobUploadChunkURL("foo/bar", "uuid-part")
+				return urlBuilder.BuildBlobUploadChunkURL(fooBarRef, "uuid-part")
 			},
 		},
 		{
 			description:  "build blob upload chunk url with digest and size",
 			expectedPath: "/v2/foo/bar/blobs/uploads/uuid-part?digest=tarsum.v1%2Bsha256%3Aabcdef0123456789&size=10000",
 			build: func() (string, error) {
-				return urlBuilder.BuildBlobUploadChunkURL("foo/bar", "uuid-part", url.Values{
+				return urlBuilder.BuildBlobUploadChunkURL(fooBarRef, "uuid-part", url.Values{
 					"size":   []string{"10000"},
 					"digest": []string{"tarsum.v1+sha256:abcdef0123456789"},
 				})

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -98,11 +98,7 @@ func (r *registry) Repositories(ctx context.Context, entries []string, last stri
 }
 
 // NewRepository creates a new Repository for the given repository name and base URL.
-func NewRepository(ctx context.Context, name, baseURL string, transport http.RoundTripper) (distribution.Repository, error) {
-	if _, err := reference.ParseNamed(name); err != nil {
-		return nil, err
-	}
-
+func NewRepository(ctx context.Context, name reference.Named, baseURL string, transport http.RoundTripper) (distribution.Repository, error) {
 	ub, err := v2.NewURLBuilderFromString(baseURL)
 	if err != nil {
 		return nil, err
@@ -125,21 +121,21 @@ type repository struct {
 	client  *http.Client
 	ub      *v2.URLBuilder
 	context context.Context
-	name    string
+	name    reference.Named
 }
 
-func (r *repository) Name() string {
+func (r *repository) Name() reference.Named {
 	return r.name
 }
 
 func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 	statter := &blobStatter{
-		name:   r.Name(),
+		name:   r.name,
 		ub:     r.ub,
 		client: r.client,
 	}
 	return &blobs{
-		name:    r.Name(),
+		name:    r.name,
 		ub:      r.ub,
 		client:  r.client,
 		statter: cache.NewCachedBlobStatter(memory.NewInMemoryBlobDescriptorCacheProvider(), statter),
@@ -149,7 +145,7 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 func (r *repository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
 	// todo(richardscothern): options should be sent over the wire
 	return &manifests{
-		name:   r.Name(),
+		name:   r.name,
 		ub:     r.ub,
 		client: r.client,
 		etags:  make(map[string]string),
@@ -180,7 +176,7 @@ func (s *signatures) Put(dgst digest.Digest, signatures ...[]byte) error {
 }
 
 type manifests struct {
-	name   string
+	name   reference.Named
 	ub     *v2.URLBuilder
 	client *http.Client
 	etags  map[string]string
@@ -349,7 +345,7 @@ func (ms *manifests) Delete(dgst digest.Digest) error {
 }
 
 type blobs struct {
-	name   string
+	name   reference.Named
 	ub     *v2.URLBuilder
 	client *http.Client
 
@@ -469,7 +465,7 @@ func (bs *blobs) Delete(ctx context.Context, dgst digest.Digest) error {
 }
 
 type blobStatter struct {
-	name   string
+	name   reference.Named
 	ub     *v2.URLBuilder
 	client *http.Client
 }

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/testutil"
 	"github.com/docker/distribution/uuid"
@@ -103,11 +104,11 @@ func addTestCatalog(route string, content []byte, link string, m *testutil.Reque
 func TestBlobDelete(t *testing.T) {
 	dgst, _ := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
-	repo := "test.example.com/repo1"
+	repo, _ := reference.ParseNamed("test.example.com/repo1")
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "DELETE",
-			Route:  "/v2/" + repo + "/blobs/" + dgst.String(),
+			Route:  "/v2/" + repo.String() + "/blobs/" + dgst.String(),
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusAccepted,
@@ -142,7 +143,8 @@ func TestBlobFetch(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, "test.example.com/repo1", e, nil)
+	repo, _ := reference.ParseNamed("test.example.com/repo1")
+	r, err := NewRepository(ctx, repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,12 +164,12 @@ func TestBlobFetch(t *testing.T) {
 func TestBlobExistsNoContentLength(t *testing.T) {
 	var m testutil.RequestResponseMap
 
-	repo := "biff"
+	repo, _ := reference.ParseNamed("biff")
 	dgst, content := newRandomBlob(1024)
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "GET",
-			Route:  "/v2/" + repo + "/blobs/" + dgst.String(),
+			Route:  "/v2/" + repo.String() + "/blobs/" + dgst.String(),
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusOK,
@@ -182,7 +184,7 @@ func TestBlobExistsNoContentLength(t *testing.T) {
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "HEAD",
-			Route:  "/v2/" + repo + "/blobs/" + dgst.String(),
+			Route:  "/v2/" + repo.String() + "/blobs/" + dgst.String(),
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusOK,
@@ -221,7 +223,8 @@ func TestBlobExists(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, "test.example.com/repo1", e, nil)
+	repo, _ := reference.ParseNamed("test.example.com/repo1")
+	r, err := NewRepository(ctx, repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,18 +255,18 @@ func TestBlobUploadChunked(t *testing.T) {
 		b1[512:513],
 		b1[513:1024],
 	}
-	repo := "test.example.com/uploadrepo"
+	repo, _ := reference.ParseNamed("test.example.com/uploadrepo")
 	uuids := []string{uuid.Generate().String()}
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "POST",
-			Route:  "/v2/" + repo + "/blobs/uploads/",
+			Route:  "/v2/" + repo.String() + "/blobs/uploads/",
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusAccepted,
 			Headers: http.Header(map[string][]string{
 				"Content-Length":     {"0"},
-				"Location":           {"/v2/" + repo + "/blobs/uploads/" + uuids[0]},
+				"Location":           {"/v2/" + repo.String() + "/blobs/uploads/" + uuids[0]},
 				"Docker-Upload-UUID": {uuids[0]},
 				"Range":              {"0-0"},
 			}),
@@ -276,14 +279,14 @@ func TestBlobUploadChunked(t *testing.T) {
 		m = append(m, testutil.RequestResponseMapping{
 			Request: testutil.Request{
 				Method: "PATCH",
-				Route:  "/v2/" + repo + "/blobs/uploads/" + uuids[i],
+				Route:  "/v2/" + repo.String() + "/blobs/uploads/" + uuids[i],
 				Body:   chunk,
 			},
 			Response: testutil.Response{
 				StatusCode: http.StatusAccepted,
 				Headers: http.Header(map[string][]string{
 					"Content-Length":     {"0"},
-					"Location":           {"/v2/" + repo + "/blobs/uploads/" + uuids[i+1]},
+					"Location":           {"/v2/" + repo.String() + "/blobs/uploads/" + uuids[i+1]},
 					"Docker-Upload-UUID": {uuids[i+1]},
 					"Range":              {fmt.Sprintf("%d-%d", offset, newOffset-1)},
 				}),
@@ -294,7 +297,7 @@ func TestBlobUploadChunked(t *testing.T) {
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "PUT",
-			Route:  "/v2/" + repo + "/blobs/uploads/" + uuids[len(uuids)-1],
+			Route:  "/v2/" + repo.String() + "/blobs/uploads/" + uuids[len(uuids)-1],
 			QueryParams: map[string][]string{
 				"digest": {dgst.String()},
 			},
@@ -311,7 +314,7 @@ func TestBlobUploadChunked(t *testing.T) {
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "HEAD",
-			Route:  "/v2/" + repo + "/blobs/" + dgst.String(),
+			Route:  "/v2/" + repo.String() + "/blobs/" + dgst.String(),
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusOK,
@@ -367,18 +370,18 @@ func TestBlobUploadChunked(t *testing.T) {
 func TestBlobUploadMonolithic(t *testing.T) {
 	dgst, b1 := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
-	repo := "test.example.com/uploadrepo"
+	repo, _ := reference.ParseNamed("test.example.com/uploadrepo")
 	uploadID := uuid.Generate().String()
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "POST",
-			Route:  "/v2/" + repo + "/blobs/uploads/",
+			Route:  "/v2/" + repo.String() + "/blobs/uploads/",
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusAccepted,
 			Headers: http.Header(map[string][]string{
 				"Content-Length":     {"0"},
-				"Location":           {"/v2/" + repo + "/blobs/uploads/" + uploadID},
+				"Location":           {"/v2/" + repo.String() + "/blobs/uploads/" + uploadID},
 				"Docker-Upload-UUID": {uploadID},
 				"Range":              {"0-0"},
 			}),
@@ -387,13 +390,13 @@ func TestBlobUploadMonolithic(t *testing.T) {
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "PATCH",
-			Route:  "/v2/" + repo + "/blobs/uploads/" + uploadID,
+			Route:  "/v2/" + repo.String() + "/blobs/uploads/" + uploadID,
 			Body:   b1,
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusAccepted,
 			Headers: http.Header(map[string][]string{
-				"Location":              {"/v2/" + repo + "/blobs/uploads/" + uploadID},
+				"Location":              {"/v2/" + repo.String() + "/blobs/uploads/" + uploadID},
 				"Docker-Upload-UUID":    {uploadID},
 				"Content-Length":        {"0"},
 				"Docker-Content-Digest": {dgst.String()},
@@ -404,7 +407,7 @@ func TestBlobUploadMonolithic(t *testing.T) {
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "PUT",
-			Route:  "/v2/" + repo + "/blobs/uploads/" + uploadID,
+			Route:  "/v2/" + repo.String() + "/blobs/uploads/" + uploadID,
 			QueryParams: map[string][]string{
 				"digest": {dgst.String()},
 			},
@@ -421,7 +424,7 @@ func TestBlobUploadMonolithic(t *testing.T) {
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "HEAD",
-			Route:  "/v2/" + repo + "/blobs/" + dgst.String(),
+			Route:  "/v2/" + repo.String() + "/blobs/" + dgst.String(),
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusOK,
@@ -472,7 +475,7 @@ func TestBlobUploadMonolithic(t *testing.T) {
 	}
 }
 
-func newRandomSchemaV1Manifest(name, tag string, blobCount int) (*schema1.SignedManifest, digest.Digest, []byte) {
+func newRandomSchemaV1Manifest(name reference.Named, tag string, blobCount int) (*schema1.SignedManifest, digest.Digest, []byte) {
 	blobs := make([]schema1.FSLayer, blobCount)
 	history := make([]schema1.History, blobCount)
 
@@ -484,7 +487,7 @@ func newRandomSchemaV1Manifest(name, tag string, blobCount int) (*schema1.Signed
 	}
 
 	m := schema1.Manifest{
-		Name:         name,
+		Name:         name.String(),
 		Tag:          tag,
 		Architecture: "x86",
 		FSLayers:     blobs,
@@ -517,11 +520,11 @@ func newRandomSchemaV1Manifest(name, tag string, blobCount int) (*schema1.Signed
 	return sm, dgst, p
 }
 
-func addTestManifestWithEtag(repo, reference string, content []byte, m *testutil.RequestResponseMap, dgst string) {
+func addTestManifestWithEtag(repo reference.Named, reference string, content []byte, m *testutil.RequestResponseMap, dgst string) {
 	actualDigest, _ := digest.FromBytes(content)
 	getReqWithEtag := testutil.Request{
 		Method: "GET",
-		Route:  "/v2/" + repo + "/manifests/" + reference,
+		Route:  "/v2/" + repo.String() + "/manifests/" + reference,
 		Headers: http.Header(map[string][]string{
 			"If-None-Match": {fmt.Sprintf(`"%s"`, dgst)},
 		}),
@@ -551,11 +554,11 @@ func addTestManifestWithEtag(repo, reference string, content []byte, m *testutil
 	*m = append(*m, testutil.RequestResponseMapping{Request: getReqWithEtag, Response: getRespWithEtag})
 }
 
-func addTestManifest(repo, reference string, content []byte, m *testutil.RequestResponseMap) {
+func addTestManifest(repo reference.Named, reference string, content []byte, m *testutil.RequestResponseMap) {
 	*m = append(*m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "GET",
-			Route:  "/v2/" + repo + "/manifests/" + reference,
+			Route:  "/v2/" + repo.String() + "/manifests/" + reference,
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusOK,
@@ -569,7 +572,7 @@ func addTestManifest(repo, reference string, content []byte, m *testutil.Request
 	*m = append(*m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "HEAD",
-			Route:  "/v2/" + repo + "/manifests/" + reference,
+			Route:  "/v2/" + repo.String() + "/manifests/" + reference,
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusOK,
@@ -610,7 +613,7 @@ func checkEqualManifest(m1, m2 *schema1.SignedManifest) error {
 
 func TestManifestFetch(t *testing.T) {
 	ctx := context.Background()
-	repo := "test.example.com/repo"
+	repo, _ := reference.ParseNamed("test.example.com/repo")
 	m1, dgst, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 	addTestManifest(repo, dgst.String(), m1.Raw, &m)
@@ -645,7 +648,7 @@ func TestManifestFetch(t *testing.T) {
 }
 
 func TestManifestFetchWithEtag(t *testing.T) {
-	repo := "test.example.com/repo/by/tag"
+	repo, _ := reference.ParseNamed("test.example.com/repo/by/tag")
 	_, d1, p1 := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 	addTestManifestWithEtag(repo, "latest", p1, &m, d1.String())
@@ -670,14 +673,14 @@ func TestManifestFetchWithEtag(t *testing.T) {
 }
 
 func TestManifestDelete(t *testing.T) {
-	repo := "test.example.com/repo/delete"
+	repo, _ := reference.ParseNamed("test.example.com/repo/delete")
 	_, dgst1, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	_, dgst2, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "DELETE",
-			Route:  "/v2/" + repo + "/manifests/" + dgst1.String(),
+			Route:  "/v2/" + repo.String() + "/manifests/" + dgst1.String(),
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusAccepted,
@@ -710,13 +713,13 @@ func TestManifestDelete(t *testing.T) {
 }
 
 func TestManifestPut(t *testing.T) {
-	repo := "test.example.com/repo/delete"
+	repo, _ := reference.ParseNamed("test.example.com/repo/delete")
 	m1, dgst, _ := newRandomSchemaV1Manifest(repo, "other", 6)
 	var m testutil.RequestResponseMap
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "PUT",
-			Route:  "/v2/" + repo + "/manifests/other",
+			Route:  "/v2/" + repo.String() + "/manifests/other",
 			Body:   m1.Raw,
 		},
 		Response: testutil.Response{
@@ -749,7 +752,7 @@ func TestManifestPut(t *testing.T) {
 }
 
 func TestManifestTags(t *testing.T) {
-	repo := "test.example.com/repo/tags/list"
+	repo, _ := reference.ParseNamed("test.example.com/repo/tags/list")
 	tagsList := []byte(strings.TrimSpace(`
 {
 	"name": "test.example.com/repo/tags/list",
@@ -764,7 +767,7 @@ func TestManifestTags(t *testing.T) {
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "GET",
-			Route:  "/v2/" + repo + "/tags/list",
+			Route:  "/v2/" + repo.String() + "/tags/list",
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusOK,
@@ -803,14 +806,14 @@ func TestManifestTags(t *testing.T) {
 }
 
 func TestManifestUnauthorized(t *testing.T) {
-	repo := "test.example.com/repo"
+	repo, _ := reference.ParseNamed("test.example.com/repo")
 	_, dgst, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "GET",
-			Route:  "/v2/" + repo + "/manifests/" + dgst.String(),
+			Route:  "/v2/" + repo.String() + "/manifests/" + dgst.String(),
 		},
 		Response: testutil.Response{
 			StatusCode: http.StatusUnauthorized,

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/distribution/health"
 	"github.com/docker/distribution/health/checks"
 	"github.com/docker/distribution/notifications"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/auth"
@@ -577,7 +578,19 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 		context.Context = ctxu.WithLogger(context.Context, ctxu.GetLogger(context.Context, "auth.user.name"))
 
 		if app.nameRequired(r) {
-			repository, err := app.registry.Repository(context, getName(context))
+			nameRef, err := reference.ParseNamed(getName(context))
+			if err != nil {
+				ctxu.GetLogger(context).Errorf("error parsing reference from context: %v", err)
+				context.Errors = append(context.Errors, distribution.ErrRepositoryNameInvalid{
+					Name:   getName(context),
+					Reason: err,
+				})
+				if err := errcode.ServeJSON(w, context.Errors); err != nil {
+					ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
+				}
+				return
+			}
+			repository, err := app.registry.Repository(context, nameRef)
 
 			if err != nil {
 				ctxu.GetLogger(context).Errorf("error resolving repository: %v", err)

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -48,7 +48,7 @@ func TestAppDispatcher(t *testing.T) {
 	varCheckingDispatcher := func(expectedVars map[string]string) dispatchFunc {
 		return func(ctx *Context, r *http.Request) http.Handler {
 			// Always checks the same name context
-			if ctx.Repository.Name() != getName(ctx) {
+			if ctx.Repository.Name().String() != getName(ctx) {
 				t.Fatalf("unexpected name: %q != %q", ctx.Repository.Name(), "foo/bar")
 			}
 

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -44,7 +44,7 @@ func blobUploadDispatcher(ctx *Context, r *http.Request) http.Handler {
 		}
 		buh.State = state
 
-		if state.Name != ctx.Repository.Name() {
+		if state.Name != ctx.Repository.Name().String() {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				ctxu.GetLogger(ctx).Infof("mismatched repository name in upload state: %q != %q", state.Name, buh.Repository.Name())
 				buh.Errors = append(buh.Errors, v2.ErrorCodeBlobUploadInvalid.WithDetail(err))
@@ -302,7 +302,7 @@ func (buh *blobUploadHandler) blobUploadResponse(w http.ResponseWriter, r *http.
 	}
 
 	// TODO(stevvooe): Need a better way to manage the upload state automatically.
-	buh.State.Name = buh.Repository.Name()
+	buh.State.Name = buh.Repository.Name().String()
 	buh.State.UUID = buh.Upload.ID()
 	buh.State.Offset = offset
 	buh.State.StartedAt = buh.Upload.StartedAt()

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -44,7 +44,7 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err := err.(type) {
 		case distribution.ErrRepositoryUnknown:
-			th.Errors = append(th.Errors, v2.ErrorCodeNameUnknown.WithDetail(map[string]string{"name": th.Repository.Name()}))
+			th.Errors = append(th.Errors, v2.ErrorCodeNameUnknown.WithDetail(map[string]string{"name": th.Repository.Name().String()}))
 		default:
 			th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		}
@@ -55,7 +55,7 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(tagsAPIResponse{
-		Name: th.Repository.Name(),
+		Name: th.Repository.Name().String(),
 		Tags: tags,
 	}); err != nil {
 		th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -133,7 +133,7 @@ func (pbs *proxyBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter,
 		if err := pbs.storeLocal(ctx, dgst); err != nil {
 			context.GetLogger(ctx).Errorf("Error committing to storage: %s", err.Error())
 		}
-		pbs.scheduler.AddBlob(dgst.String(), repositoryTTL)
+		pbs.scheduler.AddBlob(dgst, repositoryTTL)
 	}(dgst)
 
 	_, err = pbs.copyContent(ctx, dgst, w)

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/proxy/scheduler"
 	"github.com/docker/distribution/registry/storage"
 	"github.com/docker/distribution/registry/storage/cache/memory"
@@ -114,6 +115,11 @@ func (te *testEnv) RemoteStats() *map[string]int {
 
 // Populate remote store and record the digests
 func makeTestEnv(t *testing.T, name string) *testEnv {
+	nameRef, err := reference.ParseNamed(name)
+	if err != nil {
+		t.Fatalf("unable to parse reference: %s", err)
+	}
+
 	ctx := context.Background()
 
 	truthDir, err := ioutil.TempDir("", "truth")
@@ -131,7 +137,7 @@ func makeTestEnv(t *testing.T, name string) *testEnv {
 	if err != nil {
 		t.Fatalf("error creating registry: %v", err)
 	}
-	localRepo, err := localRegistry.Repository(ctx, name)
+	localRepo, err := localRegistry.Repository(ctx, nameRef)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
 	}
@@ -140,7 +146,7 @@ func makeTestEnv(t *testing.T, name string) *testEnv {
 	if err != nil {
 		t.Fatalf("error creating registry: %v", err)
 	}
-	truthRepo, err := truthRegistry.Repository(ctx, name)
+	truthRepo, err := truthRegistry.Repository(ctx, nameRef)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
 	}

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/proxy/scheduler"
 )
@@ -18,7 +19,7 @@ type proxyManifestStore struct {
 	ctx             context.Context
 	localManifests  distribution.ManifestService
 	remoteManifests distribution.ManifestService
-	repositoryName  string
+	repositoryName  reference.Named
 	scheduler       *scheduler.TTLExpirationScheduler
 }
 
@@ -58,7 +59,7 @@ func (pms proxyManifestStore) Get(dgst digest.Digest) (*schema1.SignedManifest, 
 	pms.scheduler.AddManifest(pms.repositoryName, repositoryTTL)
 
 	// Ensure the manifest blob is cleaned up
-	pms.scheduler.AddBlob(dgst.String(), repositoryTTL)
+	pms.scheduler.AddBlob(dgst, repositoryTTL)
 
 	proxyMetrics.ManifestPush(uint64(len(sm.Raw)))
 
@@ -121,7 +122,7 @@ fromremote:
 	if err != nil {
 		return nil, err
 	}
-	pms.scheduler.AddBlob(dgst.String(), repositoryTTL)
+	pms.scheduler.AddBlob(dgst, repositoryTTL)
 	pms.scheduler.AddManifest(pms.repositoryName, repositoryTTL)
 
 	proxyMetrics.ManifestPull(uint64(len(sm.Raw)))

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/proxy/scheduler"
 	"github.com/docker/distribution/registry/storage"
 	"github.com/docker/distribution/registry/storage/cache/memory"
@@ -73,12 +74,17 @@ func (sm statsManifest) Tags() ([]string, error) {
 }
 
 func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestEnv {
+	nameRef, err := reference.ParseNamed(name)
+	if err != nil {
+		t.Fatalf("unable to parse reference: %s", err)
+	}
+
 	ctx := context.Background()
 	truthRegistry, err := storage.NewRegistry(ctx, inmemory.New(), storage.BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()))
 	if err != nil {
 		t.Fatalf("error creating registry: %v", err)
 	}
-	truthRepo, err := truthRegistry.Repository(ctx, name)
+	truthRepo, err := truthRegistry.Repository(ctx, nameRef)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
 	}
@@ -100,7 +106,7 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 	if err != nil {
 		t.Fatalf("error creating registry: %v", err)
 	}
-	localRepo, err := localRegistry.Repository(ctx, name)
+	localRepo, err := localRegistry.Repository(ctx, nameRef)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
 	}

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/transport"
@@ -70,9 +71,9 @@ func (pr *proxyingRegistry) Repositories(ctx context.Context, repos []string, la
 	return pr.embedded.Repositories(ctx, repos, last)
 }
 
-func (pr *proxyingRegistry) Repository(ctx context.Context, name string) (distribution.Repository, error) {
+func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named) (distribution.Repository, error) {
 	tr := transport.NewTransport(http.DefaultTransport,
-		auth.NewAuthorizer(pr.challengeManager, auth.NewTokenHandler(http.DefaultTransport, pr.credentialStore, name, "pull")))
+		auth.NewAuthorizer(pr.challengeManager, auth.NewTokenHandler(http.DefaultTransport, pr.credentialStore, name.String(), "pull")))
 
 	localRepo, err := pr.embedded.Repository(ctx, name)
 	if err != nil {
@@ -117,7 +118,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name string) (distri
 type proxiedRepository struct {
 	blobStore  distribution.BlobStore
 	manifests  distribution.ManifestService
-	name       string
+	name       reference.Named
 	signatures distribution.SignatureService
 }
 
@@ -130,7 +131,7 @@ func (pr *proxiedRepository) Blobs(ctx context.Context) distribution.BlobStore {
 	return pr.blobStore
 }
 
-func (pr *proxiedRepository) Name() string {
+func (pr *proxiedRepository) Name() reference.Named {
 	return pr.name
 }
 

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/storage/driver"
 )
 
@@ -80,19 +82,19 @@ func (ttles *TTLExpirationScheduler) OnManifestExpire(f expiryFunc) {
 }
 
 // AddBlob schedules a blob cleanup after ttl expires
-func (ttles *TTLExpirationScheduler) AddBlob(dgst string, ttl time.Duration) error {
+func (ttles *TTLExpirationScheduler) AddBlob(dgst digest.Digest, ttl time.Duration) error {
 	ttles.Lock()
 	defer ttles.Unlock()
 
 	if ttles.stopped {
 		return fmt.Errorf("scheduler not started")
 	}
-	ttles.add(dgst, ttl, entryTypeBlob)
+	ttles.add(dgst.String(), ttl, entryTypeBlob)
 	return nil
 }
 
 // AddManifest schedules a manifest cleanup after ttl expires
-func (ttles *TTLExpirationScheduler) AddManifest(repoName string, ttl time.Duration) error {
+func (ttles *TTLExpirationScheduler) AddManifest(repoName reference.Named, ttl time.Duration) error {
 	ttles.Lock()
 	defer ttles.Unlock()
 
@@ -100,7 +102,7 @@ func (ttles *TTLExpirationScheduler) AddManifest(repoName string, ttl time.Durat
 		return fmt.Errorf("scheduler not started")
 	}
 
-	ttles.add(repoName, ttl, entryTypeManifest)
+	ttles.add(repoName.String(), ttl, entryTypeManifest)
 	return nil
 }
 

--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/storage/cache/memory"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
 	"github.com/docker/distribution/testutil"
@@ -31,7 +32,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	imageName := "foo/bar"
+	imageName, _ := reference.ParseNamed("foo/bar")
 	driver := inmemory.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -216,7 +217,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 // other tests.
 func TestSimpleBlobRead(t *testing.T) {
 	ctx := context.Background()
-	imageName := "foo/bar"
+	imageName, _ := reference.ParseNamed("foo/bar")
 	driver := inmemory.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -323,7 +324,7 @@ func TestSimpleBlobRead(t *testing.T) {
 // TestLayerUploadZeroLength uploads zero-length
 func TestLayerUploadZeroLength(t *testing.T) {
 	ctx := context.Background()
-	imageName := "foo/bar"
+	imageName, _ := reference.ParseNamed("foo/bar")
 	driver := inmemory.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -326,7 +326,7 @@ func (bw *blobWriter) moveBlob(ctx context.Context, desc distribution.Descriptor
 // resources are already not present, no error will be returned.
 func (bw *blobWriter) removeResources(ctx context.Context) error {
 	dataPath, err := pathFor(uploadDataPathSpec{
-		name: bw.blobStore.repository.Name(),
+		name: bw.blobStore.repository.Name().String(),
 		id:   bw.id,
 	})
 

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -113,7 +113,7 @@ type hashStateEntry struct {
 // getStoredHashStates returns a slice of hashStateEntries for this upload.
 func (bw *blobWriter) getStoredHashStates(ctx context.Context) ([]hashStateEntry, error) {
 	uploadHashStatePathPrefix, err := pathFor(uploadHashStatePathSpec{
-		name: bw.blobStore.repository.Name(),
+		name: bw.blobStore.repository.Name().String(),
 		id:   bw.id,
 		alg:  bw.digester.Digest().Algorithm(),
 		list: true,
@@ -159,7 +159,7 @@ func (bw *blobWriter) storeHashState(ctx context.Context) error {
 	}
 
 	uploadHashStatePath, err := pathFor(uploadHashStatePathSpec{
-		name:   bw.blobStore.repository.Name(),
+		name:   bw.blobStore.repository.Name().String(),
 		id:     bw.id,
 		alg:    bw.digester.Digest().Algorithm(),
 		offset: int64(h.Len()),

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -105,7 +105,7 @@ func (lbs *linkedBlobStore) Create(ctx context.Context) (distribution.BlobWriter
 	startedAt := time.Now().UTC()
 
 	path, err := pathFor(uploadDataPathSpec{
-		name: lbs.repository.Name(),
+		name: lbs.repository.Name().String(),
 		id:   uuid,
 	})
 
@@ -114,7 +114,7 @@ func (lbs *linkedBlobStore) Create(ctx context.Context) (distribution.BlobWriter
 	}
 
 	startedAtPath, err := pathFor(uploadStartedAtPathSpec{
-		name: lbs.repository.Name(),
+		name: lbs.repository.Name().String(),
 		id:   uuid,
 	})
 
@@ -134,7 +134,7 @@ func (lbs *linkedBlobStore) Resume(ctx context.Context, id string) (distribution
 	context.GetLogger(ctx).Debug("(*linkedBlobStore).Resume")
 
 	startedAtPath, err := pathFor(uploadStartedAtPathSpec{
-		name: lbs.repository.Name(),
+		name: lbs.repository.Name().String(),
 		id:   id,
 	})
 
@@ -158,7 +158,7 @@ func (lbs *linkedBlobStore) Resume(ctx context.Context, id string) (distribution
 	}
 
 	path, err := pathFor(uploadDataPathSpec{
-		name: lbs.repository.Name(),
+		name: lbs.repository.Name().String(),
 		id:   id,
 	})
 
@@ -228,7 +228,7 @@ func (lbs *linkedBlobStore) linkBlob(ctx context.Context, canonical distribution
 		}
 		seenDigests[dgst] = struct{}{}
 
-		blobLinkPath, err := linkPathFn(lbs.repository.Name(), dgst)
+		blobLinkPath, err := linkPathFn(lbs.repository.Name().String(), dgst)
 		if err != nil {
 			return err
 		}
@@ -298,7 +298,7 @@ func (lbs *linkedBlobStatter) Stat(ctx context.Context, dgst digest.Digest) (dis
 func (lbs *linkedBlobStatter) Clear(ctx context.Context, dgst digest.Digest) (err error) {
 	// clear any possible existence of a link described in linkPathFns
 	for _, linkPathFn := range lbs.linkPathFns {
-		blobLinkPath, err := linkPathFn(lbs.repository.Name(), dgst)
+		blobLinkPath, err := linkPathFn(lbs.repository.Name().String(), dgst)
 		if err != nil {
 			return err
 		}
@@ -321,7 +321,7 @@ func (lbs *linkedBlobStatter) Clear(ctx context.Context, dgst digest.Digest) (er
 // linkPathFuncs to let us try a few different paths before returning not
 // found.
 func (lbs *linkedBlobStatter) resolveWithLinkFunc(ctx context.Context, dgst digest.Digest, linkPathFn linkPathFunc) (digest.Digest, error) {
-	blobLinkPath, err := linkPathFn(lbs.repository.Name(), dgst)
+	blobLinkPath, err := linkPathFn(lbs.repository.Name().String(), dgst)
 	if err != nil {
 		return "", err
 	}

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/storage/cache/memory"
 	"github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
@@ -23,11 +24,11 @@ type manifestStoreTestEnv struct {
 	driver     driver.StorageDriver
 	registry   distribution.Namespace
 	repository distribution.Repository
-	name       string
+	name       reference.Named
 	tag        string
 }
 
-func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestEnv {
+func newManifestStoreTestEnv(t *testing.T, name reference.Named, tag string) *manifestStoreTestEnv {
 	ctx := context.Background()
 	driver := inmemory.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
@@ -51,7 +52,8 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 }
 
 func TestManifestStorage(t *testing.T) {
-	env := newManifestStoreTestEnv(t, "foo/bar", "thetag")
+	repoName, _ := reference.ParseNamed("foo/bar")
+	env := newManifestStoreTestEnv(t, repoName, "thetag")
 	ctx := context.Background()
 	ms, err := env.repository.Manifests(ctx)
 	if err != nil {
@@ -80,7 +82,7 @@ func TestManifestStorage(t *testing.T) {
 		Versioned: manifest.Versioned{
 			SchemaVersion: 1,
 		},
-		Name: env.name,
+		Name: env.name.String(),
 		Tag:  env.tag,
 	}
 

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -107,18 +107,11 @@ func (reg *registry) Scope() distribution.Scope {
 // Repository returns an instance of the repository tied to the registry.
 // Instances should not be shared between goroutines but are cheap to
 // allocate. In general, they should be request scoped.
-func (reg *registry) Repository(ctx context.Context, canonicalName string) (distribution.Repository, error) {
-	if _, err := reference.ParseNamed(canonicalName); err != nil {
-		return nil, distribution.ErrRepositoryNameInvalid{
-			Name:   canonicalName,
-			Reason: err,
-		}
-	}
-
+func (reg *registry) Repository(ctx context.Context, canonicalName reference.Named) (distribution.Repository, error) {
 	var descriptorCache distribution.BlobDescriptorService
 	if reg.blobDescriptorCacheProvider != nil {
 		var err error
-		descriptorCache, err = reg.blobDescriptorCacheProvider.RepositoryScoped(canonicalName)
+		descriptorCache, err = reg.blobDescriptorCacheProvider.RepositoryScoped(canonicalName.String())
 		if err != nil {
 			return nil, err
 		}
@@ -136,12 +129,12 @@ func (reg *registry) Repository(ctx context.Context, canonicalName string) (dist
 type repository struct {
 	*registry
 	ctx             context.Context
-	name            string
+	name            reference.Named
 	descriptorCache distribution.BlobDescriptorService
 }
 
 // Name returns the name of the repository.
-func (repo *repository) Name() string {
+func (repo *repository) Name() reference.Named {
 	return repo.name
 }
 

--- a/registry/storage/revisionstore.go
+++ b/registry/storage/revisionstore.go
@@ -24,7 +24,7 @@ func (rs *revisionStore) get(ctx context.Context, revision digest.Digest) (*sche
 	if err != nil {
 		if err == distribution.ErrBlobUnknown {
 			return nil, distribution.ErrManifestUnknownRevision{
-				Name:     rs.repository.Name(),
+				Name:     rs.repository.Name().String(),
 				Revision: revision,
 			}
 		}
@@ -39,7 +39,7 @@ func (rs *revisionStore) get(ctx context.Context, revision digest.Digest) (*sche
 	if err != nil {
 		if err == distribution.ErrBlobUnknown {
 			return nil, distribution.ErrManifestUnknownRevision{
-				Name:     rs.repository.Name(),
+				Name:     rs.repository.Name().String(),
 				Revision: revision,
 			}
 		}

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -27,7 +27,7 @@ var _ distribution.SignatureService = &signatureStore{}
 
 func (s *signatureStore) Get(dgst digest.Digest) ([][]byte, error) {
 	signaturesPath, err := pathFor(manifestSignaturesPathSpec{
-		name:     s.repository.Name(),
+		name:     s.repository.Name().String(),
 		revision: dgst,
 	})
 

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -19,7 +19,7 @@ type tagStore struct {
 // tags lists the manifest tags for the specified repository.
 func (ts *tagStore) tags() ([]string, error) {
 	p, err := pathFor(manifestTagPathSpec{
-		name: ts.repository.Name(),
+		name: ts.repository.Name().String(),
 	})
 
 	if err != nil {
@@ -31,7 +31,7 @@ func (ts *tagStore) tags() ([]string, error) {
 	if err != nil {
 		switch err := err.(type) {
 		case storagedriver.PathNotFoundError:
-			return nil, distribution.ErrRepositoryUnknown{Name: ts.repository.Name()}
+			return nil, distribution.ErrRepositoryUnknown{Name: ts.repository.Name().String()}
 		default:
 			return nil, err
 		}
@@ -49,7 +49,7 @@ func (ts *tagStore) tags() ([]string, error) {
 // exists returns true if the specified manifest tag exists in the repository.
 func (ts *tagStore) exists(tag string) (bool, error) {
 	tagPath, err := pathFor(manifestTagCurrentPathSpec{
-		name: ts.repository.Name(),
+		name: ts.repository.Name().String(),
 		tag:  tag,
 	})
 
@@ -69,7 +69,7 @@ func (ts *tagStore) exists(tag string) (bool, error) {
 // the current tag. The digest must point to a manifest.
 func (ts *tagStore) tag(tag string, revision digest.Digest) error {
 	currentPath, err := pathFor(manifestTagCurrentPathSpec{
-		name: ts.repository.Name(),
+		name: ts.repository.Name().String(),
 		tag:  tag,
 	})
 
@@ -90,7 +90,7 @@ func (ts *tagStore) tag(tag string, revision digest.Digest) error {
 // resolve the current revision for name and tag.
 func (ts *tagStore) resolve(tag string) (digest.Digest, error) {
 	currentPath, err := pathFor(manifestTagCurrentPathSpec{
-		name: ts.repository.Name(),
+		name: ts.repository.Name().String(),
 		tag:  tag,
 	})
 
@@ -102,7 +102,7 @@ func (ts *tagStore) resolve(tag string) (digest.Digest, error) {
 	if err != nil {
 		switch err.(type) {
 		case storagedriver.PathNotFoundError:
-			return "", distribution.ErrManifestUnknown{Name: ts.repository.Name(), Tag: tag}
+			return "", distribution.ErrManifestUnknown{Name: ts.repository.Name().String(), Tag: tag}
 		}
 
 		return "", err
@@ -115,7 +115,7 @@ func (ts *tagStore) resolve(tag string) (digest.Digest, error) {
 // revisions that have the specified tag.
 func (ts *tagStore) delete(tag string) error {
 	tagPath, err := pathFor(manifestTagPathSpec{
-		name: ts.repository.Name(),
+		name: ts.repository.Name().String(),
 		tag:  tag,
 	})
 


### PR DESCRIPTION
Most places in the registry were using string types to refer to
repository names. This changes them to use reference.Named, so the type
system can enforce validation of the naming rules.

cc @dmcgowan @stevvooe