### PR TITLE
Invalidate the blob store descriptor cache

### DIFF
--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -164,9 +164,10 @@ func makeTestEnv(t *testing.T, name string) *testEnv {
 	s := scheduler.New(ctx, inmemory.New(), "/scheduler-state.json")
 
 	proxyBlobStore := proxyBlobStore{
-		remoteStore: truthBlobs,
-		localStore:  localBlobs,
-		scheduler:   s,
+		repositoryName: nameRef,
+		remoteStore:    truthBlobs,
+		localStore:     localBlobs,
+		scheduler:      s,
 	}
 
 	te := &testEnv{

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -62,11 +62,17 @@ func (pms proxyManifestStore) Get(ctx context.Context, dgst digest.Digest, optio
 			return nil, err
 		}
 
-		// Schedule the repo for removal
-		pms.scheduler.AddManifest(pms.repositoryName, repositoryTTL)
+		// Schedule the manifest blob for removal
+		repoBlob, err := reference.WithDigest(pms.repositoryName, dgst)
+		if err != nil {
+			context.GetLogger(ctx).Errorf("Error creating reference: %s", err)
+			return nil, err
+		}
 
+		pms.scheduler.AddManifest(repoBlob, repositoryTTL)
 		// Ensure the manifest blob is cleaned up
-		pms.scheduler.AddBlob(dgst, repositoryTTL)
+		//pms.scheduler.AddBlob(blobRef, repositoryTTL)
+
 	}
 
 	return manifest, err

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -119,6 +119,7 @@ func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestE
 			localManifests:  localManifests,
 			remoteManifests: truthManifests,
 			scheduler:       s,
+			repositoryName:  nameRef,
 		},
 	}
 }

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -7,13 +7,12 @@ import (
 	"time"
 
 	"github.com/docker/distribution/context"
-	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/storage/driver"
 )
 
 // onTTLExpiryFunc is called when a repository's TTL expires
-type expiryFunc func(string) error
+type expiryFunc func(reference.Reference) error
 
 const (
 	entryTypeBlob = iota
@@ -82,19 +81,20 @@ func (ttles *TTLExpirationScheduler) OnManifestExpire(f expiryFunc) {
 }
 
 // AddBlob schedules a blob cleanup after ttl expires
-func (ttles *TTLExpirationScheduler) AddBlob(dgst digest.Digest, ttl time.Duration) error {
+func (ttles *TTLExpirationScheduler) AddBlob(blobRef reference.Canonical, ttl time.Duration) error {
 	ttles.Lock()
 	defer ttles.Unlock()
 
 	if ttles.stopped {
 		return fmt.Errorf("scheduler not started")
 	}
-	ttles.add(dgst.String(), ttl, entryTypeBlob)
+
+	ttles.add(blobRef, ttl, entryTypeBlob)
 	return nil
 }
 
 // AddManifest schedules a manifest cleanup after ttl expires
-func (ttles *TTLExpirationScheduler) AddManifest(repoName reference.Named, ttl time.Duration) error {
+func (ttles *TTLExpirationScheduler) AddManifest(manifestRef reference.Canonical, ttl time.Duration) error {
 	ttles.Lock()
 	defer ttles.Unlock()
 
@@ -102,7 +102,7 @@ func (ttles *TTLExpirationScheduler) AddManifest(repoName reference.Named, ttl t
 		return fmt.Errorf("scheduler not started")
 	}
 
-	ttles.add(repoName.Name(), ttl, entryTypeManifest)
+	ttles.add(manifestRef, ttl, entryTypeManifest)
 	return nil
 }
 
@@ -156,17 +156,17 @@ func (ttles *TTLExpirationScheduler) Start() error {
 	return nil
 }
 
-func (ttles *TTLExpirationScheduler) add(key string, ttl time.Duration, eType int) {
+func (ttles *TTLExpirationScheduler) add(r reference.Reference, ttl time.Duration, eType int) {
 	entry := &schedulerEntry{
-		Key:       key,
+		Key:       r.String(),
 		Expiry:    time.Now().Add(ttl),
 		EntryType: eType,
 	}
 	context.GetLogger(ttles.ctx).Infof("Adding new scheduler entry for %s with ttl=%s", entry.Key, entry.Expiry.Sub(time.Now()))
-	if oldEntry, present := ttles.entries[key]; present && oldEntry.timer != nil {
+	if oldEntry, present := ttles.entries[entry.Key]; present && oldEntry.timer != nil {
 		oldEntry.timer.Stop()
 	}
-	ttles.entries[key] = entry
+	ttles.entries[entry.Key] = entry
 	entry.timer = ttles.startTimer(entry, ttl)
 	ttles.indexDirty = true
 }
@@ -184,13 +184,18 @@ func (ttles *TTLExpirationScheduler) startTimer(entry *schedulerEntry, ttl time.
 		case entryTypeManifest:
 			f = ttles.onManifestExpire
 		default:
-			f = func(repoName string) error {
-				return fmt.Errorf("Unexpected scheduler entry type")
+			f = func(reference.Reference) error {
+				return fmt.Errorf("scheduler entry type")
 			}
 		}
 
-		if err := f(entry.Key); err != nil {
-			context.GetLogger(ttles.ctx).Errorf("Scheduler error returned from OnExpire(%s): %s", entry.Key, err)
+		ref, err := reference.Parse(entry.Key)
+		if err == nil {
+			if err := f(ref); err != nil {
+				context.GetLogger(ttles.ctx).Errorf("Scheduler error returned from OnExpire(%s): %s", entry.Key, err)
+			}
+		} else {
+			context.GetLogger(ttles.ctx).Errorf("Error unpacking reference: %s", err)
 		}
 
 		delete(ttles.entries, entry.Key)
@@ -249,6 +254,5 @@ func (ttles *TTLExpirationScheduler) readState() error {
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/registry/storage/cache/cachecheck/suite.go
+++ b/registry/storage/cache/cachecheck/suite.go
@@ -17,6 +17,7 @@ func CheckBlobDescriptorCache(t *testing.T, provider cache.BlobDescriptorCachePr
 
 	checkBlobDescriptorCacheEmptyRepository(t, ctx, provider)
 	checkBlobDescriptorCacheSetAndRead(t, ctx, provider)
+	checkBlobDescriptorCacheClear(t, ctx, provider)
 }
 
 func checkBlobDescriptorCacheEmptyRepository(t *testing.T, ctx context.Context, provider cache.BlobDescriptorCacheProvider) {
@@ -141,10 +142,10 @@ func checkBlobDescriptorCacheSetAndRead(t *testing.T, ctx context.Context, provi
 	}
 }
 
-func checkBlobDescriptorClear(t *testing.T, ctx context.Context, provider cache.BlobDescriptorCacheProvider) {
-	localDigest := digest.Digest("sha384:abc")
+func checkBlobDescriptorCacheClear(t *testing.T, ctx context.Context, provider cache.BlobDescriptorCacheProvider) {
+	localDigest := digest.Digest("sha384:def111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
 	expected := distribution.Descriptor{
-		Digest:    "sha256:abc",
+		Digest:    "sha256:def1111111111111111111111111111111111111111111111111111111111111",
 		Size:      10,
 		MediaType: "application/octet-stream"}
 
@@ -168,12 +169,11 @@ func checkBlobDescriptorClear(t *testing.T, ctx context.Context, provider cache.
 
 	err = cache.Clear(ctx, localDigest)
 	if err != nil {
-		t.Fatalf("unexpected error deleting descriptor")
+		t.Error(err)
 	}
 
-	nonExistantDigest := digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	err = cache.Clear(ctx, nonExistantDigest)
+	desc, err = cache.Stat(ctx, localDigest)
 	if err == nil {
-		t.Fatalf("expected error deleting unknown descriptor")
+		t.Fatalf("expected error statting deleted blob: %v", err)
 	}
 }


### PR DESCRIPTION
Invalidate the blob store descriptor cache when content is removed from from
the proxy.  Also, change the scheduler to use the reference package.

Closes #1356

Signed-off-by: Richard Scothern <richard.scothern@gmail.com>