### PR TITLE
StorageDriver GCS: improve test suite clean-up and add retrying to all GCS api calls

### DIFF
--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -155,8 +155,12 @@ func TestEmptyRootList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating content: %v", err)
 	}
-	defer rootedDriver.Delete(ctx, filename)
-
+	defer func() {
+		err := rootedDriver.Delete(ctx, filename)
+		if err != nil {
+			t.Fatalf("failed to remove %v due to %v\n", filename, err)
+		}
+	}()
 	keys, err := emptyRootDriver.List(ctx, "/")
 	for _, path := range keys {
 		if !storagedriver.PathRegexp.MatchString(path) {


### PR DESCRIPTION
This PR is a followup on #1366. While #1366 solves issues where the results of the List call after a Delete operation is inconsistently reporting that some files still exist, it does not handle the case where the Delete operation itself does not delete files that were just created (due to "eventual consistency").

In addition this PR changes the test suite to report errors occurring during cleanup instead of silently continuing and panicking with a generic message later. This makes it much easier to figure out why a file was not deleted.  

In fact sometimes files were not deleted due the the Google API returning 5XX status codes. In such cases the operation can simply be retried and usually succeeds the next time.  To solve this, this PR automatically retries all storage API requests.

@RichardScothern 
