### PR TITLE
remove argument context from tag service interface

### DIFF
--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -205,7 +205,7 @@ type tags struct {
 }
 
 // All returns all tags
-func (t *tags) All(ctx context.Context) ([]string, error) {
+func (t *tags) All() ([]string, error) {
 	var tags []string
 
 	u, err := t.ub.BuildTagsURL(t.name)
@@ -283,7 +283,7 @@ func descriptorFromResponse(response *http.Response) (distribution.Descriptor, e
 // Get issues a HEAD request for a Manifest against its named endpoint in order
 // to construct a descriptor for the tag.  If the registry doesn't support HEADing
 // a manifest, fallback to GET.
-func (t *tags) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
+func (t *tags) Get(tag string) (distribution.Descriptor, error) {
 	ref, err := reference.WithTag(t.name, tag)
 	if err != nil {
 		return distribution.Descriptor{}, err
@@ -315,15 +315,15 @@ check:
 	}
 }
 
-func (t *tags) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+func (t *tags) Lookup(digest distribution.Descriptor) ([]string, error) {
 	panic("not implemented")
 }
 
-func (t *tags) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
+func (t *tags) Tag(tag string, desc distribution.Descriptor) error {
 	panic("not implemented")
 }
 
-func (t *tags) Untag(ctx context.Context, tag string) error {
+func (t *tags) Untag(tag string) error {
 	panic("not implemented")
 }
 

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -912,7 +912,7 @@ func TestManifestTags(t *testing.T) {
 	ctx := context.Background()
 	tagService := r.Tags(ctx)
 
-	tags, err := tagService.All(ctx)
+	tags, err := tagService.All()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -73,7 +73,7 @@ func (imh *imageManifestHandler) GetImageManifest(w http.ResponseWriter, r *http
 	var manifest distribution.Manifest
 	if imh.Tag != "" {
 		tags := imh.Repository.Tags(imh)
-		desc, err := tags.Get(imh, imh.Tag)
+		desc, err := tags.Get(imh.Tag)
 		if err != nil {
 			imh.Errors = append(imh.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
 			return
@@ -281,7 +281,7 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 	// Tag this manifest
 	if imh.Tag != "" {
 		tags := imh.Repository.Tags(imh)
-		err = tags.Tag(imh, imh.Tag, desc)
+		err = tags.Tag(imh.Tag, desc)
 		if err != nil {
 			imh.Errors = append(imh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 			return
@@ -339,14 +339,14 @@ func (imh *imageManifestHandler) DeleteImageManifest(w http.ResponseWriter, r *h
 	}
 
 	tagService := imh.Repository.Tags(imh)
-	referencedTags, err := tagService.Lookup(imh, distribution.Descriptor{Digest: imh.Digest})
+	referencedTags, err := tagService.Lookup(distribution.Descriptor{Digest: imh.Digest})
 	if err != nil {
 		imh.Errors = append(imh.Errors, err)
 		return
 	}
 
 	for _, tag := range referencedTags {
-		if err := tagService.Untag(imh, tag); err != nil {
+		if err := tagService.Untag(tag); err != nil {
 			imh.Errors = append(imh.Errors, err)
 			return
 		}

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -36,7 +36,7 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	tagService := th.Repository.Tags(th)
-	tags, err := tagService.All(th)
+	tags, err := tagService.All()
 	if err != nil {
 		switch err := err.(type) {
 		case distribution.ErrRepositoryUnknown:

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -157,6 +157,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 		tags: &proxyTagService{
 			localTags:  localRepo.Tags(ctx),
 			remoteTags: remoteRepo.Tags(ctx),
+			ctx:        ctx,
 		},
 	}, nil
 }

--- a/registry/proxy/proxytagservice.go
+++ b/registry/proxy/proxytagservice.go
@@ -7,6 +7,7 @@ import (
 
 // proxyTagService supports local and remote lookup of tags.
 type proxyTagService struct {
+	ctx        context.Context
 	localTags  distribution.TagService
 	remoteTags distribution.TagService
 }
@@ -16,43 +17,43 @@ var _ distribution.TagService = proxyTagService{}
 // Get attempts to get the most recent digest for the tag by checking the remote
 // tag service first and then caching it locally.  If the remote is unavailable
 // the local association is returned
-func (pt proxyTagService) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
-	desc, err := pt.remoteTags.Get(ctx, tag)
+func (pt proxyTagService) Get(tag string) (distribution.Descriptor, error) {
+	desc, err := pt.remoteTags.Get(tag)
 	if err == nil {
-		err := pt.localTags.Tag(ctx, tag, desc)
+		err := pt.localTags.Tag(tag, desc)
 		if err != nil {
 			return distribution.Descriptor{}, err
 		}
 		return desc, nil
 	}
 
-	desc, err = pt.localTags.Get(ctx, tag)
+	desc, err = pt.localTags.Get(tag)
 	if err != nil {
 		return distribution.Descriptor{}, err
 	}
 	return desc, nil
 }
 
-func (pt proxyTagService) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
+func (pt proxyTagService) Tag(tag string, desc distribution.Descriptor) error {
 	return distribution.ErrUnsupported
 }
 
-func (pt proxyTagService) Untag(ctx context.Context, tag string) error {
-	err := pt.localTags.Untag(ctx, tag)
+func (pt proxyTagService) Untag(tag string) error {
+	err := pt.localTags.Untag(tag)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (pt proxyTagService) All(ctx context.Context) ([]string, error) {
-	tags, err := pt.remoteTags.All(ctx)
+func (pt proxyTagService) All() ([]string, error) {
+	tags, err := pt.remoteTags.All()
 	if err == nil {
 		return tags, err
 	}
-	return pt.localTags.All(ctx)
+	return pt.localTags.All()
 }
 
-func (pt proxyTagService) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+func (pt proxyTagService) Lookup(digest distribution.Descriptor) ([]string, error) {
 	return []string{}, distribution.ErrUnsupported
 }

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -162,6 +162,7 @@ func (repo *repository) Named() reference.Named {
 
 func (repo *repository) Tags(ctx context.Context) distribution.TagService {
 	tags := &tagStore{
+		ctx:        ctx,
 		repository: repo,
 		blobStore:  repo.registry.blobStore,
 	}

--- a/registry/storage/tagstore_test.go
+++ b/registry/storage/tagstore_test.go
@@ -37,21 +37,20 @@ func testTagStore(t *testing.T) *tagsTestEnv {
 func TestTagStoreTag(t *testing.T) {
 	env := testTagStore(t)
 	tags := env.ts
-	ctx := env.ctx
 
 	d := distribution.Descriptor{}
-	err := tags.Tag(ctx, "latest", d)
+	err := tags.Tag("latest", d)
 	if err == nil {
 		t.Errorf("unexpected error putting malformed descriptor : %s", err)
 	}
 
 	d.Digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	err = tags.Tag(ctx, "latest", d)
+	err = tags.Tag("latest", d)
 	if err != nil {
 		t.Error(err)
 	}
 
-	d1, err := tags.Get(ctx, "latest")
+	d1, err := tags.Get("latest")
 	if err != nil {
 		t.Error(err)
 	}
@@ -62,12 +61,12 @@ func TestTagStoreTag(t *testing.T) {
 
 	// Overwrite existing
 	d.Digest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	err = tags.Tag(ctx, "latest", d)
+	err = tags.Tag("latest", d)
 	if err != nil {
 		t.Error(err)
 	}
 
-	d1, err = tags.Get(ctx, "latest")
+	d1, err = tags.Get("latest")
 	if err != nil {
 		t.Error(err)
 	}
@@ -80,25 +79,24 @@ func TestTagStoreTag(t *testing.T) {
 func TestTagStoreUnTag(t *testing.T) {
 	env := testTagStore(t)
 	tags := env.ts
-	ctx := env.ctx
 	desc := distribution.Descriptor{Digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
 
-	err := tags.Untag(ctx, "latest")
+	err := tags.Untag("latest")
 	if err == nil {
 		t.Errorf("Expected error untagging non-existant tag")
 	}
 
-	err = tags.Tag(ctx, "latest", desc)
+	err = tags.Tag("latest", desc)
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = tags.Untag(ctx, "latest")
+	err = tags.Untag("latest")
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = tags.Get(ctx, "latest")
+	_, err = tags.Get("latest")
 	if err == nil {
 		t.Error("Expected error getting untagged tag")
 	}
@@ -107,19 +105,18 @@ func TestTagStoreUnTag(t *testing.T) {
 func TestTagStoreAll(t *testing.T) {
 	env := testTagStore(t)
 	tagStore := env.ts
-	ctx := env.ctx
 
 	alpha := "abcdefghijklmnopqrstuvwxyz"
 	for i := 0; i < len(alpha); i++ {
 		tag := alpha[i]
 		desc := distribution.Descriptor{Digest: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}
-		err := tagStore.Tag(ctx, string(tag), desc)
+		err := tagStore.Tag(string(tag), desc)
 		if err != nil {
 			t.Error(err)
 		}
 	}
 
-	all, err := tagStore.All(ctx)
+	all, err := tagStore.All()
 	if err != nil {
 		t.Error(err)
 	}
@@ -134,12 +131,12 @@ func TestTagStoreAll(t *testing.T) {
 	}
 
 	removed := "a"
-	err = tagStore.Untag(ctx, removed)
+	err = tagStore.Untag(removed)
 	if err != nil {
 		t.Error(err)
 	}
 
-	all, err = tagStore.All(ctx)
+	all, err = tagStore.All()
 	if err != nil {
 		t.Error(err)
 	}
@@ -154,12 +151,11 @@ func TestTagStoreAll(t *testing.T) {
 func TestTagLookup(t *testing.T) {
 	env := testTagStore(t)
 	tagStore := env.ts
-	ctx := env.ctx
 
 	descA := distribution.Descriptor{Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 	desc0 := distribution.Descriptor{Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"}
 
-	tags, err := tagStore.Lookup(ctx, descA)
+	tags, err := tagStore.Lookup(descA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,27 +163,27 @@ func TestTagLookup(t *testing.T) {
 		t.Fatalf("Lookup returned > 0 tags from empty store")
 	}
 
-	err = tagStore.Tag(ctx, "a", descA)
+	err = tagStore.Tag("a", descA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = tagStore.Tag(ctx, "b", descA)
+	err = tagStore.Tag("b", descA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = tagStore.Tag(ctx, "0", desc0)
+	err = tagStore.Tag("0", desc0)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = tagStore.Tag(ctx, "1", desc0)
+	err = tagStore.Tag("1", desc0)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tags, err = tagStore.Lookup(ctx, descA)
+	tags, err = tagStore.Lookup(descA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +192,7 @@ func TestTagLookup(t *testing.T) {
 		t.Errorf("Lookup of descA returned %d tags, expected 2", len(tags))
 	}
 
-	tags, err = tagStore.Lookup(ctx, desc0)
+	tags, err = tagStore.Lookup(desc0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tags.go
+++ b/tags.go
@@ -1,27 +1,23 @@
 package distribution
 
-import (
-	"github.com/docker/distribution/context"
-)
-
 // TagService provides access to information about tagged objects.
 type TagService interface {
 	// Get retrieves the descriptor identified by the tag. Some
 	// implementations may differentiate between "trusted" tags and
 	// "untrusted" tags. If a tag is "untrusted", the mapping will be returned
 	// as an ErrTagUntrusted error, with the target descriptor.
-	Get(ctx context.Context, tag string) (Descriptor, error)
+	Get(tag string) (Descriptor, error)
 
 	// Tag associates the tag with the provided descriptor, updating the
 	// current association, if needed.
-	Tag(ctx context.Context, tag string, desc Descriptor) error
+	Tag(tag string, desc Descriptor) error
 
 	// Untag removes the given tag association
-	Untag(ctx context.Context, tag string) error
+	Untag(tag string) error
 
 	// All returns the set of tags managed by this tag service
-	All(ctx context.Context) ([]string, error)
+	All() ([]string, error)
 
 	// Lookup returns the set of tags referencing the given digest.
-	Lookup(ctx context.Context, digest Descriptor) ([]string, error)
+	Lookup(digest Descriptor) ([]string, error)
 }


### PR DESCRIPTION
The argument `context.Context` is build in application handler, and is not a strong correlation to `TagService` interface.
It can be transferred to tag handler objects by adding a field in `tagStore`, but not by argument.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>