### PR TITLE
Update title of Registry to Docker Registry

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 <!--[metadata]>
 +++
-title = "Registry"
+title = "Docker Registry"
 description = "High-level overview of the Registry"
 keywords = ["registry, on-prem, images, tags, repository, distribution"]
 [menu.main]


### PR DESCRIPTION
This adds Docker to the Registry menu.

![image](https://cloud.githubusercontent.com/assets/1347209/12822120/5717087a-cb1b-11e5-98d5-d493aa396bca.png)


Signed-off-by: Mary Anthony <mary@docker.com>

cc/ @RichardScothern @endophage @dmp42 