### PR TITLE
Lowercase name portion of references

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -6,7 +6,7 @@
 // 	reference                       := repository [ ":" tag ] [ "@" digest ]
 //	name                            := [hostname '/'] component ['/' component]*
 //	hostname                        := hostcomponent ['.' hostcomponent]* [':' port-number]
-//	hostcomponent                   := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+//	hostcomponent                   := /([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])/
 //	port-number                     := /[0-9]+/
 //	component                       := alpha-numeric [separator alpha-numeric]*
 // 	alpha-numeric                   := /[a-z0-9]+/

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -6,10 +6,10 @@
 // 	reference                       := repository [ ":" tag ] [ "@" digest ]
 //	name                            := [hostname '/'] component ['/' component]*
 //	hostname                        := hostcomponent ['.' hostcomponent]* [':' port-number]
-//	hostcomponent                   := /([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])/
+//	hostcomponent                   := /([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])/
 //	port-number                     := /[0-9]+/
 //	component                       := alpha-numeric [separator alpha-numeric]*
-// 	alpha-numeric                   := /[a-z0-9]+/
+// 	alpha-numeric                   := /[A-Za-z0-9]+/
 //	separator                       := /[_.]|__|[-]*/
 //
 //	tag                             := /[\w][\w.-]{0,127}/
@@ -24,6 +24,7 @@ package reference
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/docker/distribution/digest"
 )
@@ -158,7 +159,7 @@ func Parse(s string) (Reference, error) {
 	}
 
 	ref := reference{
-		name: matches[1],
+		name: strings.ToLower(matches[1]),
 		tag:  matches[2],
 	}
 	if matches[3] != "" {
@@ -203,7 +204,7 @@ func WithName(name string) (Named, error) {
 	if !anchoredNameRegexp.MatchString(name) {
 		return nil, ErrReferenceInvalidFormat
 	}
-	return repository(name), nil
+	return repository(strings.ToLower(name)), nil
 }
 
 // WithTag combines the name from "name" and the tag from "tag" to form a

--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -150,6 +150,21 @@ func TestReferenceParse(t *testing.T) {
 			repository: "foo/foo_bar.com",
 			tag:        "8080",
 		},
+		{
+			input:      "TEST_REF",
+			repository: "test_ref",
+		},
+		{
+			input:      "Hostname:8080/Name",
+			hostname:   "hostname:8080",
+			repository: "hostname:8080/name",
+		},
+		{
+			input:      "Hostname:8080/Name:TAG",
+			hostname:   "hostname:8080",
+			repository: "hostname:8080/name",
+			tag:        "TAG",
+		},
 	}
 	for _, testcase := range referenceTestcases {
 		failf := func(format string, v ...interface{}) {
@@ -169,7 +184,7 @@ func TestReferenceParse(t *testing.T) {
 			failf("unexpected parse error: %v", err)
 			continue
 		}
-		if repo.String() != testcase.input {
+		if !strings.EqualFold(repo.String(), testcase.input) {
 			failf("mismatched repo: got %q, expected %q", repo.String(), testcase.input)
 		}
 

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -5,7 +5,7 @@ import "regexp"
 var (
 	// alphaNumericRegexp defines the alpha numeric atom, typically a
 	// component of names. This only allows lower case characters and digits.
-	alphaNumericRegexp = match(`[a-z0-9]+`)
+	alphaNumericRegexp = match(`[A-Za-z0-9]+`)
 
 	// separatorRegexp defines the separators allowed to be embedded in name
 	// components. This allow one period, one or two underscore and multiple
@@ -22,7 +22,7 @@ var (
 	// hostnameComponentRegexp restricts the registry hostname component of a
 	// repository name to start with a component as defined by hostnameRegexp
 	// and followed by an optional port.
-	hostnameComponentRegexp = match(`(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])`)
+	hostnameComponentRegexp = match(`(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])`)
 
 	// hostnameRegexp defines the structure of potential hostname components
 	// that may be part of image names. This is purposely a subset of what is

--- a/reference/regexp.go
+++ b/reference/regexp.go
@@ -22,7 +22,7 @@ var (
 	// hostnameComponentRegexp restricts the registry hostname component of a
 	// repository name to start with a component as defined by hostnameRegexp
 	// and followed by an optional port.
-	hostnameComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
+	hostnameComponentRegexp = match(`(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])`)
 
 	// hostnameRegexp defines the structure of potential hostname components
 	// that may be part of image names. This is purposely a subset of what is

--- a/reference/regexp_test.go
+++ b/reference/regexp_test.go
@@ -111,10 +111,6 @@ func TestHostRegexp(t *testing.T) {
 			input: "xn--n3h.com", // ☃.com in punycode
 			match: true,
 		},
-		{
-			input: "Asdf.com", // uppercase character
-			match: true,
-		},
 	}
 	r := regexp.MustCompile(`^` + hostnameRegexp.String() + `$`)
 	for i := range hostcases {
@@ -402,14 +398,6 @@ func TestFullNameRegexp(t *testing.T) {
 			input: "registry.io/foo/project--id.module--name.ver---sion--name",
 			match: true,
 			subs:  []string{"registry.io", "foo/project--id.module--name.ver---sion--name"},
-		},
-		{
-			input: "Asdf.com/foo/bar", // uppercase character in hostname
-			match: true,
-		},
-		{
-			input: "Foo/FarB", // uppercase characters in remote name
-			match: false,
 		},
 	}
 	for i := range testcases {


### PR DESCRIPTION
This is a different approach to fixing #1433, after some discussion. It does two things:

- Revert #1434.
- Replace this with a new commit: extend regexps to allow uppercase and lowercase, then lowercase name portion after parsing.

This involves the behavioral change that `ref.String()` may not equal the originally parsed text under a case-sensitive string comparison.