### PR TITLE
In testsuites.go, enlarge the size of randomBytes to 128M to fix the …

### DIFF
--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -1144,7 +1144,7 @@ func randomFilename(length int64) string {
 
 // randomBytes pre-allocates all of the memory sizes needed for the test. If
 // anything panics while accessing randomBytes, just make this number bigger.
-var randomBytes = make([]byte, 96<<20)
+var randomBytes = make([]byte, 128<<20)
 
 func init() {
 	// increase the random bytes to the required maximum


### PR DESCRIPTION
…crash of running TestConcurrentStreamReads

Signed-off-by: yuzou <zouyu7@huawei.com>