### PR TITLE
Fix broken daemon startup with master

### DIFF
--- a/contrib/docker-integration/run.sh
+++ b/contrib/docker-integration/run.sh
@@ -38,12 +38,12 @@ docker pull $INTEGRATION_IMAGE
 ID=$(docker run -d -it --privileged $volumeMount $dockerMount \
 	-v ${DISTRIBUTION_ROOT}:/go/src/github.com/docker/distribution \
 	-e "DOCKER_GRAPHDRIVER=$DOCKER_GRAPHDRIVER" \
-	-e "EXEC_DRIVER=$EXEC_DRIVER" \
 	${INTEGRATION_IMAGE} \
 	./run_engine.sh)
 
 # Stop container on exit
 trap "docker rm -f -v $ID" EXIT
+
 
 # Wait for it to become reachable.
 tries=10

--- a/contrib/docker-integration/run_engine.sh
+++ b/contrib/docker-integration/run_engine.sh
@@ -11,5 +11,13 @@ echo "$IP localregistry" >> /etc/hosts
 
 sh install_certs.sh localregistry
 
-docker --daemon --log-level=panic \
-	--storage-driver="$DOCKER_GRAPHDRIVER" --exec-driver="$EXEC_DRIVER"
+DOCKER_VERSION=$(docker --version | cut -d ' ' -f3 | cut -d ',' -f1)
+major=$(echo "$DOCKER_VERSION"| cut -d '.' -f1)
+minor=$(echo "$DOCKER_VERSION"| cut -d '.' -f2)
+
+daemonOpts="daemon"
+if [ $major -le 1 ] && [ $minor -lt 9 ]; then
+	daemonOpts="--daemon"
+fi
+
+docker $daemonOpts --log-level=debug --storage-driver="$DOCKER_GRAPHDRIVER"

--- a/contrib/docker-integration/run_multiversion.sh
+++ b/contrib/docker-integration/run_multiversion.sh
@@ -23,7 +23,7 @@ fi
 
 # Released versions
 
-versions="1.6.0 1.6.1 1.7.0 1.7.1"
+versions="1.6.1 1.7.1 1.8.3 1.9.1"
 
 for v in $versions; do
 	echo "Extracting Docker $v from dind image"


### PR DESCRIPTION
Since the daemon flag was deprecated and replaced by the daemon subcommand, the run engine should use the subcommand and only the flag for older version.

Updated docker versions which are tested to include the last 2 releases.

Also the jenkins has been updated to no longer attempt to run the distribution tests on a centos machine (which would fail because it was trying to use aufs).
