### PR TITLE
GCS Storagedriver: fix test failure caused by #1187

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -461,6 +461,11 @@ func (d *driver) List(context ctx.Context, path string) ([]string, error) {
 			break
 		}
 	}
+	if path != "/" && len(list) == 0 {
+		// Treat empty response as missing directory, since we don't actually
+		// have directories in Google Cloud Storage.
+		return nil, storagedriver.PathNotFoundError{Path: path}
+	}
 	return list, nil
 }
 


### PR DESCRIPTION
This PR fixes a test failure due to an added test case. 

@stevvooe @RichardScothern 