### PR TITLE
docs: mark manifest as "draft"

### DIFF
--- a/docs/spec/manifest-v2-2.md
+++ b/docs/spec/manifest-v2-2.md
@@ -1,3 +1,9 @@
+<!--[metadata]>
++++
+draft = true
++++
+<![end-metadata]-->
+
 # Image Manifest Version 2, Schema 2
 
 This document outlines the format of of the V2 image manifest, schema version 2.


### PR DESCRIPTION
Markdown linter produced an error on this page;

    running markdownlint
    ERROR (registry/spec/manifest-v2-2.md) frontmatter: Unexpected non-whitespace char: # Image Manifest Version 2, Schema 2

