### PR TITLE
Fix content type for schema1 signed manifests

### DIFF
--- a/manifest/schema1/manifest.go
+++ b/manifest/schema1/manifest.go
@@ -39,11 +39,11 @@ func init() {
 		desc := distribution.Descriptor{
 			Digest:    digest.FromBytes(sm.Canonical),
 			Size:      int64(len(sm.Canonical)),
-			MediaType: MediaTypeManifest,
+			MediaType: MediaTypeSignedManifest,
 		}
 		return sm, desc, err
 	}
-	err := distribution.RegisterManifestSchema(MediaTypeManifest, schema1Func)
+	err := distribution.RegisterManifestSchema(MediaTypeSignedManifest, schema1Func)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to register manifest: %s", err))
 	}
@@ -167,7 +167,7 @@ func (sm *SignedManifest) MarshalJSON() ([]byte, error) {
 
 // Payload returns the signed content of the signed manifest.
 func (sm SignedManifest) Payload() (string, []byte, error) {
-	return MediaTypeManifest, sm.all, nil
+	return MediaTypeSignedManifest, sm.all, nil
 }
 
 // Signatures returns the signatures as provided by

--- a/notifications/event_test.go
+++ b/notifications/event_test.go
@@ -21,7 +21,7 @@ func TestEventEnvelopeJSONFormat(t *testing.T) {
          "timestamp": "2006-01-02T15:04:05Z",
          "action": "push",
          "target": {
-            "mediaType": "application/vnd.docker.distribution.manifest.v1+json",
+            "mediaType": "application/vnd.docker.distribution.manifest.v1+prettyjws",
             "size": 1,
             "digest": "sha256:0123456789abcdef0",
             "length": 1,
@@ -120,7 +120,7 @@ func TestEventEnvelopeJSONFormat(t *testing.T) {
 	manifestPush.Target.Digest = "sha256:0123456789abcdef0"
 	manifestPush.Target.Length = 1
 	manifestPush.Target.Size = 1
-	manifestPush.Target.MediaType = schema1.MediaTypeManifest
+	manifestPush.Target.MediaType = schema1.MediaTypeSignedManifest
 	manifestPush.Target.Repository = "library/test"
 	manifestPush.Target.URL = "http://example.com/v2/library/test/manifests/latest"
 

--- a/notifications/http_test.go
+++ b/notifications/http_test.go
@@ -75,12 +75,12 @@ func TestHTTPSink(t *testing.T) {
 		{
 			statusCode: http.StatusOK,
 			events: []Event{
-				createTestEvent("push", "library/test", schema1.MediaTypeManifest)},
+				createTestEvent("push", "library/test", schema1.MediaTypeSignedManifest)},
 		},
 		{
 			statusCode: http.StatusOK,
 			events: []Event{
-				createTestEvent("push", "library/test", schema1.MediaTypeManifest),
+				createTestEvent("push", "library/test", schema1.MediaTypeSignedManifest),
 				createTestEvent("push", "library/test", layerMediaType),
 				createTestEvent("push", "library/test", layerMediaType),
 			},

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -592,7 +592,7 @@ func addTestManifestWithEtag(repo, reference string, content []byte, m *testutil
 			Headers: http.Header(map[string][]string{
 				"Content-Length": {"0"},
 				"Last-Modified":  {time.Now().Add(-1 * time.Second).Format(time.ANSIC)},
-				"Content-Type":   {schema1.MediaTypeManifest},
+				"Content-Type":   {schema1.MediaTypeSignedManifest},
 			}),
 		}
 	} else {
@@ -602,7 +602,7 @@ func addTestManifestWithEtag(repo, reference string, content []byte, m *testutil
 			Headers: http.Header(map[string][]string{
 				"Content-Length": {fmt.Sprint(len(content))},
 				"Last-Modified":  {time.Now().Add(-1 * time.Second).Format(time.ANSIC)},
-				"Content-Type":   {schema1.MediaTypeManifest},
+				"Content-Type":   {schema1.MediaTypeSignedManifest},
 			}),
 		}
 
@@ -622,7 +622,7 @@ func addTestManifest(repo, reference string, content []byte, m *testutil.Request
 			Headers: http.Header(map[string][]string{
 				"Content-Length": {fmt.Sprint(len(content))},
 				"Last-Modified":  {time.Now().Add(-1 * time.Second).Format(time.ANSIC)},
-				"Content-Type":   {schema1.MediaTypeManifest},
+				"Content-Type":   {schema1.MediaTypeSignedManifest},
 			}),
 		},
 	})
@@ -636,7 +636,7 @@ func addTestManifest(repo, reference string, content []byte, m *testutil.Request
 			Headers: http.Header(map[string][]string{
 				"Content-Length": {fmt.Sprint(len(content))},
 				"Last-Modified":  {time.Now().Add(-1 * time.Second).Format(time.ANSIC)},
-				"Content-Type":   {schema1.MediaTypeManifest},
+				"Content-Type":   {schema1.MediaTypeSignedManifest},
 			}),
 		},
 	})

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -957,7 +957,7 @@ func testManifestAPISchema1(t *testing.T, env *testEnv, imageName string) manife
 	// Re-push with a few different Content-Types. The official schema1
 	// content type should work, as should application/json with/without a
 	// charset.
-	resp = putManifest(t, "re-putting signed manifest", manifestDigestURL, schema1.MediaTypeManifest, sm2)
+	resp = putManifest(t, "re-putting signed manifest", manifestDigestURL, schema1.MediaTypeSignedManifest, sm2)
 	checkResponse(t, "re-putting signed manifest", resp, http.StatusCreated)
 	resp = putManifest(t, "re-putting signed manifest", manifestDigestURL, "application/json; charset=utf-8", sm2)
 	checkResponse(t, "re-putting signed manifest", resp, http.StatusCreated)
@@ -1486,7 +1486,7 @@ func testManifestAPIManifestList(t *testing.T, env *testEnv, args manifestArgs) 
 		t.Fatalf("Error constructing request: %s", err)
 	}
 	req.Header.Set("Accept", manifestlist.MediaTypeManifestList)
-	req.Header.Add("Accept", schema1.MediaTypeManifest)
+	req.Header.Add("Accept", schema1.MediaTypeSignedManifest)
 	req.Header.Add("Accept", schema2.MediaTypeManifest)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
The Payload function for schema1 currently returns a signed manifest,
but indicates the content type is that of a manifest that isn't signed.

Note that this breaks compatibility with Registry 2.3 alpha 1 and
Docker 1.10-rc1, because they use the incorrect content type.