### PR TITLE
Storage: Add CloseStreamWriter function

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -211,9 +211,6 @@ type BlobWriter interface {
 	// result in a no-op. This allows use of Cancel in a defer statement,
 	// increasing the assurance that it is correctly called.
 	Cancel(ctx context.Context) error
-
-	// Get a reader to the blob being written by this BlobWriter
-	Reader() (io.ReadCloser, error)
 }
 
 // BlobService combines the operations to access, read and write blobs. This

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -96,11 +96,17 @@ func (bw *blobWriter) Write(p []byte) (int, error) {
 	// Ensure that the current write offset matches how many bytes have been
 	// written to the digester. If not, we need to update the digest state to
 	// match the current write position.
-	if err := bw.resumeDigestAt(bw.blobStore.ctx, bw.offset); err != nil && err != errResumableDigestNotAvailable {
+	err := bw.resumeDigestAt(bw.blobStore.ctx, bw.offset, false)
+	if err != nil && err != errResumableDigestNotAvailable {
 		return 0, err
 	}
-
-	n, err := io.MultiWriter(&bw.bufferedFileWriter, bw.digester.Hash()).Write(p)
+	resumeDigest := err != errResumableDigestNotAvailable
+	n, err := bw.bufferedFileWriter.Write(p)
+	if resumeDigest {
+		// update the Hash with the bytes that have been written succesfully to the
+		// file writer
+		bw.digester.Hash().Write(p[0:n])
+	}
 	bw.written += int64(n)
 
 	return n, err
@@ -110,11 +116,15 @@ func (bw *blobWriter) ReadFrom(r io.Reader) (n int64, err error) {
 	// Ensure that the current write offset matches how many bytes have been
 	// written to the digester. If not, we need to update the digest state to
 	// match the current write position.
-	if err := bw.resumeDigestAt(bw.blobStore.ctx, bw.offset); err != nil && err != errResumableDigestNotAvailable {
+	if err = bw.resumeDigestAt(bw.blobStore.ctx, bw.offset, false); err != nil && err != errResumableDigestNotAvailable {
 		return 0, err
 	}
 
-	nn, err := bw.bufferedFileWriter.ReadFrom(io.TeeReader(r, bw.digester.Hash()))
+	reader := r
+	if err != errResumableDigestNotAvailable {
+		reader = io.TeeReader(r, bw.digester.Hash())
+	}
+	nn, err := bw.bufferedFileWriter.ReadFrom(reader)
 	bw.written += nn
 
 	return nn, err
@@ -181,7 +191,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 	// TODO(stevvooe): This section is very meandering. Need to be broken down
 	// to be a lot more clear.
 
-	if err := bw.resumeDigestAt(ctx, bw.size); err == nil {
+	if err := bw.resumeDigestAt(ctx, bw.size, true); err == nil {
 		canonical = bw.digester.Digest()
 
 		if canonical.Algorithm() == desc.Digest.Algorithm() {
@@ -351,30 +361,4 @@ func (bw *blobWriter) removeResources(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (bw *blobWriter) Reader() (io.ReadCloser, error) {
-	// todo(richardscothern): Change to exponential backoff, i=0.5, e=2, n=4
-	try := 1
-	for try <= 5 {
-		_, err := bw.bufferedFileWriter.driver.Stat(bw.ctx, bw.path)
-		if err == nil {
-			break
-		}
-		switch err.(type) {
-		case storagedriver.PathNotFoundError:
-			context.GetLogger(bw.ctx).Debugf("Nothing found on try %d, sleeping...", try)
-			time.Sleep(1 * time.Second)
-			try++
-		default:
-			return nil, err
-		}
-	}
-
-	readCloser, err := bw.bufferedFileWriter.driver.ReadStream(bw.ctx, bw.path, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	return readCloser, nil
 }

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -96,7 +96,7 @@ func (bw *blobWriter) Write(p []byte) (int, error) {
 	// Ensure that the current write offset matches how many bytes have been
 	// written to the digester. If not, we need to update the digest state to
 	// match the current write position.
-	err := bw.resumeDigestAt(bw.blobStore.ctx, bw.offset, false)
+	err := bw.resumeDigest(bw.blobStore.ctx)
 	if err != nil && err != errResumableDigestNotAvailable {
 		return 0, err
 	}
@@ -116,7 +116,7 @@ func (bw *blobWriter) ReadFrom(r io.Reader) (n int64, err error) {
 	// Ensure that the current write offset matches how many bytes have been
 	// written to the digester. If not, we need to update the digest state to
 	// match the current write position.
-	if err = bw.resumeDigestAt(bw.blobStore.ctx, bw.offset, false); err != nil && err != errResumableDigestNotAvailable {
+	if err = bw.resumeDigest(bw.blobStore.ctx); err != nil && err != errResumableDigestNotAvailable {
 		return 0, err
 	}
 
@@ -191,7 +191,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 	// TODO(stevvooe): This section is very meandering. Need to be broken down
 	// to be a lot more clear.
 
-	if err := bw.resumeDigestAt(ctx, bw.size, true); err == nil {
+	if err := bw.resumeDigest(ctx); err == nil {
 		canonical = bw.digester.Digest()
 
 		if canonical.Algorithm() == desc.Digest.Algorithm() {

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -4,8 +4,6 @@ package storage
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"path"
 	"strconv"
 
@@ -20,23 +18,17 @@ import (
 )
 
 // resumeDigestAt attempts to restore the state of the internal hash function
-// by loading the most recent saved hash state less than or equal to the given
-// offset. Any unhashed bytes remaining less than the given offset are hashed
-// from the content uploaded so far.
-func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64, allowRead bool) error {
+// by loading the most recent saved hash state equal to the current size of the blob.
+func (bw *blobWriter) resumeDigest(ctx context.Context) error {
 	if !bw.resumableDigestEnabled {
 		return errResumableDigestNotAvailable
-	}
-
-	if offset < 0 {
-		return fmt.Errorf("cannot resume hash at negative offset: %d", offset)
 	}
 
 	h, ok := bw.digester.Hash().(resumable.Hash)
 	if !ok {
 		return errResumableDigestNotAvailable
 	}
-
+	offset := bw.bufferedFileWriter.size
 	if offset == int64(h.Len()) {
 		// State of digester is already at the requested offset.
 		return nil
@@ -49,24 +41,12 @@ func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64, allowRea
 		return fmt.Errorf("unable to get stored hash states with offset %d: %s", offset, err)
 	}
 
-	// Find the highest stored hashState with offset less than or equal to
+	// Find the highest stored hashState with offset equal to
 	// the requested offset.
 	for _, hashState := range hashStates {
 		if hashState.offset == offset {
 			hashStateMatch = hashState
 			break // Found an exact offset match.
-		} else if hashState.offset < offset && hashState.offset > hashStateMatch.offset {
-			// This offset is closer to the requested offset.
-			hashStateMatch = hashState
-		} else if hashState.offset > offset {
-			// Remove any stored hash state with offsets higher than this one
-			// as writes to this resumed hasher will make those invalid. This
-			// is probably okay to skip for now since we don't expect anyone to
-			// use the API in this way. For that reason, we don't treat an
-			// an error here as a fatal error, but only log it.
-			if err := bw.driver.Delete(ctx, hashState.path); err != nil {
-				logrus.Errorf("unable to delete stale hash state %q: %s", hashState.path, err)
-			}
 		}
 	}
 
@@ -86,23 +66,7 @@ func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64, allowRea
 
 	// Mind the gap.
 	if gapLen := offset - int64(h.Len()); gapLen > 0 {
-		if !allowRead {
-			return errResumableDigestNotAvailable
-		}
-		// Need to read content from the upload to catch up to the desired offset.
-		fr, err := newFileReader(ctx, bw.driver, bw.path, bw.size)
-		if err != nil {
-			return err
-		}
-		defer fr.Close()
-
-		if _, err = fr.Seek(int64(h.Len()), os.SEEK_SET); err != nil {
-			return fmt.Errorf("unable to seek to layer reader offset %d: %s", h.Len(), err)
-		}
-
-		if _, err := io.CopyN(h, fr, gapLen); err != nil {
-			return err
-		}
+		return errResumableDigestNotAvailable
 	}
 
 	return nil

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -23,7 +23,7 @@ import (
 // by loading the most recent saved hash state less than or equal to the given
 // offset. Any unhashed bytes remaining less than the given offset are hashed
 // from the content uploaded so far.
-func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64) error {
+func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64, allowRead bool) error {
 	if !bw.resumableDigestEnabled {
 		return errResumableDigestNotAvailable
 	}
@@ -86,6 +86,9 @@ func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64) error {
 
 	// Mind the gap.
 	if gapLen := offset - int64(h.Len()); gapLen > 0 {
+		if !allowRead {
+			return errResumableDigestNotAvailable
+		}
 		// Need to read content from the upload to catch up to the desired offset.
 		fr, err := newFileReader(ctx, bw.driver, bw.path, bw.size)
 		if err != nil {

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -174,6 +174,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return zw.Write(d.container, path, offset, reader)
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -161,6 +161,10 @@ func (d *driver) WriteStream(ctx context.Context, subPath string, offset int64, 
 	return io.Copy(fp, reader)
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, subPath string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -222,6 +222,10 @@ func (d *driver) ReadStream(context ctx.Context, path string, offset int64) (io.
 	return res.Body, nil
 }
 
+func (d *driver) CloseWriteStream(context ctx.Context, path string) error {
+	return nil
+}
+
 // WriteStream stores the contents of the provided io.ReadCloser at a
 // location designated by the given path.
 // May be used to resume writing a stream by providing a nonzero offset.

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -167,6 +167,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return nn, err
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat returns info about the provided path.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
 	d.mutex.RLock()

--- a/registry/storage/driver/oss/oss.go
+++ b/registry/storage/driver/oss/oss.go
@@ -590,6 +590,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return totalRead, nil
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/rados/rados.go
+++ b/registry/storage/driver/rados/rados.go
@@ -356,6 +356,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return totalRead, nil
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
 	// get oid from filename

--- a/registry/storage/driver/s3/s3.go
+++ b/registry/storage/driver/s3/s3.go
@@ -632,6 +632,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return totalRead, nil
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -60,6 +60,10 @@ type StorageDriver interface {
 	// The offset must be no larger than the CurrentSize for this path.
 	WriteStream(ctx context.Context, path string, offset int64, reader io.Reader) (nn int64, err error)
 
+	// CloseWriteStream is invoked after the last chunk of an upload has been written by
+	// WriteStream
+	CloseWriteStream(ctx context.Context, path string) error
+
 	// Stat retrieves the FileInfo for the given path, including the current
 	// size in bytes and the creation time.
 	Stat(ctx context.Context, path string) (FileInfo, error)

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -525,6 +525,10 @@ func (d *driver) WriteStream(ctx context.Context, path string, offset int64, rea
 	return bytesRead, err
 }
 
+func (d *driver) CloseWriteStream(ctx context.Context, path string) error {
+	return nil
+}
+
 // Stat retrieves the FileInfo for the given path, including the current size
 // in bytes and the creation time.
 func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -286,6 +286,9 @@ func (suite *DriverSuite) TestWriteReadLargeStreams(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(written, check.Equals, fileSize)
 
+	err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
+
 	reader, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 	c.Assert(err, check.IsNil)
 	defer reader.Close()
@@ -448,6 +451,9 @@ func (suite *DriverSuite) testContinueStreamAppend(c *check.C, chunkSize int64) 
 	c.Assert(err, check.IsNil)
 	c.Assert(fi, check.NotNil)
 	c.Assert(fi.Size(), check.Equals, int64(len(fullContents)))
+
+	err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
 
 	received, err := suite.StorageDriver.GetContent(suite.ctx, filename)
 	c.Assert(err, check.IsNil)
@@ -880,7 +886,7 @@ func (suite *DriverSuite) TestConcurrentFileStreams(c *check.C) {
 
 // TestEventualConsistency checks that stat reports the right file size, after
 // appending a chunk to the file, and that the contents of the file can be read after
-// calling CloseStream (these are the only guarantees that the driver needs to provide)
+// calling CloseWriteStream (these are the only guarantees that the driver needs to provide)
 func (suite *DriverSuite) TestEventualConsistency(c *check.C) {
 	if testing.Short() {
 		c.Skip("Skipping test in short mode")
@@ -910,6 +916,9 @@ func (suite *DriverSuite) TestEventualConsistency(c *check.C) {
 		c.Log("There were " + string(misswrites) + " occurences of a write not being instantly available.")
 	}
 	c.Assert(misswrites, check.Not(check.Equals), 1024)
+
+	err := suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
 
 	reader, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 	c.Assert(err, check.IsNil)
@@ -992,6 +1001,9 @@ func (suite *DriverSuite) benchmarkStreamFiles(c *check.C, size int64) {
 		written, err := suite.StorageDriver.WriteStream(suite.ctx, filename, 0, bytes.NewReader(randomContents(size)))
 		c.Assert(err, check.IsNil)
 		c.Assert(written, check.Equals, size)
+
+		err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+		c.Assert(err, check.IsNil)
 
 		rc, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 		c.Assert(err, check.IsNil)
@@ -1078,6 +1090,9 @@ func (suite *DriverSuite) testFileStreams(c *check.C, size int64) {
 	c.Assert(err, check.IsNil)
 	c.Assert(nn, check.Equals, size)
 
+	err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
+
 	reader, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 	c.Assert(err, check.IsNil)
 	defer reader.Close()
@@ -1106,6 +1121,9 @@ func (suite *DriverSuite) writeReadCompareStreams(c *check.C, filename string, c
 	nn, err := suite.StorageDriver.WriteStream(suite.ctx, filename, 0, bytes.NewReader(contents))
 	c.Assert(err, check.IsNil)
 	c.Assert(nn, check.Equals, int64(len(contents)))
+
+	err = suite.StorageDriver.CloseWriteStream(suite.ctx, filename)
+	c.Assert(err, check.IsNil)
 
 	reader, err := suite.StorageDriver.ReadStream(suite.ctx, filename, 0)
 	c.Assert(err, check.IsNil)

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -432,10 +432,6 @@ func (suite *DriverSuite) testContinueStreamAppend(c *check.C, chunkSize int64) 
 	c.Assert(err, check.IsNil)
 	c.Assert(nn, check.Equals, int64(len(fullContents[fi.Size():])))
 
-	received, err := suite.StorageDriver.GetContent(suite.ctx, filename)
-	c.Assert(err, check.IsNil)
-	c.Assert(received, check.DeepEquals, fullContents)
-
 	// Writing past size of file extends file (no offset error). We would like
 	// to write chunk 4 one chunk length past chunk 3. It should be successful
 	// and the resulting file will be 5 chunks long, with a chunk of all
@@ -453,7 +449,7 @@ func (suite *DriverSuite) testContinueStreamAppend(c *check.C, chunkSize int64) 
 	c.Assert(fi, check.NotNil)
 	c.Assert(fi.Size(), check.Equals, int64(len(fullContents)))
 
-	received, err = suite.StorageDriver.GetContent(suite.ctx, filename)
+	received, err := suite.StorageDriver.GetContent(suite.ctx, filename)
 	c.Assert(err, check.IsNil)
 	c.Assert(len(received), check.Equals, len(fullContents))
 	c.Assert(received[chunkSize*3:chunkSize*4], check.DeepEquals, zeroChunk)

--- a/registry/storage/filewriter.go
+++ b/registry/storage/filewriter.go
@@ -176,7 +176,8 @@ func (fw *fileWriter) Close() error {
 		return fw.err
 	}
 
+	err := fw.driver.CloseWriteStream(fw.ctx, fw.path)
 	fw.err = fmt.Errorf("filewriter@%v: closed", fw.path)
 
-	return nil
+	return err
 }

--- a/registry/storage/filewriter.go
+++ b/registry/storage/filewriter.go
@@ -157,6 +157,8 @@ func (fw *fileWriter) Seek(offset int64, whence int) (int64, error) {
 
 	if newOffset < 0 {
 		err = fmt.Errorf("cannot seek to negative position")
+	} else if newOffset > fw.size {
+		err = fmt.Errorf("cannot seek beyond the end of the file")
 	} else {
 		// No problems, set the offset.
 		fw.offset = newOffset


### PR DESCRIPTION
This PR is a pre-requisite for #1322, and makes the following modifications to the storage driver API:
1. Add function CloseWriteStream that indicates the end of an upload session, after a call to this function, no further chunks should be appended.
2. Ensure that no read operations are attempted on partial uploads (ie no ```ReadStream```/```GetContent ```calls before ```CloseWriteStream``` has been called.