### PR TITLE
Ensure the canonical manifest digest and length are sent to notification endpoints.

### DIFF
--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -103,10 +103,16 @@ func (b *bridge) createManifestEvent(action string, repo string, sm distribution
 		return nil, err
 	}
 
+	// Ensure we have the canonical manifest descriptor here
+	_, desc, err := distribution.UnmarshalManifest(mt, p)
+	if err != nil {
+		return nil, err
+	}
+
 	event.Target.MediaType = mt
-	event.Target.Length = int64(len(p))
-	event.Target.Size = int64(len(p))
-	event.Target.Digest = digest.FromBytes(p)
+	event.Target.Length = desc.Size
+	event.Target.Size = desc.Size
+	event.Target.Digest = desc.Digest
 
 	event.Target.URL, err = b.ub.BuildManifestURL(repo, event.Target.Digest.String())
 	if err != nil {

--- a/notifications/bridge_test.go
+++ b/notifications/bridge_test.go
@@ -4,13 +4,10 @@ import (
 	"testing"
 
 	"github.com/docker/distribution/digest"
-
-	"github.com/docker/libtrust"
-
 	"github.com/docker/distribution/manifest/schema1"
-
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/uuid"
+	"github.com/docker/libtrust"
 )
 
 var (
@@ -85,11 +82,7 @@ func createTestEnv(t *testing.T, fn testSinkFn) Listener {
 		t.Fatalf("error signing manifest: %v", err)
 	}
 
-	_, payload, err = sm.Payload()
-	if err != nil {
-		t.Fatalf("error getting manifest payload: %v", err)
-	}
-
+	payload = sm.Canonical
 	dgst = digest.FromBytes(payload)
 
 	return NewBridge(ub, source, actor, request, fn)


### PR DESCRIPTION
Ensure the canonical manifest digest and length are sent to notification endpoints.

Closes #1374 
Signed-off-by: Richard Scothern <richard.scothern@gmail.com>