### PR TITLE
Gcs resume write

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -211,9 +211,6 @@ type BlobWriter interface {
 	// result in a no-op. This allows use of Cancel in a defer statement,
 	// increasing the assurance that it is correctly called.
 	Cancel(ctx context.Context) error
-
-	// Get a reader to the blob being written by this BlobWriter
-	Reader() (io.ReadCloser, error)
 }
 
 // BlobService combines the operations to access, read and write blobs. This

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -96,11 +96,17 @@ func (bw *blobWriter) Write(p []byte) (int, error) {
 	// Ensure that the current write offset matches how many bytes have been
 	// written to the digester. If not, we need to update the digest state to
 	// match the current write position.
-	if err := bw.resumeDigestAt(bw.blobStore.ctx, bw.offset); err != nil && err != errResumableDigestNotAvailable {
+	err := bw.resumeDigestAt(bw.blobStore.ctx, bw.offset, false)
+	if err != nil && err != errResumableDigestNotAvailable {
 		return 0, err
 	}
-
-	n, err := io.MultiWriter(&bw.bufferedFileWriter, bw.digester.Hash()).Write(p)
+	resumeDigest := err != errResumableDigestNotAvailable
+	n, err := bw.bufferedFileWriter.Write(p)
+	if resumeDigest {
+		// update the Hash with the bytes that have been written succesfully to the
+		// file writer
+		bw.digester.Hash().Write(p[0:n])
+	}
 	bw.written += int64(n)
 
 	return n, err
@@ -110,11 +116,15 @@ func (bw *blobWriter) ReadFrom(r io.Reader) (n int64, err error) {
 	// Ensure that the current write offset matches how many bytes have been
 	// written to the digester. If not, we need to update the digest state to
 	// match the current write position.
-	if err := bw.resumeDigestAt(bw.blobStore.ctx, bw.offset); err != nil && err != errResumableDigestNotAvailable {
+	if err = bw.resumeDigestAt(bw.blobStore.ctx, bw.offset, false); err != nil && err != errResumableDigestNotAvailable {
 		return 0, err
 	}
 
-	nn, err := bw.bufferedFileWriter.ReadFrom(io.TeeReader(r, bw.digester.Hash()))
+	reader := r
+	if err != errResumableDigestNotAvailable {
+		reader = io.TeeReader(r, bw.digester.Hash())
+	}
+	nn, err := bw.bufferedFileWriter.ReadFrom(reader)
 	bw.written += nn
 
 	return nn, err
@@ -181,7 +191,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 	// TODO(stevvooe): This section is very meandering. Need to be broken down
 	// to be a lot more clear.
 
-	if err := bw.resumeDigestAt(ctx, bw.size); err == nil {
+	if err := bw.resumeDigestAt(ctx, bw.size, true); err == nil {
 		canonical = bw.digester.Digest()
 
 		if canonical.Algorithm() == desc.Digest.Algorithm() {
@@ -351,30 +361,4 @@ func (bw *blobWriter) removeResources(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (bw *blobWriter) Reader() (io.ReadCloser, error) {
-	// todo(richardscothern): Change to exponential backoff, i=0.5, e=2, n=4
-	try := 1
-	for try <= 5 {
-		_, err := bw.bufferedFileWriter.driver.Stat(bw.ctx, bw.path)
-		if err == nil {
-			break
-		}
-		switch err.(type) {
-		case storagedriver.PathNotFoundError:
-			context.GetLogger(bw.ctx).Debugf("Nothing found on try %d, sleeping...", try)
-			time.Sleep(1 * time.Second)
-			try++
-		default:
-			return nil, err
-		}
-	}
-
-	readCloser, err := bw.bufferedFileWriter.driver.ReadStream(bw.ctx, bw.path, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	return readCloser, nil
 }

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -96,7 +96,7 @@ func (bw *blobWriter) Write(p []byte) (int, error) {
 	// Ensure that the current write offset matches how many bytes have been
 	// written to the digester. If not, we need to update the digest state to
 	// match the current write position.
-	err := bw.resumeDigestAt(bw.blobStore.ctx, bw.offset, false)
+	err := bw.resumeDigest(bw.blobStore.ctx)
 	if err != nil && err != errResumableDigestNotAvailable {
 		return 0, err
 	}
@@ -116,7 +116,7 @@ func (bw *blobWriter) ReadFrom(r io.Reader) (n int64, err error) {
 	// Ensure that the current write offset matches how many bytes have been
 	// written to the digester. If not, we need to update the digest state to
 	// match the current write position.
-	if err = bw.resumeDigestAt(bw.blobStore.ctx, bw.offset, false); err != nil && err != errResumableDigestNotAvailable {
+	if err = bw.resumeDigest(bw.blobStore.ctx); err != nil && err != errResumableDigestNotAvailable {
 		return 0, err
 	}
 
@@ -191,7 +191,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 	// TODO(stevvooe): This section is very meandering. Need to be broken down
 	// to be a lot more clear.
 
-	if err := bw.resumeDigestAt(ctx, bw.size, true); err == nil {
+	if err := bw.resumeDigest(ctx); err == nil {
 		canonical = bw.digester.Digest()
 
 		if canonical.Algorithm() == desc.Digest.Algorithm() {

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -4,8 +4,6 @@ package storage
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"path"
 	"strconv"
 
@@ -20,23 +18,17 @@ import (
 )
 
 // resumeDigestAt attempts to restore the state of the internal hash function
-// by loading the most recent saved hash state less than or equal to the given
-// offset. Any unhashed bytes remaining less than the given offset are hashed
-// from the content uploaded so far.
-func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64, allowRead bool) error {
+// by loading the most recent saved hash state equal to the current size of the blob.
+func (bw *blobWriter) resumeDigest(ctx context.Context) error {
 	if !bw.resumableDigestEnabled {
 		return errResumableDigestNotAvailable
-	}
-
-	if offset < 0 {
-		return fmt.Errorf("cannot resume hash at negative offset: %d", offset)
 	}
 
 	h, ok := bw.digester.Hash().(resumable.Hash)
 	if !ok {
 		return errResumableDigestNotAvailable
 	}
-
+	offset := bw.bufferedFileWriter.size
 	if offset == int64(h.Len()) {
 		// State of digester is already at the requested offset.
 		return nil
@@ -49,24 +41,12 @@ func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64, allowRea
 		return fmt.Errorf("unable to get stored hash states with offset %d: %s", offset, err)
 	}
 
-	// Find the highest stored hashState with offset less than or equal to
+	// Find the highest stored hashState with offset equal to
 	// the requested offset.
 	for _, hashState := range hashStates {
 		if hashState.offset == offset {
 			hashStateMatch = hashState
 			break // Found an exact offset match.
-		} else if hashState.offset < offset && hashState.offset > hashStateMatch.offset {
-			// This offset is closer to the requested offset.
-			hashStateMatch = hashState
-		} else if hashState.offset > offset {
-			// Remove any stored hash state with offsets higher than this one
-			// as writes to this resumed hasher will make those invalid. This
-			// is probably okay to skip for now since we don't expect anyone to
-			// use the API in this way. For that reason, we don't treat an
-			// an error here as a fatal error, but only log it.
-			if err := bw.driver.Delete(ctx, hashState.path); err != nil {
-				logrus.Errorf("unable to delete stale hash state %q: %s", hashState.path, err)
-			}
 		}
 	}
 
@@ -86,23 +66,7 @@ func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64, allowRea
 
 	// Mind the gap.
 	if gapLen := offset - int64(h.Len()); gapLen > 0 {
-		if !allowRead {
-			return errResumableDigestNotAvailable
-		}
-		// Need to read content from the upload to catch up to the desired offset.
-		fr, err := newFileReader(ctx, bw.driver, bw.path, bw.size)
-		if err != nil {
-			return err
-		}
-		defer fr.Close()
-
-		if _, err = fr.Seek(int64(h.Len()), os.SEEK_SET); err != nil {
-			return fmt.Errorf("unable to seek to layer reader offset %d: %s", h.Len(), err)
-		}
-
-		if _, err := io.CopyN(h, fr, gapLen); err != nil {
-			return err
-		}
+		return errResumableDigestNotAvailable
 	}
 
 	return nil

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -23,7 +23,7 @@ import (
 // by loading the most recent saved hash state less than or equal to the given
 // offset. Any unhashed bytes remaining less than the given offset are hashed
 // from the content uploaded so far.
-func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64) error {
+func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64, allowRead bool) error {
 	if !bw.resumableDigestEnabled {
 		return errResumableDigestNotAvailable
 	}
@@ -86,6 +86,9 @@ func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64) error {
 
 	// Mind the gap.
 	if gapLen := offset - int64(h.Len()); gapLen > 0 {
+		if !allowRead {
+			return errResumableDigestNotAvailable
+		}
 		// Need to read content from the upload to catch up to the desired offset.
 		fr, err := newFileReader(ctx, bw.driver, bw.path, bw.size)
 		if err != nil {

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -174,6 +174,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return zw.Write(d.container, path, offset, reader)
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -161,6 +161,10 @@ func (d *driver) WriteStream(ctx context.Context, subPath string, offset int64, 
 	return io.Copy(fp, reader)
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, subPath string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -7,11 +7,8 @@
 // Because gcs is a key, value store the Stat call does not support last modification
 // time for directories (directories are an abstraction for key, value stores)
 //
-// Keep in mind that gcs guarantees only eventual consistency, so do not assume
-// that a successful write will mean immediate access to the data written (although
-// in most regions a new object put has guaranteed read after write). The only true
-// guarantee is that once you call Stat and receive a certain file size, that much of
-// the file is already accessible.
+// Note that the contents of incomplete uploads are not accessible even though
+// Stat returns their length
 //
 // +build include_gcs
 
@@ -25,7 +22,9 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,7 +33,6 @@ import (
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/googleapi"
-	storageapi "google.golang.org/api/storage/v1"
 	"google.golang.org/cloud"
 	"google.golang.org/cloud/storage"
 
@@ -44,8 +42,23 @@ import (
 	"github.com/docker/distribution/registry/storage/driver/factory"
 )
 
-const driverName = "gcs"
-const dummyProjectID = "<unknown>"
+const (
+	driverName     = "gcs"
+	dummyProjectID = "<unknown>"
+
+	uploadSessionContentType = "application/x-docker-upload-session"
+	minChunkSize             = 256 * 1024
+	maxChunkSize             = 20 * minChunkSize
+)
+
+var rangeHeader = regexp.MustCompile(`^bytes=([0-9])+-([0-9]+)$`)
+
+type uploadSession struct {
+	name       string
+	sessionURI string
+	offset     int64
+	buffer     []byte
+}
 
 // driverParameters is a struct that encapsulates all of the driver parameters after all values have been set
 type driverParameters struct {
@@ -180,6 +193,21 @@ func (d *driver) PutContent(context ctx.Context, path string, contents []byte) e
 // with a given byte offset.
 // May be used to resume reading a stream by providing a nonzero offset.
 func (d *driver) ReadStream(context ctx.Context, path string, offset int64) (io.ReadCloser, error) {
+	s, rc, err := d.readFile(context, path, offset)
+	if err != nil {
+		return nil, err
+	}
+	if s != nil {
+		err = d.endUploadSession(context, s)
+		if err != nil {
+			return nil, err
+		}
+		return storage.NewReader(d.context(context), d.bucket, d.pathToKey(path))
+	}
+	return rc, nil
+}
+
+func (d *driver) readFile(context ctx.Context, path string, offset int64) (*uploadSession, io.ReadCloser, error) {
 	name := d.pathToKey(path)
 
 	// copied from google.golang.org/cloud/storage#NewReader :
@@ -191,35 +219,54 @@ func (d *driver) ReadStream(context ctx.Context, path string, offset int64) (io.
 	}
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if offset > 0 {
 		req.Header.Set("Range", fmt.Sprintf("bytes=%v-", offset))
 	}
 	res, err := d.client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if res.StatusCode == http.StatusNotFound {
 		res.Body.Close()
-		return nil, storagedriver.PathNotFoundError{Path: path}
+		return nil, nil, storagedriver.PathNotFoundError{Path: path}
 	}
 	if res.StatusCode == http.StatusRequestedRangeNotSatisfiable {
 		res.Body.Close()
 		obj, err := storageStatObject(d.context(context), d.bucket, name)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if offset == int64(obj.Size) {
-			return ioutil.NopCloser(bytes.NewReader([]byte{})), nil
+			return nil, ioutil.NopCloser(bytes.NewReader([]byte{})), nil
 		}
-		return nil, storagedriver.InvalidOffsetError{Path: path, Offset: offset}
+		return nil, nil, storagedriver.InvalidOffsetError{Path: path, Offset: offset}
 	}
 	if res.StatusCode < 200 || res.StatusCode > 299 {
 		res.Body.Close()
-		return nil, fmt.Errorf("storage: can't read object %v/%v, status code: %v", d.bucket, name, res.Status)
+		return nil, nil, googleapi.CheckMediaResponse(res)
 	}
-	return res.Body, nil
+
+	if res.Header.Get("Content-Type") == uploadSessionContentType {
+		defer res.Body.Close()
+		buffer, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, nil, err
+		}
+		offset, err := strconv.ParseInt(res.Header.Get("X-Goog-Meta-Offset"), 10, 64)
+		if err != nil {
+			return nil, nil, err
+		}
+		s := &uploadSession{
+			name:       name,
+			sessionURI: res.Header.Get("X-Goog-Meta-Session-URI"),
+			buffer:     buffer,
+			offset:     offset,
+		}
+		return s, nil, nil
+	}
+	return nil, res.Body, nil
 }
 
 func (d *driver) CloseWriteStream(context ctx.Context, path string) error {
@@ -235,82 +282,76 @@ func (d *driver) WriteStream(context ctx.Context, path string, offset int64, rea
 		return 0, storagedriver.InvalidOffsetError{Path: path, Offset: offset}
 	}
 
-	if offset == 0 {
-		return d.writeCompletely(context, path, 0, reader)
-	}
-
-	service, err := storageapi.New(d.client)
-	if err != nil {
-		return 0, err
-	}
-	objService := storageapi.NewObjectsService(service)
-	var obj *storageapi.Object
-	err = retry(5, func() error {
-		o, err := objService.Get(d.bucket, d.pathToKey(path)).Do()
-		obj = o
-		return err
-	})
-	//	obj, err := retry(5, objService.Get(d.bucket, d.pathToKey(path)).Do)
-	if err != nil {
-		return 0, err
-	}
-
-	// cannot append more chunks, so redo from scratch
-	if obj.ComponentCount >= 1023 {
-		return d.writeCompletely(context, path, offset, reader)
-	}
-
-	// skip from reader
-	objSize := int64(obj.Size)
-	nn, err := skip(reader, objSize-offset)
-	if err != nil {
-		return nn, err
-	}
-
-	// Size <= offset
-	partName := fmt.Sprintf("%v#part-%d#", d.pathToKey(path), obj.ComponentCount)
-	gcsContext := d.context(context)
-	wc := storage.NewWriter(gcsContext, d.bucket, partName)
-	wc.ContentType = "application/octet-stream"
-
-	if objSize < offset {
-		err = writeZeros(wc, offset-objSize)
+	var s *uploadSession
+	if offset > 0 {
+		s, err = d.getUploadSession(context, path)
 		if err != nil {
-			wc.CloseWithError(err)
-			return nn, err
+			return 0, err
 		}
 	}
-	n, err := io.Copy(wc, reader)
-	if err != nil {
-		wc.CloseWithError(err)
-		return nn, err
-	}
-	err = wc.Close()
-	if err != nil {
-		return nn, err
-	}
-	// wc was closed succesfully, so the temporary part exists, schedule it for deletion at the end
-	// of the function
-	defer storageDeleteObject(gcsContext, d.bucket, partName)
-
-	req := &storageapi.ComposeRequest{
-		Destination: &storageapi.Object{Bucket: obj.Bucket, Name: obj.Name, ContentType: obj.ContentType},
-		SourceObjects: []*storageapi.ComposeRequestSourceObjects{
-			{
-				Name:       obj.Name,
-				Generation: obj.Generation,
-			}, {
-				Name:       partName,
-				Generation: wc.Object().Generation,
-			}},
+	if s == nil {
+		s = d.newUploadSession(path)
 	}
 
-	err = retry(5, func() error { _, err := objService.Compose(d.bucket, obj.Name, req).Do(); return err })
-	if err == nil {
-		nn = nn + n
+	overlap := s.length() - offset
+	if overlap > 0 {
+		totalRead, err = io.Copy(ioutil.Discard, io.LimitReader(reader, overlap))
+		if err != nil {
+			return totalRead, err
+		}
+		offset += totalRead
 	}
 
-	return nn, err
+	chunk := make([]byte, maxChunkSize)
+	more := true
+	for more {
+		copy(chunk, s.buffer)
+		start := len(s.buffer)
+		// add zeros if offset is larger than the current size of the file
+		if offset > s.length() {
+			count := len(chunk)
+			diff := offset - s.length()
+			if diff < int64(count) {
+				count = int(diff)
+			}
+			for i := 0; i < count; i++ {
+				chunk[start] = 0
+				start++
+			}
+		}
+
+		n, err := reader.Read(chunk[start:])
+		if err == io.EOF {
+			more = false
+		} else if err != nil {
+			return totalRead, err
+		}
+		remainder := (start + n) % minChunkSize
+		chunkSize := start + n - remainder
+		if chunkSize > 0 {
+			if s.sessionURI == "" {
+				s.sessionURI, err = startSession(d.client, d.bucket, s.name)
+				if err != nil {
+					return totalRead, err
+				}
+			}
+			nn, err := putChunk(d.client, s.sessionURI, chunk[0:chunkSize], s.offset, -1)
+			// TODO handle nn != int64(chunkSize) case better
+			if err != nil || nn != int64(chunkSize) {
+				return totalRead, err
+			}
+			s.offset += nn
+		}
+		s.buffer = s.buffer[:remainder]
+		copy(s.buffer, chunk[chunkSize:chunkSize+remainder])
+		err = d.updateUploadSession(context, s)
+		if err != nil {
+			return totalRead, err
+		}
+		totalRead += int64(n)
+		offset += int64(n)
+	}
+	return totalRead, nil
 }
 
 type request func() error
@@ -337,64 +378,59 @@ func retry(maxTries int, req request) error {
 	return err
 }
 
-func (d *driver) writeCompletely(context ctx.Context, path string, offset int64, reader io.Reader) (totalRead int64, err error) {
-	wc := storage.NewWriter(d.context(context), d.bucket, d.pathToKey(path))
-	wc.ContentType = "application/octet-stream"
+func (d *driver) getUploadSession(context ctx.Context, path string) (*uploadSession, error) {
+	s, rc, err := d.readFile(context, path, 0)
+	if err != nil {
+		return nil, err
+	}
+	if rc != nil {
+		rc.Close()
+		return nil, nil
+	}
+	return s, nil
+}
+
+func (d *driver) updateUploadSession(context ctx.Context, s *uploadSession) error {
+	wc := storage.NewWriter(d.context(context), d.bucket, s.name)
+	wc.ContentType = uploadSessionContentType
+	wc.Metadata = map[string]string{
+		"Session-URI": s.sessionURI,
+		"Offset":      fmt.Sprintf("%v", s.offset),
+	}
 	defer wc.Close()
-
-	// Copy the first offset bytes of the existing contents
-	// (padded with zeros if needed) into the writer
-	if offset > 0 {
-		existing, err := d.ReadStream(context, path, 0)
-		if err != nil {
-			return 0, err
-		}
-		defer existing.Close()
-		n, err := io.CopyN(wc, existing, offset)
-		if err == io.EOF {
-			err = writeZeros(wc, offset-n)
-		}
-		if err != nil {
-			return 0, err
-		}
-	}
-	return io.Copy(wc, reader)
+	_, err := wc.Write(s.buffer)
+	return err
 }
 
-func skip(reader io.Reader, count int64) (int64, error) {
-	if count <= 0 {
-		return 0, nil
+func (d *driver) endUploadSession(context ctx.Context, s *uploadSession) error {
+	// no session started yet just perform a simple upload
+	if s.sessionURI == "" {
+		return d.PutContent(context, d.keyToPath(s.name), s.buffer)
 	}
-	return io.CopyN(ioutil.Discard, reader, count)
-}
-
-func writeZeros(wc io.Writer, count int64) error {
-	buf := make([]byte, 32*1024)
-	for count > 0 {
-		size := cap(buf)
-		if int64(size) > count {
-			size = int(count)
-		}
-		n, err := wc.Write(buf[0:size])
-		if err != nil {
-			return err
-		}
-		count = count - int64(n)
-	}
-	return nil
+	_, err := putChunk(d.client, s.sessionURI, s.buffer, s.offset, s.length())
+	return err
 }
 
 // Stat retrieves the FileInfo for the given path, including the current
 // size in bytes and the creation time.
 func (d *driver) Stat(context ctx.Context, path string) (storagedriver.FileInfo, error) {
+
 	var fi storagedriver.FileInfoFields
 	//try to get as file
 	gcsContext := d.context(context)
 	obj, err := storageStatObject(gcsContext, d.bucket, d.pathToKey(path))
 	if err == nil {
+		size := obj.Size
+		if obj.ContentType == uploadSessionContentType {
+			offset, err := strconv.ParseInt(obj.Metadata["Offset"], 0, 64)
+			if err != nil {
+				return nil, err
+			}
+			size = size + offset
+		}
 		fi = storagedriver.FileInfoFields{
 			Path:    path,
-			Size:    obj.Size,
+			Size:    size,
 			ModTime: obj.Updated,
 			IsDir:   false,
 		}
@@ -445,12 +481,7 @@ func (d *driver) List(context ctx.Context, path string) ([]string, error) {
 			// DELETE and LIST operationsCheck that the object is not deleted,
 			// so filter out any objects with a non-zero time-deleted
 			if object.Deleted.IsZero() {
-				name := object.Name
-				// Ignore objects with names that end with '#' (these are uploaded parts)
-				if name[len(name)-1] != '#' {
-					name = d.keyToPath(name)
-					list = append(list, name)
-				}
+				list = append(list, d.keyToPath(object.Name))
 			}
 		}
 		for _, subpath := range objects.Prefixes {
@@ -475,7 +506,7 @@ func (d *driver) List(context ctx.Context, path string) ([]string, error) {
 func (d *driver) Move(context ctx.Context, sourcePath string, destPath string) error {
 	prefix := d.pathToDirKey(sourcePath)
 	gcsContext := d.context(context)
-	keys, err := d.listAll(gcsContext, prefix)
+	keys, err := d.listAll(gcsContext, prefix, true)
 	if err != nil {
 		return err
 	}
@@ -509,9 +540,14 @@ func (d *driver) Move(context ctx.Context, sourcePath string, destPath string) e
 		}
 		return err
 	}
+	rc, err := d.ReadStream(context, sourcePath, 0)
+	if err != nil {
+		return err
+	}
+	rc.Close()
 	_, err = storageCopyObject(gcsContext, d.bucket, d.pathToKey(sourcePath), d.bucket, d.pathToKey(destPath), nil)
 	if err != nil {
-		if status := err.(*googleapi.Error); status != nil {
+		if status, ok := err.(*googleapi.Error); ok {
 			if status.Code == http.StatusNotFound {
 				return storagedriver.PathNotFoundError{Path: sourcePath}
 			}
@@ -522,7 +558,7 @@ func (d *driver) Move(context ctx.Context, sourcePath string, destPath string) e
 }
 
 // listAll recursively lists all names of objects stored at "prefix" and its subpaths.
-func (d *driver) listAll(context context.Context, prefix string) ([]string, error) {
+func (d *driver) listAll(context context.Context, prefix string, finishUploads bool) ([]string, error) {
 	list := make([]string, 0, 64)
 	query := &storage.Query{}
 	query.Prefix = prefix
@@ -538,6 +574,13 @@ func (d *driver) listAll(context context.Context, prefix string) ([]string, erro
 			// so filter out any objects with a non-zero time-deleted
 			if obj.Deleted.IsZero() {
 				list = append(list, obj.Name)
+				if finishUploads && obj.ContentType == uploadSessionContentType {
+					rc, err := d.ReadStream(context, d.keyToPath(obj.Name), 0)
+					if err != nil {
+						return nil, err
+					}
+					rc.Close()
+				}
 			}
 		}
 		query = objects.Next
@@ -552,7 +595,7 @@ func (d *driver) listAll(context context.Context, prefix string) ([]string, erro
 func (d *driver) Delete(context ctx.Context, path string) error {
 	prefix := d.pathToDirKey(path)
 	gcsContext := d.context(context)
-	keys, err := d.listAll(gcsContext, prefix)
+	keys, err := d.listAll(gcsContext, prefix, false)
 	if err != nil {
 		return err
 	}
@@ -576,7 +619,7 @@ func (d *driver) Delete(context ctx.Context, path string) error {
 	}
 	err = storageDeleteObject(gcsContext, d.bucket, d.pathToKey(path))
 	if err != nil {
-		if status := err.(*googleapi.Error); status != nil {
+		if status, ok := err.(*googleapi.Error); ok {
 			if status.Code == http.StatusNotFound {
 				return storagedriver.PathNotFoundError{Path: path}
 			}
@@ -655,6 +698,92 @@ func (d *driver) URLFor(context ctx.Context, path string, options map[string]int
 		Expires:        expiresTime,
 	}
 	return storage.SignedURL(d.bucket, name, opts)
+}
+
+func (d *driver) newUploadSession(path string) *uploadSession {
+	return &uploadSession{
+		name:   d.pathToKey(path),
+		buffer: make([]byte, 0, minChunkSize-1),
+		offset: 0,
+	}
+}
+
+func (s *uploadSession) length() int64 {
+	return s.offset + int64(len(s.buffer))
+}
+
+func startSession(client *http.Client, bucket string, name string) (uri string, err error) {
+	u := &url.URL{
+		Scheme:   "https",
+		Host:     "www.googleapis.com",
+		Path:     fmt.Sprintf("/upload/storage/v1/b/%v/o", bucket),
+		RawQuery: fmt.Sprintf("uploadType=resumable&name=%v", name),
+	}
+	err = retry(5, func() error {
+		req, err := http.NewRequest("POST", u.String(), nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("X-Upload-Content-Type", "application/octet-stream")
+		req.Header.Set("Content-Length", "0")
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		err = googleapi.CheckMediaResponse(resp)
+		if err != nil {
+			return err
+		}
+		uri = resp.Header.Get("Location")
+		return nil
+	})
+	return uri, err
+}
+
+func putChunk(client *http.Client, sessionURI string, chunk []byte, from int64, totalSize int64) (int64, error) {
+	bytesPut := int64(0)
+	err := retry(5, func() error {
+		req, err := http.NewRequest("PUT", sessionURI, bytes.NewReader(chunk))
+		if err != nil {
+			return err
+		}
+		length := int64(len(chunk))
+		to := from + length - 1
+		size := "*"
+		if totalSize >= 0 {
+			size = fmt.Sprintf("%v", totalSize)
+		}
+		req.Header.Set("Content-Type", "application/octet-stream")
+		if from == to+1 {
+			req.Header.Set("Content-Range", fmt.Sprintf("bytes */%v", size))
+		} else {
+			req.Header.Set("Content-Range", fmt.Sprintf("bytes %v-%v/%v", from, to, size))
+		}
+		req.Header.Set("Content-Length", fmt.Sprintf("%v", length))
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if totalSize < 0 && resp.StatusCode == 308 {
+			groups := rangeHeader.FindStringSubmatch(resp.Header.Get("Range"))
+			end, err := strconv.ParseInt(groups[2], 10, 64)
+			if err != nil {
+				return err
+			}
+			bytesPut = end - from + 1
+			return nil
+		}
+		err = googleapi.CheckMediaResponse(resp)
+		if err != nil {
+			return err
+		}
+		bytesPut = to - from + 1
+		return nil
+	})
+	return bytesPut, err
 }
 
 func (d *driver) context(context ctx.Context) context.Context {

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -222,6 +222,10 @@ func (d *driver) ReadStream(context ctx.Context, path string, offset int64) (io.
 	return res.Body, nil
 }
 
+func (d *driver) CloseWriteStream(context ctx.Context, path string) error {
+	return nil
+}
+
 // WriteStream stores the contents of the provided io.ReadCloser at a
 // location designated by the given path.
 // May be used to resume writing a stream by providing a nonzero offset.

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -167,6 +167,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return nn, err
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat returns info about the provided path.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
 	d.mutex.RLock()

--- a/registry/storage/driver/oss/oss.go
+++ b/registry/storage/driver/oss/oss.go
@@ -590,6 +590,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return totalRead, nil
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/rados/rados.go
+++ b/registry/storage/driver/rados/rados.go
@@ -356,6 +356,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return totalRead, nil
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
 	// get oid from filename

--- a/registry/storage/driver/s3/s3.go
+++ b/registry/storage/driver/s3/s3.go
@@ -632,6 +632,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return totalRead, nil
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -60,6 +60,10 @@ type StorageDriver interface {
 	// The offset must be no larger than the CurrentSize for this path.
 	WriteStream(ctx context.Context, path string, offset int64, reader io.Reader) (nn int64, err error)
 
+	// CloseWriteStream is invoked after the last chunk of an upload has been written by
+	// WriteStream
+	CloseWriteStream(ctx context.Context, path string) error
+
 	// Stat retrieves the FileInfo for the given path, including the current
 	// size in bytes and the creation time.
 	Stat(ctx context.Context, path string) (FileInfo, error)

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -525,6 +525,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return bytesRead, err
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -286,6 +286,9 @@ func (suite *DriverSuite) TestWriteReadLargeStreams(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(written, check.Equals, fileSize)
 
+	err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
+
 	reader, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 	c.Assert(err, check.IsNil)
 	defer reader.Close()
@@ -448,6 +451,9 @@ func (suite *DriverSuite) testContinueStreamAppend(c *check.C, chunkSize int64) 
 	c.Assert(err, check.IsNil)
 	c.Assert(fi, check.NotNil)
 	c.Assert(fi.Size(), check.Equals, int64(len(fullContents)))
+
+	err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
 
 	received, err := suite.StorageDriver.GetContent(suite.ctx, filename)
 	c.Assert(err, check.IsNil)
@@ -880,7 +886,7 @@ func (suite *DriverSuite) TestConcurrentFileStreams(c *check.C) {
 
 // TestEventualConsistency checks that stat reports the right file size, after
 // appending a chunk to the file, and that the contents of the file can be read after
-// calling CloseStream (these are the only guarantees that the driver needs to provide)
+// calling CloseWriteStream (these are the only guarantees that the driver needs to provide)
 func (suite *DriverSuite) TestEventualConsistency(c *check.C) {
 	if testing.Short() {
 		c.Skip("Skipping test in short mode")
@@ -910,6 +916,9 @@ func (suite *DriverSuite) TestEventualConsistency(c *check.C) {
 		c.Log("There were " + string(misswrites) + " occurences of a write not being instantly available.")
 	}
 	c.Assert(misswrites, check.Not(check.Equals), 1024)
+
+	err := suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
 
 	reader, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 	c.Assert(err, check.IsNil)
@@ -992,6 +1001,9 @@ func (suite *DriverSuite) benchmarkStreamFiles(c *check.C, size int64) {
 		written, err := suite.StorageDriver.WriteStream(suite.ctx, filename, 0, bytes.NewReader(randomContents(size)))
 		c.Assert(err, check.IsNil)
 		c.Assert(written, check.Equals, size)
+
+		err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+		c.Assert(err, check.IsNil)
 
 		rc, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 		c.Assert(err, check.IsNil)
@@ -1078,6 +1090,9 @@ func (suite *DriverSuite) testFileStreams(c *check.C, size int64) {
 	c.Assert(err, check.IsNil)
 	c.Assert(nn, check.Equals, size)
 
+	err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
+
 	reader, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 	c.Assert(err, check.IsNil)
 	defer reader.Close()
@@ -1106,6 +1121,9 @@ func (suite *DriverSuite) writeReadCompareStreams(c *check.C, filename string, c
 	nn, err := suite.StorageDriver.WriteStream(suite.ctx, filename, 0, bytes.NewReader(contents))
 	c.Assert(err, check.IsNil)
 	c.Assert(nn, check.Equals, int64(len(contents)))
+
+	err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
 
 	reader, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 	c.Assert(err, check.IsNil)

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -432,10 +432,6 @@ func (suite *DriverSuite) testContinueStreamAppend(c *check.C, chunkSize int64) 
 	c.Assert(err, check.IsNil)
 	c.Assert(nn, check.Equals, int64(len(fullContents[fi.Size():])))
 
-	received, err := suite.StorageDriver.GetContent(suite.ctx, filename)
-	c.Assert(err, check.IsNil)
-	c.Assert(received, check.DeepEquals, fullContents)
-
 	// Writing past size of file extends file (no offset error). We would like
 	// to write chunk 4 one chunk length past chunk 3. It should be successful
 	// and the resulting file will be 5 chunks long, with a chunk of all
@@ -453,7 +449,7 @@ func (suite *DriverSuite) testContinueStreamAppend(c *check.C, chunkSize int64) 
 	c.Assert(fi, check.NotNil)
 	c.Assert(fi.Size(), check.Equals, int64(len(fullContents)))
 
-	received, err = suite.StorageDriver.GetContent(suite.ctx, filename)
+	received, err := suite.StorageDriver.GetContent(suite.ctx, filename)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(received), check.Equals, len(fullContents))
 	c.Assert(received[chunkSize*3:chunkSize*4], check.DeepEquals, zeroChunk)

--- a/registry/storage/filewriter.go
+++ b/registry/storage/filewriter.go
@@ -176,7 +176,8 @@ func (fw *fileWriter) Close() error {
 		return fw.err
 	}
 
+	err := fw.driver.CloseWriteStream(fw.ctx, fw.path)
 	fw.err = fmt.Errorf("filewriter@%v: closed", fw.path)
 
-	return nil
+	return err
 }

--- a/registry/storage/filewriter.go
+++ b/registry/storage/filewriter.go
@@ -157,6 +157,8 @@ func (fw *fileWriter) Seek(offset int64, whence int) (int64, error) {
 
 	if newOffset < 0 {
 		err = fmt.Errorf("cannot seek to negative position")
+	} else if newOffset > fw.size {
+		err = fmt.Errorf("cannot seek beyond the end of the file")
 	} else {
 		// No problems, set the offset.
 		fw.offset = newOffset


### PR DESCRIPTION
This PR changes the implementation of WriteStream to use [Google's resumable upload api](https://cloud.google.com/storage/docs/json_api/v1/how-tos/upload#resumable) instead of using the compose operator to join parts of uploaded content. The problem with using the compose operation is that this operation has several limitations:
* Only 1024 parts can be joined, requiring a full rewrite (ie download and upload) of a file if that limit is exceeded
* The operation is rate-limited (at most 1 operation every 1 or 2 seconds), requiring lots of back-off and retries if things get a bit busy.

The Resumable upload api has some limitations:
* The size of each chunk (except the last) must be a multiple of 256KB, this is taken care of in the driver
* The contents of an incomplete upload are not available for download
* An upload session must be explicitly closed. After closing  the uploaded contents become available, and no further contents can be appended

The second point required some small changes to the test suite, as it assume in two places that partial data is available for download. The third point is a bit of a problem as there is  (as far as I know) no way of telling whether a particular call to WriteStream is the last. This is solved by adding a new function CloseStream to the storage driver interface.

@stevvooe @RichardScothern 