### PR TITLE
read the actual number of bytes according to the initial size.

### DIFF
--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -1184,7 +1184,11 @@ func (rr *randReader) Read(p []byte) (n int, err error) {
 	rr.m.Lock()
 	defer rr.m.Unlock()
 
-	n = copy(p, randomContents(int64(len(p))))
+	toread := int64(len(p))
+	if toread > rr.r {
+		toread = rr.r
+	}
+	n = copy(p, randomContents(toread))
 	rr.r -= int64(n)
 
 	if rr.r <= 0 {


### PR DESCRIPTION
Dear maintainer,
This PR is to grantee that we will read the correct number of bytes from randReader in testsuites of storage driver.
Currently, we will usually read more number of bytes than the initial size from randReader.