### PR TITLE
Remove tags referencing deleted manifests.

### DIFF
--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -226,5 +226,19 @@ func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *h
 		}
 	}
 
+	tagService := imh.Repository.Tags(imh)
+	referencedTags, err := tagService.Lookup(imh, distribution.Descriptor{Digest: imh.Digest})
+	if err != nil {
+		imh.Errors = append(imh.Errors, err)
+		return
+	}
+
+	for _, tag := range referencedTags {
+		if err := tagService.Untag(imh, tag); err != nil {
+			imh.Errors = append(imh.Errors, err)
+			return
+		}
+	}
+
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/registry/storage/tagstore_test.go
+++ b/registry/storage/tagstore_test.go
@@ -102,7 +102,7 @@ func TestTagStoreUnTag(t *testing.T) {
 	}
 }
 
-func TestTagAll(t *testing.T) {
+func TestTagStoreAll(t *testing.T) {
 	env := testTagStore(t)
 	tagStore := env.ts
 	ctx := env.ctx
@@ -145,6 +145,62 @@ func TestTagAll(t *testing.T) {
 		if tag == removed {
 			t.Errorf("unexpected tag in enumerate %s", removed)
 		}
+	}
+
+}
+
+func TestTagLookup(t *testing.T) {
+	env := testTagStore(t)
+	tagStore := env.ts
+	ctx := env.ctx
+
+	descA := distribution.Descriptor{Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	desc0 := distribution.Descriptor{Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"}
+
+	tags, err := tagStore.Lookup(ctx, descA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 0 {
+		t.Fatalf("Lookup returned > 0 tags from empty store")
+	}
+
+	err = tagStore.Tag(ctx, "a", descA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tagStore.Tag(ctx, "b", descA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tagStore.Tag(ctx, "0", desc0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tagStore.Tag(ctx, "1", desc0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tags, err = tagStore.Lookup(ctx, descA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tags) != 2 {
+		t.Errorf("Lookup of descA returned %d tags, expected 2", len(tags))
+	}
+
+	tags, err = tagStore.Lookup(ctx, desc0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tags) != 2 {
+		t.Errorf("Lookup of descB returned %d tags, expected 2", len(tags))
 	}
 
 }


### PR DESCRIPTION
When a manifest is deleted by digest, look up the referenced tags in the tag
store and remove all associations.

closes #1293 
closes #938
supercedes #1297 

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>