### PR TITLE
Rename Name method of Repository to Named

### DIFF
--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -78,7 +78,7 @@ type manifestServiceListener struct {
 func (msl *manifestServiceListener) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
 	sm, err := msl.ManifestService.Get(ctx, dgst)
 	if err == nil {
-		if err := msl.parent.listener.ManifestPulled(msl.parent.Repository.Name(), sm); err != nil {
+		if err := msl.parent.listener.ManifestPulled(msl.parent.Repository.Named(), sm); err != nil {
 			logrus.Errorf("error dispatching manifest pull to listener: %v", err)
 		}
 	}
@@ -90,7 +90,7 @@ func (msl *manifestServiceListener) Put(ctx context.Context, sm distribution.Man
 	dgst, err := msl.ManifestService.Put(ctx, sm, options...)
 
 	if err == nil {
-		if err := msl.parent.listener.ManifestPushed(msl.parent.Repository.Name(), sm); err != nil {
+		if err := msl.parent.listener.ManifestPushed(msl.parent.Repository.Named(), sm); err != nil {
 			logrus.Errorf("error dispatching manifest push to listener: %v", err)
 		}
 	}
@@ -111,7 +111,7 @@ func (bsl *blobServiceListener) Get(ctx context.Context, dgst digest.Digest) ([]
 		if desc, err := bsl.Stat(ctx, dgst); err != nil {
 			context.GetLogger(ctx).Errorf("error resolving descriptor in ServeBlob listener: %v", err)
 		} else {
-			if err := bsl.parent.listener.BlobPulled(bsl.parent.Repository.Name(), desc); err != nil {
+			if err := bsl.parent.listener.BlobPulled(bsl.parent.Repository.Named(), desc); err != nil {
 				context.GetLogger(ctx).Errorf("error dispatching layer pull to listener: %v", err)
 			}
 		}
@@ -126,7 +126,7 @@ func (bsl *blobServiceListener) Open(ctx context.Context, dgst digest.Digest) (d
 		if desc, err := bsl.Stat(ctx, dgst); err != nil {
 			context.GetLogger(ctx).Errorf("error resolving descriptor in ServeBlob listener: %v", err)
 		} else {
-			if err := bsl.parent.listener.BlobPulled(bsl.parent.Repository.Name(), desc); err != nil {
+			if err := bsl.parent.listener.BlobPulled(bsl.parent.Repository.Named(), desc); err != nil {
 				context.GetLogger(ctx).Errorf("error dispatching layer pull to listener: %v", err)
 			}
 		}
@@ -141,7 +141,7 @@ func (bsl *blobServiceListener) ServeBlob(ctx context.Context, w http.ResponseWr
 		if desc, err := bsl.Stat(ctx, dgst); err != nil {
 			context.GetLogger(ctx).Errorf("error resolving descriptor in ServeBlob listener: %v", err)
 		} else {
-			if err := bsl.parent.listener.BlobPulled(bsl.parent.Repository.Name(), desc); err != nil {
+			if err := bsl.parent.listener.BlobPulled(bsl.parent.Repository.Named(), desc); err != nil {
 				context.GetLogger(ctx).Errorf("error dispatching layer pull to listener: %v", err)
 			}
 		}
@@ -153,7 +153,7 @@ func (bsl *blobServiceListener) ServeBlob(ctx context.Context, w http.ResponseWr
 func (bsl *blobServiceListener) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
 	desc, err := bsl.BlobStore.Put(ctx, mediaType, p)
 	if err == nil {
-		if err := bsl.parent.listener.BlobPushed(bsl.parent.Repository.Name(), desc); err != nil {
+		if err := bsl.parent.listener.BlobPushed(bsl.parent.Repository.Named(), desc); err != nil {
 			context.GetLogger(ctx).Errorf("error dispatching layer pull to listener: %v", err)
 		}
 	}
@@ -165,7 +165,7 @@ func (bsl *blobServiceListener) Create(ctx context.Context, options ...distribut
 	wr, err := bsl.BlobStore.Create(ctx, options...)
 	switch err := err.(type) {
 	case distribution.ErrBlobMounted:
-		if err := bsl.parent.listener.BlobMounted(bsl.parent.Repository.Name(), err.Descriptor, err.From); err != nil {
+		if err := bsl.parent.listener.BlobMounted(bsl.parent.Repository.Named(), err.Descriptor, err.From); err != nil {
 			context.GetLogger(ctx).Errorf("error dispatching blob mount to listener: %v", err)
 		}
 		return nil, err
@@ -193,7 +193,7 @@ type blobWriterListener struct {
 func (bwl *blobWriterListener) Commit(ctx context.Context, desc distribution.Descriptor) (distribution.Descriptor, error) {
 	committed, err := bwl.BlobWriter.Commit(ctx, desc)
 	if err == nil {
-		if err := bwl.parent.parent.listener.BlobPushed(bwl.parent.parent.Repository.Name(), committed); err != nil {
+		if err := bwl.parent.parent.listener.BlobPushed(bwl.parent.parent.Repository.Named(), committed); err != nil {
 			context.GetLogger(ctx).Errorf("error dispatching blob push to listener: %v", err)
 		}
 	}

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -109,7 +109,7 @@ func checkExerciseRepository(t *testing.T, repository distribution.Repository) {
 		Versioned: manifest.Versioned{
 			SchemaVersion: 1,
 		},
-		Name: repository.Name().Name(),
+		Name: repository.Named().Name(),
 		Tag:  tag,
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -49,8 +49,8 @@ type ManifestServiceOption interface {
 
 // Repository is a named collection of manifests and layers.
 type Repository interface {
-	// Name returns the name of the repository.
-	Name() reference.Named
+	// Named returns the name of the repository.
+	Named() reference.Named
 
 	// Manifests returns a reference to this repository's manifest service.
 	// with the supplied options applied.

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -146,7 +146,7 @@ type repository struct {
 	name    reference.Named
 }
 
-func (r *repository) Name() reference.Named {
+func (r *repository) Named() reference.Named {
 	return r.name
 }
 
@@ -179,7 +179,7 @@ func (r *repository) Tags(ctx context.Context) distribution.TagService {
 		client:  r.client,
 		ub:      r.ub,
 		context: r.context,
-		name:    r.Name(),
+		name:    r.Named(),
 	}
 }
 

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -48,8 +48,8 @@ func TestAppDispatcher(t *testing.T) {
 	varCheckingDispatcher := func(expectedVars map[string]string) dispatchFunc {
 		return func(ctx *Context, r *http.Request) http.Handler {
 			// Always checks the same name context
-			if ctx.Repository.Name().Name() != getName(ctx) {
-				t.Fatalf("unexpected name: %q != %q", ctx.Repository.Name(), "foo/bar")
+			if ctx.Repository.Named().Name() != getName(ctx) {
+				t.Fatalf("unexpected name: %q != %q", ctx.Repository.Named().Name(), "foo/bar")
 			}
 
 			// Check that we have all that is expected

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -46,9 +46,9 @@ func blobUploadDispatcher(ctx *Context, r *http.Request) http.Handler {
 		}
 		buh.State = state
 
-		if state.Name != ctx.Repository.Name().Name() {
+		if state.Name != ctx.Repository.Named().Name() {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				ctxu.GetLogger(ctx).Infof("mismatched repository name in upload state: %q != %q", state.Name, buh.Repository.Name())
+				ctxu.GetLogger(ctx).Infof("mismatched repository name in upload state: %q != %q", state.Name, buh.Repository.Named().Name())
 				buh.Errors = append(buh.Errors, v2.ErrorCodeBlobUploadInvalid.WithDetail(err))
 			})
 		}
@@ -312,7 +312,7 @@ func (buh *blobUploadHandler) blobUploadResponse(w http.ResponseWriter, r *http.
 	}
 
 	// TODO(stevvooe): Need a better way to manage the upload state automatically.
-	buh.State.Name = buh.Repository.Name().Name()
+	buh.State.Name = buh.Repository.Named().Name()
 	buh.State.UUID = buh.Upload.ID()
 	buh.State.Offset = offset
 	buh.State.StartedAt = buh.Upload.StartedAt()
@@ -324,7 +324,7 @@ func (buh *blobUploadHandler) blobUploadResponse(w http.ResponseWriter, r *http.
 	}
 
 	uploadURL, err := buh.urlBuilder.BuildBlobUploadChunkURL(
-		buh.Repository.Name(), buh.Upload.ID(),
+		buh.Repository.Named(), buh.Upload.ID(),
 		url.Values{
 			"_state": []string{token},
 		})
@@ -372,7 +372,7 @@ func (buh *blobUploadHandler) createBlobMountOption(fromRepo, mountDigest string
 // created blob. A 201 Created is written as well as the canonical URL and
 // blob digest.
 func (buh *blobUploadHandler) writeBlobCreatedHeaders(w http.ResponseWriter, desc distribution.Descriptor) error {
-	ref, err := reference.WithDigest(buh.Repository.Name(), desc.Digest)
+	ref, err := reference.WithDigest(buh.Repository.Named(), desc.Digest)
 	if err != nil {
 		return err
 	}

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -174,10 +174,10 @@ func (imh *imageManifestHandler) convertSchema2Manifest(schema2Manifest *schema2
 		return nil, err
 	}
 
-	ref := imh.Repository.Name()
+	ref := imh.Repository.Named()
 
 	if imh.Tag != "" {
-		ref, err = reference.WithTag(imh.Repository.Name(), imh.Tag)
+		ref, err = reference.WithTag(ref, imh.Tag)
 		if err != nil {
 			imh.Errors = append(imh.Errors, v2.ErrorCodeTagInvalid.WithDetail(err))
 			return nil, err
@@ -289,7 +289,7 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 	}
 
 	// Construct a canonical url for the uploaded manifest.
-	ref, err := reference.WithDigest(imh.Repository.Name(), imh.Digest)
+	ref, err := reference.WithDigest(imh.Repository.Named(), imh.Digest)
 	if err != nil {
 		imh.Errors = append(imh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		return

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -40,7 +40,7 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err := err.(type) {
 		case distribution.ErrRepositoryUnknown:
-			th.Errors = append(th.Errors, v2.ErrorCodeNameUnknown.WithDetail(map[string]string{"name": th.Repository.Name().Name()}))
+			th.Errors = append(th.Errors, v2.ErrorCodeNameUnknown.WithDetail(map[string]string{"name": th.Repository.Named().Name()}))
 		default:
 			th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		}
@@ -51,7 +51,7 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(tagsAPIResponse{
-		Name: th.Repository.Name().Name(),
+		Name: th.Repository.Named().Name(),
 		Tags: tags,
 	}); err != nil {
 		th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -179,7 +179,7 @@ func (pr *proxiedRepository) Blobs(ctx context.Context) distribution.BlobStore {
 	return pr.blobStore
 }
 
-func (pr *proxiedRepository) Name() reference.Named {
+func (pr *proxiedRepository) Named() reference.Named {
 	return pr.name
 }
 

--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -378,7 +378,7 @@ func TestBlobMount(t *testing.T) {
 		t.Fatalf("unexpected non-error stating unmounted blob: %v", desc)
 	}
 
-	canonicalRef, err := reference.WithDigest(sourceRepository.Name(), desc.Digest)
+	canonicalRef, err := reference.WithDigest(sourceRepository.Named(), desc.Digest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -326,7 +326,7 @@ func (bw *blobWriter) moveBlob(ctx context.Context, desc distribution.Descriptor
 // resources are already not present, no error will be returned.
 func (bw *blobWriter) removeResources(ctx context.Context) error {
 	dataPath, err := pathFor(uploadDataPathSpec{
-		name: bw.blobStore.repository.Name().Name(),
+		name: bw.blobStore.repository.Named().Name(),
 		id:   bw.id,
 	})
 

--- a/registry/storage/blobwriter_resumable.go
+++ b/registry/storage/blobwriter_resumable.go
@@ -113,7 +113,7 @@ type hashStateEntry struct {
 // getStoredHashStates returns a slice of hashStateEntries for this upload.
 func (bw *blobWriter) getStoredHashStates(ctx context.Context) ([]hashStateEntry, error) {
 	uploadHashStatePathPrefix, err := pathFor(uploadHashStatePathSpec{
-		name: bw.blobStore.repository.Name().String(),
+		name: bw.blobStore.repository.Named().String(),
 		id:   bw.id,
 		alg:  bw.digester.Digest().Algorithm(),
 		list: true,
@@ -159,7 +159,7 @@ func (bw *blobWriter) storeHashState(ctx context.Context) error {
 	}
 
 	uploadHashStatePath, err := pathFor(uploadHashStatePathSpec{
-		name:   bw.blobStore.repository.Name().String(),
+		name:   bw.blobStore.repository.Named().String(),
 		id:     bw.id,
 		alg:    bw.digester.Digest().Algorithm(),
 		offset: int64(h.Len()),

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -153,7 +153,7 @@ func (lbs *linkedBlobStore) Create(ctx context.Context, options ...distribution.
 	startedAt := time.Now().UTC()
 
 	path, err := pathFor(uploadDataPathSpec{
-		name: lbs.repository.Name().Name(),
+		name: lbs.repository.Named().Name(),
 		id:   uuid,
 	})
 
@@ -162,7 +162,7 @@ func (lbs *linkedBlobStore) Create(ctx context.Context, options ...distribution.
 	}
 
 	startedAtPath, err := pathFor(uploadStartedAtPathSpec{
-		name: lbs.repository.Name().Name(),
+		name: lbs.repository.Named().Name(),
 		id:   uuid,
 	})
 
@@ -182,7 +182,7 @@ func (lbs *linkedBlobStore) Resume(ctx context.Context, id string) (distribution
 	context.GetLogger(ctx).Debug("(*linkedBlobStore).Resume")
 
 	startedAtPath, err := pathFor(uploadStartedAtPathSpec{
-		name: lbs.repository.Name().Name(),
+		name: lbs.repository.Named().Name(),
 		id:   id,
 	})
 
@@ -206,7 +206,7 @@ func (lbs *linkedBlobStore) Resume(ctx context.Context, id string) (distribution
 	}
 
 	path, err := pathFor(uploadDataPathSpec{
-		name: lbs.repository.Name().Name(),
+		name: lbs.repository.Named().Name(),
 		id:   id,
 	})
 
@@ -298,7 +298,7 @@ func (lbs *linkedBlobStore) linkBlob(ctx context.Context, canonical distribution
 		}
 		seenDigests[dgst] = struct{}{}
 
-		blobLinkPath, err := linkPathFn(lbs.repository.Name().Name(), dgst)
+		blobLinkPath, err := linkPathFn(lbs.repository.Named().Name(), dgst)
 		if err != nil {
 			return err
 		}
@@ -368,7 +368,7 @@ func (lbs *linkedBlobStatter) Stat(ctx context.Context, dgst digest.Digest) (dis
 func (lbs *linkedBlobStatter) Clear(ctx context.Context, dgst digest.Digest) (err error) {
 	// clear any possible existence of a link described in linkPathFns
 	for _, linkPathFn := range lbs.linkPathFns {
-		blobLinkPath, err := linkPathFn(lbs.repository.Name().Name(), dgst)
+		blobLinkPath, err := linkPathFn(lbs.repository.Named().Name(), dgst)
 		if err != nil {
 			return err
 		}
@@ -391,7 +391,7 @@ func (lbs *linkedBlobStatter) Clear(ctx context.Context, dgst digest.Digest) (er
 // linkPathFuncs to let us try a few different paths before returning not
 // found.
 func (lbs *linkedBlobStatter) resolveWithLinkFunc(ctx context.Context, dgst digest.Digest, linkPathFn linkPathFunc) (digest.Digest, error) {
-	blobLinkPath, err := linkPathFn(lbs.repository.Name().Name(), dgst)
+	blobLinkPath, err := linkPathFn(lbs.repository.Named().Name(), dgst)
 	if err != nil {
 		return "", err
 	}

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -77,7 +77,7 @@ func (ms *manifestStore) Get(ctx context.Context, dgst digest.Digest, options ..
 	if err != nil {
 		if err == distribution.ErrBlobUnknown {
 			return nil, distribution.ErrManifestUnknownRevision{
-				Name:     ms.repository.Name().Name(),
+				Name:     ms.repository.Named().Name(),
 				Revision: dgst,
 			}
 		}

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -134,7 +134,7 @@ type repository struct {
 }
 
 // Name returns the name of the repository.
-func (repo *repository) Name() reference.Named {
+func (repo *repository) Named() reference.Named {
 	return repo.name
 }
 

--- a/registry/storage/signaturestore.go
+++ b/registry/storage/signaturestore.go
@@ -16,7 +16,7 @@ type signatureStore struct {
 
 func (s *signatureStore) Get(dgst digest.Digest) ([][]byte, error) {
 	signaturesPath, err := pathFor(manifestSignaturesPathSpec{
-		name:     s.repository.Name().Name(),
+		name:     s.repository.Named().Name(),
 		revision: dgst,
 	})
 

--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -26,7 +26,7 @@ func (ts *tagStore) All(ctx context.Context) ([]string, error) {
 	var tags []string
 
 	pathSpec, err := pathFor(manifestTagPathSpec{
-		name: ts.repository.Name().Name(),
+		name: ts.repository.Named().Name(),
 	})
 	if err != nil {
 		return tags, err
@@ -36,7 +36,7 @@ func (ts *tagStore) All(ctx context.Context) ([]string, error) {
 	if err != nil {
 		switch err := err.(type) {
 		case storagedriver.PathNotFoundError:
-			return tags, distribution.ErrRepositoryUnknown{Name: ts.repository.Name().Name()}
+			return tags, distribution.ErrRepositoryUnknown{Name: ts.repository.Named().Name()}
 		default:
 			return tags, err
 		}
@@ -53,7 +53,7 @@ func (ts *tagStore) All(ctx context.Context) ([]string, error) {
 // exists returns true if the specified manifest tag exists in the repository.
 func (ts *tagStore) exists(ctx context.Context, tag string) (bool, error) {
 	tagPath, err := pathFor(manifestTagCurrentPathSpec{
-		name: ts.repository.Name().Name(),
+		name: ts.repository.Named().Name(),
 		tag:  tag,
 	})
 
@@ -73,7 +73,7 @@ func (ts *tagStore) exists(ctx context.Context, tag string) (bool, error) {
 // the current tag. The digest must point to a manifest.
 func (ts *tagStore) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
 	currentPath, err := pathFor(manifestTagCurrentPathSpec{
-		name: ts.repository.Name().Name(),
+		name: ts.repository.Named().Name(),
 		tag:  tag,
 	})
 
@@ -95,7 +95,7 @@ func (ts *tagStore) Tag(ctx context.Context, tag string, desc distribution.Descr
 // resolve the current revision for name and tag.
 func (ts *tagStore) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
 	currentPath, err := pathFor(manifestTagCurrentPathSpec{
-		name: ts.repository.Name().Name(),
+		name: ts.repository.Named().Name(),
 		tag:  tag,
 	})
 
@@ -119,7 +119,7 @@ func (ts *tagStore) Get(ctx context.Context, tag string) (distribution.Descripto
 // Untag removes the tag association
 func (ts *tagStore) Untag(ctx context.Context, tag string) error {
 	tagPath, err := pathFor(manifestTagPathSpec{
-		name: ts.repository.Name().Name(),
+		name: ts.repository.Named().Name(),
 		tag:  tag,
 	})
 
@@ -172,7 +172,7 @@ func (ts *tagStore) Lookup(ctx context.Context, desc distribution.Descriptor) ([
 	var tags []string
 	for _, tag := range allTags {
 		tagLinkPathSpec := manifestTagCurrentPathSpec{
-			name: ts.repository.Name().Name(),
+			name: ts.repository.Named().Name(),
 			tag:  tag,
 		}
 


### PR DESCRIPTION
This makes code that gets the name as a string read like
`repo.NameRef().Name()` instead of `repo.Name().Name()`.

Requested in
https://github.com/docker/docker/pull/19887#discussion_r51479753