### PR TITLE
Allow uppercase characters in hostnames

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -6,7 +6,7 @@
 // 	reference                       := repository [ ":" tag ] [ "@" digest ]
 //	name                            := [hostname '/'] component ['/' component]*
 //	hostname                        := hostcomponent ['.' hostcomponent]* [':' port-number]
-//	hostcomponent                   := /([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])/
+//	hostcomponent                   := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
 //	port-number                     := /[0-9]+/
 //	component                       := alpha-numeric [separator alpha-numeric]*
 // 	alpha-numeric                   := /[a-z0-9]+/

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -22,7 +22,7 @@ var (
 	// hostnameComponentRegexp restricts the registry hostname component of a
 	// repository name to start with a component as defined by hostnameRegexp
 	// and followed by an optional port.
-	hostnameComponentRegexp = match(`(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])`)
+	hostnameComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
 
 	// hostnameRegexp defines the structure of potential hostname components
 	// that may be part of image names. This is purposely a subset of what is

--- a/reference/regexp_test.go
+++ b/reference/regexp_test.go
@@ -111,6 +111,10 @@ func TestHostRegexp(t *testing.T) {
 			input: "xn--n3h.com", // ☃.com in punycode
 			match: true,
 		},
+		{
+			input: "Asdf.com", // uppercase character
+			match: true,
+		},
 	}
 	r := regexp.MustCompile(`^` + hostnameRegexp.String() + `$`)
 	for i := range hostcases {
@@ -398,6 +402,14 @@ func TestFullNameRegexp(t *testing.T) {
 			input: "registry.io/foo/project--id.module--name.ver---sion--name",
 			match: true,
 			subs:  []string{"registry.io", "foo/project--id.module--name.ver---sion--name"},
+		},
+		{
+			input: "Asdf.com/foo/bar", // uppercase character in hostname
+			match: true,
+		},
+		{
+			input: "Foo/FarB", // uppercase characters in remote name
+			match: false,
 		},
 	}
 	for i := range testcases {


### PR DESCRIPTION
This allows hostnames to contain uppercase characters, matching behavior
in Docker versions before 1.10. It does not attempt to canonicalize
hostnames into a lowercase format before parsing, since this could lead
to corner cases (for example, making `Hostname.Domain.Com/ref` ambiguous
on a daemon which contains references for both `hostname.domain.com/ref`
and `Hostname.Domain.Com/ref`).

Fixes: #1433