### PR TITLE
Fix schema1 manifest etag and docker content digest header

### DIFF
--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -196,6 +196,7 @@ func (imh *imageManifestHandler) convertSchema2Manifest(schema2Manifest *schema2
 		imh.Errors = append(imh.Errors, v2.ErrorCodeManifestInvalid.WithDetail(err))
 		return nil, err
 	}
+	imh.Digest = digest.FromBytes(manifest.(*schema1.SignedManifest).Canonical)
 
 	return manifest, nil
 }


### PR DESCRIPTION
When schema2 manifests are rewritten as schema1 currently the etag and docker content digest header keep the value for the schema2 manifest.

Fixes #1444