### PR TITLE
Fixes cross-repo blob mounting in the BlobUploadHandler

### DIFF
--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -127,7 +127,7 @@ func (buh *blobUploadHandler) StartBlobUpload(w http.ResponseWriter, r *http.Req
 
 	if mountDigest != "" && fromRepo != "" {
 		opt, err := buh.createBlobMountOption(fromRepo, mountDigest)
-		if err != nil {
+		if opt != nil && err == nil {
 			options = append(options, opt)
 		}
 	}


### PR DESCRIPTION
Accidentally checked for err != nil instead of err == nil :/
Also now ensures that only a non-nil option is appended to the create
options slice