### PR TITLE
Adds functional options arguments to the Blobs Create method, remove Mount operation

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -735,6 +735,25 @@ the uploaded blob which may differ from the provided digest. Most clients may
 ignore the value but if it is used, the client should verify the value against
 the uploaded blob data.
 
+If a mount fails due to invalid repository or digest arguments, the registry
+will fall back to the standard upload behavior and return a `202 Accepted` with
+the upload URL in the `Location` header:
+
+```
+202 Accepted
+Location: /v2/<name>/blobs/uploads/<uuid>
+Range: bytes=0-<offset>
+Content-Length: 0
+Docker-Upload-UUID: <uuid>
+```
+
+This behavior is consistent with older versions of the registry, which do not
+recognize the repository mount query parameters.
+
+Note: a client may issue a HEAD request to check existence of a blob in a source
+repository to distinguish between the registry not supporting blob mounts and
+the blob not existing in the expected repository.
+
 ##### Errors
 
 If an 502, 503 or 504 error is received, the client should assume that the

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -735,6 +735,25 @@ the uploaded blob which may differ from the provided digest. Most clients may
 ignore the value but if it is used, the client should verify the value against
 the uploaded blob data.
 
+If a mount fails due to invalid repository or digest arguments, the registry
+will fall back to the standard upload behavior and return a `202 Accepted` with
+the upload URL in the `Location` header:
+
+```
+202 Accepted
+Location: /v2/<name>/blobs/uploads/<uuid>
+Range: bytes=0-<offset>
+Content-Length: 0
+Docker-Upload-UUID: <uuid>
+```
+
+This behavior is consistent with older versions of the registry, which do not
+recognize the repository mount query parameters.
+
+Note: a client may issue a HEAD request to check existence of a blob in a source
+repository to distinguish between the registry not supporting blob mounts and
+the blob not existing in the expected repository.
+
 ##### Errors
 
 If an 502, 503 or 504 error is received, the client should assume that the

--- a/manifest/schema1/config_builder_test.go
+++ b/manifest/schema1/config_builder_test.go
@@ -42,15 +42,11 @@ func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) 
 	return d, nil
 }
 
-func (bs *mockBlobService) Create(ctx context.Context) (distribution.BlobWriter, error) {
+func (bs *mockBlobService) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
 	panic("not implemented")
 }
 
 func (bs *mockBlobService) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Mount(ctx context.Context, sourceRepo string, dgst digest.Digest) (distribution.Descriptor, error) {
 	panic("not implemented")
 }
 

--- a/manifest/schema2/builder_test.go
+++ b/manifest/schema2/builder_test.go
@@ -38,15 +38,11 @@ func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) 
 	return d, nil
 }
 
-func (bs *mockBlobService) Create(ctx context.Context) (distribution.BlobWriter, error) {
+func (bs *mockBlobService) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
 	panic("not implemented")
 }
 
 func (bs *mockBlobService) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
-	panic("not implemented")
-}
-
-func (bs *mockBlobService) Mount(ctx context.Context, sourceRepo string, dgst digest.Digest) (distribution.Descriptor, error) {
 	panic("not implemented")
 }
 

--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -161,7 +161,7 @@ func (pbs *proxyBlobStore) Put(ctx context.Context, mediaType string, p []byte) 
 	return distribution.Descriptor{}, distribution.ErrUnsupported
 }
 
-func (pbs *proxyBlobStore) Create(ctx context.Context) (distribution.BlobWriter, error) {
+func (pbs *proxyBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
 	return nil, distribution.ErrUnsupported
 }
 

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -42,12 +42,12 @@ func (sbs statsBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, 
 	return sbs.blobs.Get(ctx, dgst)
 }
 
-func (sbs statsBlobStore) Create(ctx context.Context) (distribution.BlobWriter, error) {
+func (sbs statsBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
 	sbsMu.Lock()
 	sbs.stats["create"]++
 	sbsMu.Unlock()
 
-	return sbs.blobs.Create(ctx)
+	return sbs.blobs.Create(ctx, options...)
 }
 
 func (sbs statsBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
@@ -56,14 +56,6 @@ func (sbs statsBlobStore) Resume(ctx context.Context, id string) (distribution.B
 	sbsMu.Unlock()
 
 	return sbs.blobs.Resume(ctx, id)
-}
-
-func (sbs statsBlobStore) Mount(ctx context.Context, sourceRepo string, dgst digest.Digest) (distribution.Descriptor, error) {
-	sbsMu.Lock()
-	sbs.stats["mount"]++
-	sbsMu.Unlock()
-
-	return sbs.blobs.Mount(ctx, sourceRepo, dgst)
 }
 
 func (sbs statsBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {


### PR DESCRIPTION
Removes the Mount operation and instead implements this behavior as part
of Create a From option is provided, which in turn returns a rich
ErrBlobMounted indicating that a blob upload session was not initiated,
but instead the blob was mounted from another repository