### PR TITLE
GCS storage driver: fix retry function

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -318,13 +318,13 @@ func retry(maxTries int, req request) error {
 	backoff := time.Second
 	var err error
 	for i := 0; i < maxTries; i++ {
-		err := req()
+		err = req()
 		if err == nil {
 			return nil
 		}
 
-		status := err.(*googleapi.Error)
-		if status == nil || (status.Code != 429 && status.Code < http.StatusInternalServerError) {
+		status, ok := err.(*googleapi.Error)
+		if !ok || (status.Code != 429 && status.Code < http.StatusInternalServerError) {
 			return err
 		}
 


### PR DESCRIPTION
This PR fixes two bugs in the retry-function:
* the function panics if a request returns an error that is not of type googleapi.Error
* the function redeclares the "err" variable causing it to return nil if the request still fails after the maximum number of retries.

@RichardScothern 