### PR TITLE
On redirect, only copy headers when they don't already exist in the redirected request

### DIFF
--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -36,8 +36,21 @@ func checkHTTPRedirect(req *http.Request, via []*http.Request) error {
 
 	if len(via) > 0 {
 		for headerName, headerVals := range via[0].Header {
-			if headerName == "Accept" || headerName == "Range" {
-				for _, val := range headerVals {
+			if headerName != "Accept" && headerName != "Range" {
+				continue
+			}
+			for _, val := range headerVals {
+				// Don't add to redirected request if redirected
+				// request already has a header with the same
+				// name and value.
+				hasValue := false
+				for _, existingVal := range req.Header[headerName] {
+					if existingVal == val {
+						hasValue = true
+						break
+					}
+				}
+				if !hasValue {
 					req.Header.Add(headerName, val)
 				}
 			}


### PR DESCRIPTION
A changeset under consideration for Go 1.7 would automatically copy
headers on redirect. This change future-proofs our code so we won't make
duplicate copies of the headers if net/http does it automatically in the
future.