### PR TITLE
Storage: remove bufferedFileWriter (dead code)

### DIFF
--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -197,7 +197,7 @@ func (lbs *linkedBlobStore) newBlobUpload(ctx context.Context, uuid, path string
 		id:                     uuid,
 		startedAt:              startedAt,
 		digester:               digest.Canonical.New(),
-		bufferedFileWriter:     *fw,
+		fileWriter:             *fw,
 		resumableDigestEnabled: lbs.resumableDigestEnabled,
 	}
 


### PR DESCRIPTION
A bufferedFileWriter has an underlying fileWriter and a buffered writer that it initialised with a pointer to its fileWriter. When a bufferedFileWriter is copied its underlying fileWriter struct is copied as well. However, the buffered writer will still refer to fileWriter struct of the original bufferedFileWriter.

A bufferedFileWriter is dereferenced here: https://github.com/aibaars/distribution/blob/9f83bfc071094019b942c4332d17327b4dc5cdfc/registry/storage/linkedblobstore.go#L200

@stevvooe @RichardScothern 