### PR TITLE
Lazily evaluate auth challenges

### DIFF
--- a/registry/proxy/proxyauth.go
+++ b/registry/proxy/proxyauth.go
@@ -8,6 +8,7 @@ import (
 )
 
 const tokenURL = "https://auth.docker.io/token"
+const challengeHeader = "Docker-Distribution-Api-Version"
 
 type userpass struct {
 	username string
@@ -24,12 +25,8 @@ func (c credentials) Basic(u *url.URL) (string, string) {
 	return up.username, up.password
 }
 
-// ConfigureAuth authorizes with the upstream registry
-func ConfigureAuth(remoteURL, username, password string, cm auth.ChallengeManager) (auth.CredentialStore, error) {
-	if err := ping(cm, remoteURL+"/v2/", "Docker-Distribution-Api-Version"); err != nil {
-		return nil, err
-	}
-
+// ConfigureAuth stores credentials for challenge responses
+func configureAuth(username, password string) (auth.CredentialStore, error) {
 	creds := map[string]userpass{
 		tokenURL: {
 			username: username,

--- a/registry/proxy/proxyauth.go
+++ b/registry/proxy/proxyauth.go
@@ -25,7 +25,7 @@ func (c credentials) Basic(u *url.URL) (string, string) {
 	return up.username, up.password
 }
 
-// ConfigureAuth stores credentials for challenge responses
+// configureAuth stores credentials for challenge responses
 func configureAuth(username, password string) (auth.CredentialStore, error) {
 	creds := map[string]userpass{
 		tokenURL: {

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -168,6 +168,7 @@ func makeTestEnv(t *testing.T, name string) *testEnv {
 		remoteStore:    truthBlobs,
 		localStore:     localBlobs,
 		scheduler:      s,
+		authChallenger: &mockChallenger{},
 	}
 
 	te := &testEnv{
@@ -242,6 +243,11 @@ func TestProxyStoreStat(t *testing.T) {
 	if (*remoteStats)["stat"] != remoteBlobCount {
 		t.Errorf("Unexpected remote stat count")
 	}
+
+	if te.store.authChallenger.(*mockChallenger).count != len(te.inRemote) {
+		t.Fatalf("Unexpected auth challenge count, got %#v", te.store.authChallenger)
+	}
+
 }
 
 func TestProxyStoreServeHighConcurrency(t *testing.T) {

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/distribution/manifest"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/proxy/scheduler"
 	"github.com/docker/distribution/registry/storage"
 	"github.com/docker/distribution/registry/storage/cache/memory"
@@ -71,11 +72,19 @@ type mockChallenger struct {
 }
 
 // Called for remote operations only
-func (mc *mockChallenger) tryEstablishChallenges(context.Context) error {
-	mc.Lock()
-	defer mc.Unlock()
+func (m *mockChallenger) tryEstablishChallenges(context.Context) error {
+	m.Lock()
+	defer m.Unlock()
 
-	mc.count++
+	m.count++
+	return nil
+}
+
+func (m *mockChallenger) credentialStore() auth.CredentialStore {
+	return nil
+}
+
+func (m *mockChallenger) challengeManager() auth.ChallengeManager {
 	return nil
 }
 


### PR DESCRIPTION
To avoid any network use unless necessary, delay establishing authorization 
challenges with the upstream until any proxied data is found not to be local.

Implement auth challenges behind an interface and add to unit tests.  Also,
remove a non-sensical unit test.

Closes #1435
Signed-off-by: Richard Scothern <richard.scothern@docker.com>