### PR TITLE
Splits up blob create options definitions to be package-specific

### DIFF
--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/docker/distribution/registry/storage"
 	"github.com/docker/distribution/testutil"
 	"github.com/docker/distribution/uuid"
 	"github.com/docker/libtrust"
@@ -523,7 +522,7 @@ func TestBlobMount(t *testing.T) {
 
 	l := r.Blobs(ctx)
 
-	bw, err := l.Create(ctx, storage.WithMountFrom(canonicalRef))
+	bw, err := l.Create(ctx, WithMountFrom(canonicalRef))
 	if bw != nil {
 		t.Fatalf("Expected blob writer to be nil, was %v", bw)
 	}

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -97,9 +97,9 @@ func (lbs *linkedBlobStore) Put(ctx context.Context, mediaType string, p []byte)
 	return desc, lbs.linkBlob(ctx, desc)
 }
 
-// CreateOptions is a collection of blob creation modifiers relevant to general
+// createOptions is a collection of blob creation modifiers relevant to general
 // blob storage intended to be configured by the BlobCreateOption.Apply method.
-type CreateOptions struct {
+type createOptions struct {
 	Mount struct {
 		ShouldMount bool
 		From        reference.Canonical
@@ -116,7 +116,7 @@ func (f optionFunc) Apply(v interface{}) error {
 // mounted from the given canonical reference.
 func WithMountFrom(ref reference.Canonical) distribution.BlobCreateOption {
 	return optionFunc(func(v interface{}) error {
-		opts, ok := v.(*CreateOptions)
+		opts, ok := v.(*createOptions)
 		if !ok {
 			return fmt.Errorf("unexpected options type: %T", v)
 		}
@@ -132,7 +132,7 @@ func WithMountFrom(ref reference.Canonical) distribution.BlobCreateOption {
 func (lbs *linkedBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
 	context.GetLogger(ctx).Debug("(*linkedBlobStore).Writer")
 
-	var opts CreateOptions
+	var opts createOptions
 
 	for _, option := range options {
 		err := option.Apply(&opts)


### PR DESCRIPTION
Redefines privately in both storage and client packages

Signed-off-by: Brian Bland <brian.bland@docker.com>