### PR TITLE
Handle nonstandard token endpoint errors

### DIFF
--- a/registry/api/errcode/errors.go
+++ b/registry/api/errcode/errors.go
@@ -69,6 +69,15 @@ func (ec *ErrorCode) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// WithMessage creates a new Error struct based on the passed-in info and
+// overrides the Message property.
+func (ec ErrorCode) WithMessage(message string) Error {
+	return Error{
+		Code:    ec,
+		Message: message,
+	}
+}
+
 // WithDetail creates a new Error struct based on the passed-in info and
 // set the Detail property appropriately
 func (ec ErrorCode) WithDetail(detail interface{}) Error {


### PR DESCRIPTION
https://github.com/docker/distribution/pull/1249 changed token fetching
to parse HTTP error response bodies as serialized errcodes. However,
Docker Hub's authentication endpoint does not return error bodies in
this format. To work around this, convert its format into
ErrCodeUnauthorized or ErrCodeUnknown.

Fixes #1373
See also docker/docker#19476