### PR TITLE
Avoid empty Accept headers in client requests

### DIFF
--- a/manifests.go
+++ b/manifests.go
@@ -69,7 +69,9 @@ type Describable interface {
 // ManifestMediaTypes returns the supported media types for manifests.
 func ManifestMediaTypes() (mediaTypes []string) {
 	for t := range mappings {
-		mediaTypes = append(mediaTypes, t)
+		if t != "" {
+			mediaTypes = append(mediaTypes, t)
+		}
 	}
 	return
 }


### PR DESCRIPTION
One of the keys in the manifest media type map is an empty string. This
should not be sent as an Accept header.