### PR TITLE
If the media type for a manifest is unrecognized, default to schema1

### DIFF
--- a/manifests.go
+++ b/manifests.go
@@ -96,7 +96,10 @@ func UnmarshalManifest(ctHeader string, p []byte) (Manifest, Descriptor, error) 
 
 	unmarshalFunc, ok := mappings[mediatype]
 	if !ok {
-		return nil, Descriptor{}, fmt.Errorf("unsupported manifest mediatype: %s", mediatype)
+		unmarshalFunc, ok = mappings[""]
+		if !ok {
+			return nil, Descriptor{}, fmt.Errorf("unsupported manifest mediatype and no default available: %s", mediatype)
+		}
 	}
 
 	return unmarshalFunc(p)


### PR DESCRIPTION
This is needed for compatibility with some third-party registries that
send an inappropriate Content-Type header such as text/html.