### PR TITLE
Use mime package to parse media type

### DIFF
--- a/manifests.go
+++ b/manifests.go
@@ -2,7 +2,7 @@ package distribution
 
 import (
 	"fmt"
-	"strings"
+	"mime"
 
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
@@ -82,14 +82,15 @@ var mappings = make(map[string]UnmarshalFunc, 0)
 // UnmarshalManifest looks up manifest unmarshall functions based on
 // MediaType
 func UnmarshalManifest(ctHeader string, p []byte) (Manifest, Descriptor, error) {
-	// Need to look up by the actual content type, not the raw contents of
+	// Need to look up by the actual media type, not the raw contents of
 	// the header. Strip semicolons and anything following them.
 	var mediatype string
-	semicolonIndex := strings.Index(ctHeader, ";")
-	if semicolonIndex != -1 {
-		mediatype = ctHeader[:semicolonIndex]
-	} else {
-		mediatype = ctHeader
+	if ctHeader != "" {
+		var err error
+		mediatype, _, err = mime.ParseMediaType(ctHeader)
+		if err != nil {
+			return nil, Descriptor{}, err
+		}
 	}
 
 	unmarshalFunc, ok := mappings[mediatype]


### PR DESCRIPTION
This replaces custom parsing with the standard library's mime package.
This is simpler and more correct.