### PR TITLE
Rev base version to 2.2.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,4 +8,4 @@ var Package = "github.com/docker/distribution"
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "v2.1.0+unknown"
+var Version = "v2.2.1+unknown"


### PR DESCRIPTION
Now that there's an official 2.2.1 release we can say all builds are
"2.2.1+unknown" if the Makefile is not used.