### PR TITLE
Change the parameters to the GCS drivers to allow CircleCI testing.

### DIFF
--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -3,17 +3,18 @@
 package gcs
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 
-	"google.golang.org/api/googleapi"
-
+	"fmt"
 	ctx "github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/testsuites"
-
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/cloud/storage"
 	"gopkg.in/check.v1"
 )
 
@@ -25,8 +26,19 @@ var skipGCS func() string
 
 func init() {
 	bucket := os.Getenv("REGISTRY_STORAGE_GCS_BUCKET")
-	keyfile := os.Getenv("REGISTRY_STORAGE_GCS_KEYFILE")
 	credentials := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+
+	// Skip GCS storage driver tests if environment variable parameters are not provided
+	skipGCS = func() string {
+		if bucket == "" || credentials == "" {
+			return "The following environment variables must be set to enable these tests: REGISTRY_STORAGE_GCS_BUCKET, REGISTRY_STORAGE_GCS_CREDS"
+		}
+		return ""
+	}
+
+	if skipGCS() != "" {
+		return
+	}
 
 	root, err := ioutil.TempDir("", "driver-")
 	if err != nil {
@@ -34,23 +46,32 @@ func init() {
 	}
 	defer os.Remove(root)
 
-	gcsDriverConstructor = func(rootDirectory string) (storagedriver.StorageDriver, error) {
+	_, err = os.Stat(credentials)
+	if err == nil {
+		jsonKey, err := ioutil.ReadFile(credentials)
+		if err != nil {
+			panic(fmt.Sprintf("Unable to read credentials from file : %s", err))
+		}
+		credentials = string(jsonKey)
+	}
 
+	// Assume that the file contents are within the environment variable since it exists
+	// but does not contain a valid file path
+	jwtConfig, err := google.JWTConfigFromJSON([]byte(credentials), storage.ScopeFullControl)
+	if err != nil {
+		panic(fmt.Sprintf("Error reading JWT config : %s", err))
+	}
+
+	gcsDriverConstructor = func(rootDirectory string) (storagedriver.StorageDriver, error) {
 		parameters := driverParameters{
-			bucket,
-			keyfile,
-			rootDirectory,
+			bucket:        bucket,
+			rootDirectory: root,
+			email:         jwtConfig.Email,
+			privateKey:    []byte(jwtConfig.PrivateKey),
+			client:        oauth2.NewClient(ctx.Background(), jwtConfig.TokenSource(ctx.Background())),
 		}
 
 		return New(parameters)
-	}
-
-	// Skip GCS storage driver tests if environment variable parameters are not provided
-	skipGCS = func() string {
-		if bucket == "" || (credentials == "" && keyfile == "") {
-			return "Must set REGISTRY_STORAGE_GCS_BUCKET and (GOOGLE_APPLICATION_CREDENTIALS or REGISTRY_STORAGE_GCS_KEYFILE) to run GCS tests"
-		}
-		return ""
 	}
 
 	testsuites.RegisterSuite(func() (storagedriver.StorageDriver, error) {


### PR DESCRIPTION
Remove the requirement of file system access to run GCS unit tests.  Deconstruct
the input parameters to take the private key and email which can be specified on
the build system via environment variables.

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>