### PR TITLE
Add option to disable signatures

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -145,6 +145,21 @@ type Configuration struct {
 	Health Health `yaml:"health,omitempty"`
 
 	Proxy Proxy `yaml:"proxy,omitempty"`
+
+	// Compatibility is used for configurations of working with older or deprecated features.
+	Compatibility struct {
+		// Schema1 configures how schema1 manifests will be handled
+		Schema1 struct {
+			// TrustKey is the signing key to use for adding the signature to
+			// schema1 manifests.
+			TrustKey string `yaml:"signingkeyfile,omitempty"`
+
+			// DisableSignatureStore will cause all signatures attached to schema1 manifests
+			// to be ignored. Signatures will be generated on all schema1 manifest requests
+			// rather than only requests which converted schema2 to schema1.
+			DisableSignatureStore bool `yaml:"disablesignaturestore,omitempty"`
+		} `yaml:"schema1,omitempty"`
+	} `yaml:"compatibility,omitempty"`
 }
 
 // LogHook is composed of hook Level and Type.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,6 +235,10 @@ information about each option that appears later in this page.
       remoteurl: https://registry-1.docker.io
       username: [username]
       password: [password]
+    compatibility:
+      schema1:
+        signingkeyfile: /etc/registry/key.json
+        disablesignaturestore: true
 
 In some instances a configuration option is **optional** but it contains child
 options marked as **required**. This indicates that you can omit the parent with
@@ -1732,6 +1736,55 @@ Proxy enables a registry to be configured as a pull through cache to the officia
 
 To enable pulling private repositories (e.g. `batman/robin`) a username and password for user `batman` must be specified.  Note: These private repositories will be stored in the proxy cache's storage and relevant measures should be taken to protect access to this.
 
+## Compatibility
+
+    compatibility:
+      schema1:
+        signingkeyfile: /etc/registry/key.json
+        disablesignaturestore: true
+
+Configure handling of older and deprecated features. Each subsection
+defines a such a feature with configurable behavior.
+
+### Schema1
+
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Required</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>
+      <code>signingkeyfile</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+     The signing private key used for adding signatures to schema1 manifests.
+     If no signing key is provided, a new ECDSA key will be generated on
+     startup.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>disablesignaturestore</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+     Disables storage of signatures attached to schema1 manifests. By default
+     signatures are detached from schema1 manifests, stored, and reattached
+     when the manifest is requested. When this is true, the storage is disabled
+     and a new signature is always generated for schema1 manifests using the
+     schema1 signing key. Disabling signature storage will cause all newly
+     uploaded signatures to be discarded. Existing stored signatures will not
+     be removed but they will not be re-attached to the corresponding manifest.
+    </td>
+  </tr>
+</table>
 
 ## Example: Development configuration
 

--- a/manifest/schema1/manifest.go
+++ b/manifest/schema1/manifest.go
@@ -102,7 +102,7 @@ type SignedManifest struct {
 	Canonical []byte `json:"-"`
 
 	// all contains the byte representation of the Manifest including signatures
-	// and is retuend by Payload()
+	// and is returned by Payload()
 	all []byte
 }
 

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -28,11 +28,10 @@ type manifestStoreTestEnv struct {
 	tag        string
 }
 
-func newManifestStoreTestEnv(t *testing.T, name reference.Named, tag string) *manifestStoreTestEnv {
+func newManifestStoreTestEnv(t *testing.T, name reference.Named, tag string, options ...RegistryOption) *manifestStoreTestEnv {
 	ctx := context.Background()
 	driver := inmemory.New()
-	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(
-		memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
+	registry, err := NewRegistry(ctx, driver, options...)
 	if err != nil {
 		t.Fatalf("error creating registry: %v", err)
 	}
@@ -53,13 +52,26 @@ func newManifestStoreTestEnv(t *testing.T, name reference.Named, tag string) *ma
 }
 
 func TestManifestStorage(t *testing.T) {
+	testManifestStorage(t, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
+}
+
+func TestManifestStorageDisabledSignatures(t *testing.T) {
+	k, err := libtrust.GenerateECP256PrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	testManifestStorage(t, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect, DisableSchema1Signatures, Schema1SigningKey(k))
+}
+
+func testManifestStorage(t *testing.T, options ...RegistryOption) {
 	repoName, _ := reference.ParseNamed("foo/bar")
-	env := newManifestStoreTestEnv(t, repoName, "thetag")
+	env := newManifestStoreTestEnv(t, repoName, "thetag", options...)
 	ctx := context.Background()
 	ms, err := env.repository.Manifests(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+	equalSignatures := env.registry.(*registry).schema1SignaturesEnabled
 
 	m := schema1.Manifest{
 		Versioned: manifest.Versioned{
@@ -159,8 +171,14 @@ func TestManifestStorage(t *testing.T) {
 		t.Fatalf("unexpected manifest type from signedstore")
 	}
 
-	if !reflect.DeepEqual(fetchedManifest, sm) {
-		t.Fatalf("fetched manifest not equal: %#v != %#v", fetchedManifest, sm)
+	if !bytes.Equal(fetchedManifest.Canonical, sm.Canonical) {
+		t.Fatalf("fetched payload does not match original payload: %q != %q", fetchedManifest.Canonical, sm.Canonical)
+	}
+
+	if equalSignatures {
+		if !reflect.DeepEqual(fetchedManifest, sm) {
+			t.Fatalf("fetched manifest not equal: %#v != %#v", fetchedManifest.Manifest, sm.Manifest)
+		}
 	}
 
 	_, pl, err := fetchedManifest.Payload()
@@ -196,8 +214,19 @@ func TestManifestStorage(t *testing.T) {
 		t.Fatalf("unexpected error fetching manifest by digest: %v", err)
 	}
 
-	if !reflect.DeepEqual(fetchedByDigest, fetchedManifest) {
-		t.Fatalf("fetched manifest not equal: %#v != %#v", fetchedByDigest, fetchedManifest)
+	byDigestManifest, ok := fetchedByDigest.(*schema1.SignedManifest)
+	if !ok {
+		t.Fatalf("unexpected manifest type from signedstore")
+	}
+
+	if !bytes.Equal(byDigestManifest.Canonical, fetchedManifest.Canonical) {
+		t.Fatalf("fetched manifest not equal: %q != %q", byDigestManifest.Canonical, fetchedManifest.Canonical)
+	}
+
+	if equalSignatures {
+		if !reflect.DeepEqual(fetchedByDigest, fetchedManifest) {
+			t.Fatalf("fetched manifest not equal: %#v != %#v", fetchedByDigest, fetchedManifest)
+		}
 	}
 
 	sigs, err := fetchedJWS.Signatures()
@@ -286,14 +315,16 @@ func TestManifestStorage(t *testing.T) {
 		t.Fatalf("payloads are not equal")
 	}
 
-	receivedSigs, err := receivedJWS.Signatures()
-	if err != nil {
-		t.Fatalf("error getting signatures: %v", err)
-	}
+	if equalSignatures {
+		receivedSigs, err := receivedJWS.Signatures()
+		if err != nil {
+			t.Fatalf("error getting signatures: %v", err)
+		}
 
-	for i, sig := range receivedSigs {
-		if !bytes.Equal(sig, expectedSigs[i]) {
-			t.Fatalf("mismatched signatures from remote: %v != %v", string(sig), string(expectedSigs[i]))
+		for i, sig := range receivedSigs {
+			if !bytes.Equal(sig, expectedSigs[i]) {
+				t.Fatalf("mismatched signatures from remote: %v != %v", string(sig), string(expectedSigs[i]))
+			}
 		}
 	}
 


### PR DESCRIPTION
Add option for specifying trust key for signing schema1 manifests.
Since schema1 signature key identifiers are not verified anywhere and deprecated, storing signatures is no longer a requirement.
Furthermore in schema2 there is no signature, requiring the registry to already add signatures to generated schema1 manifests.

Remaining items if design approved:
- [ ] Configuration documentation update