### PR TITLE
Use Go 1.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.2
+FROM golang:1.5.3
 
 RUN apt-get update && \
     apt-get install -y librados-dev apache2-utils && \


### PR DESCRIPTION
Updates Dockerfile to Go 1.5.3 base image.