### PR TITLE
Upgrade CI to go 1.5.3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
 
   post:
   # go
-    - gvm install go1.5 --prefer-binary --name=stable
+    - gvm install go1.5.3 --prefer-binary --name=stable
 
   environment:
   # Convenient shortcuts to "common" locations


### PR DESCRIPTION
Go 1.5.0 has some stack pointer bugs. This may have been causing some CI
failures. Upgrade to a newer version.