### PR TITLE
Fixes error codes in the API spec template

### DIFF
--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -1149,7 +1149,7 @@ The error codes that may be included in the response body are enumerated below:
 
 |Code|Message|Description|
 |----|-------|-----------|
-{{range $err := .ErrorCodes}}| `{{$err}}` | {{$err.Descriptor.Message}} | {{$err.Descriptor.Description|removenewlines}} |
+{{range $err := .ErrorCodes}}| `{{$err.Descriptor.Value}}` | {{$err.Descriptor.Message}} | {{$err.Descriptor.Description|removenewlines}} |
 {{end}}
 
 {{end}}{{end}}{{end}}{{end}}{{end}}{{end}}


### PR DESCRIPTION
Uses UPPER_UNDERSCORE_CASE instead of the nice error message format
added in #911