### PR TITLE
Serve blobs when a storage driver supports redirects but are disabled

### DIFF
--- a/registry/storage/blobserver.go
+++ b/registry/storage/blobserver.go
@@ -34,45 +34,45 @@ func (bs *blobServer) ServeBlob(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	redirectURL, err := bs.driver.URLFor(ctx, path, map[string]interface{}{"method": r.Method})
-
-	switch err.(type) {
-	case nil:
-		if bs.redirect {
+	if bs.redirect {
+		redirectURL, err := bs.driver.URLFor(ctx, path, map[string]interface{}{"method": r.Method})
+		switch err.(type) {
+		case nil:
 			// Redirect to storage URL.
 			http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 			return err
-		}
 
-	case driver.ErrUnsupportedMethod:
-		// Fallback to serving the content directly.
-		br, err := newFileReader(ctx, bs.driver, path, desc.Size)
-		if err != nil {
+		case driver.ErrUnsupportedMethod:
+			// Fallback to serving the content directly.
+		default:
+			// Some unexpected error.
 			return err
 		}
-		defer br.Close()
-
-		w.Header().Set("ETag", fmt.Sprintf(`"%s"`, desc.Digest)) // If-None-Match handled by ServeContent
-		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%.f", blobCacheControlMaxAge.Seconds()))
-
-		if w.Header().Get("Docker-Content-Digest") == "" {
-			w.Header().Set("Docker-Content-Digest", desc.Digest.String())
-		}
-
-		if w.Header().Get("Content-Type") == "" {
-			// Set the content type if not already set.
-			w.Header().Set("Content-Type", desc.MediaType)
-		}
-
-		if w.Header().Get("Content-Length") == "" {
-			// Set the content length if not already set.
-			w.Header().Set("Content-Length", fmt.Sprint(desc.Size))
-		}
-
-		http.ServeContent(w, r, desc.Digest.String(), time.Time{}, br)
-		return nil
 	}
 
-	// Some unexpected error.
-	return err
+	br, err := newFileReader(ctx, bs.driver, path, desc.Size)
+	if err != nil {
+		return err
+	}
+	defer br.Close()
+
+	w.Header().Set("ETag", fmt.Sprintf(`"%s"`, desc.Digest)) // If-None-Match handled by ServeContent
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%.f", blobCacheControlMaxAge.Seconds()))
+
+	if w.Header().Get("Docker-Content-Digest") == "" {
+		w.Header().Set("Docker-Content-Digest", desc.Digest.String())
+	}
+
+	if w.Header().Get("Content-Type") == "" {
+		// Set the content type if not already set.
+		w.Header().Set("Content-Type", desc.MediaType)
+	}
+
+	if w.Header().Get("Content-Length") == "" {
+		// Set the content length if not already set.
+		w.Header().Set("Content-Length", fmt.Sprint(desc.Size))
+	}
+
+	http.ServeContent(w, r, desc.Digest.String(), time.Time{}, br)
+	return nil
 }


### PR DESCRIPTION
Fixes issue where an error was returned instead of serving the blob

#1300, docker/docker#15264