### PR TITLE
Update auth context keys to use constant

### DIFF
--- a/registry/auth/auth.go
+++ b/registry/auth/auth.go
@@ -39,6 +39,16 @@ import (
 	"github.com/docker/distribution/context"
 )
 
+const (
+	// UserKey is used to get the user object from
+	// a user context
+	UserKey = "auth.user"
+
+	// UserNameKey is used to get the user name from
+	// a user context
+	UserNameKey = "auth.user.name"
+)
+
 // UserInfo carries information about
 // an autenticated/authorized client.
 type UserInfo struct {
@@ -102,9 +112,9 @@ type userInfoContext struct {
 
 func (uic userInfoContext) Value(key interface{}) interface{} {
 	switch key {
-	case "auth.user":
+	case UserKey:
 		return uic.user
-	case "auth.user.name":
+	case UserNameKey:
 		return uic.user.Name
 	}
 

--- a/registry/auth/htpasswd/access_test.go
+++ b/registry/auth/htpasswd/access_test.go
@@ -56,7 +56,7 @@ func TestBasicAccessController(t *testing.T) {
 			}
 		}
 
-		userInfo, ok := authCtx.Value("auth.user").(auth.UserInfo)
+		userInfo, ok := authCtx.Value(auth.UserKey).(auth.UserInfo)
 		if !ok {
 			t.Fatal("basic accessController did not set auth.user context")
 		}

--- a/registry/auth/silly/access_test.go
+++ b/registry/auth/silly/access_test.go
@@ -29,7 +29,7 @@ func TestSillyAccessController(t *testing.T) {
 			}
 		}
 
-		userInfo, ok := authCtx.Value("auth.user").(auth.UserInfo)
+		userInfo, ok := authCtx.Value(auth.UserKey).(auth.UserInfo)
 		if !ok {
 			t.Fatal("silly accessController did not set auth.user context")
 		}

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -375,7 +375,7 @@ func TestAccessController(t *testing.T) {
 		t.Fatalf("accessController returned unexpected error: %s", err)
 	}
 
-	userInfo, ok := authCtx.Value("auth.user").(auth.UserInfo)
+	userInfo, ok := authCtx.Value(auth.UserKey).(auth.UserInfo)
 	if !ok {
 		t.Fatal("token accessController did not set auth.user context")
 	}

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -588,7 +588,7 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 		}
 
 		// Add username to request logging
-		context.Context = ctxu.WithLogger(context.Context, ctxu.GetLogger(context.Context, "auth.user.name"))
+		context.Context = ctxu.WithLogger(context.Context, ctxu.GetLogger(context.Context, auth.UserNameKey))
 
 		if app.nameRequired(r) {
 			nameRef, err := reference.ParseNamed(getName(context))

--- a/registry/handlers/context.go
+++ b/registry/handlers/context.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/auth"
 	"golang.org/x/net/context"
 )
 
@@ -77,7 +78,7 @@ func getUploadUUID(ctx context.Context) (uuid string) {
 // getUserName attempts to resolve a username from the context and request. If
 // a username cannot be resolved, the empty string is returned.
 func getUserName(ctx context.Context, r *http.Request) string {
-	username := ctxu.GetStringValue(ctx, "auth.user.name")
+	username := ctxu.GetStringValue(ctx, auth.UserNameKey)
 
 	// Fallback to request user with basic auth
 	if username == "" {


### PR DESCRIPTION
Prevent using strings throughout the code to reference a string key defined in the auth package.

For reference 
```
$ grep -rn "auth\.user" .
./registry/auth/silly/access_test.go:34:	t.Fatal("silly accessController did not set auth.user context")
./registry/auth/token/token_test.go:380:	t.Fatal("token accessController did not set auth.user context")
./registry/auth/htpasswd/access_test.go:61:	t.Fatal("basic accessController did not set auth.user context")
./registry/auth/auth.go:43:					UserKey     = "auth.user"
./registry/auth/auth.go:44:					UserNameKey = "auth.user.name"
./registry/auth/auth.go:91:					// object should have a "auth.user" value set to a UserInfo struct.

```