### PR TITLE
[driver/s3aws] Fix TestStorageClass

### DIFF
--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -186,7 +186,7 @@ func TestStorageClass(t *testing.T) {
 	rrDriverUnwrapped := rrDriver.Base.StorageDriver.(*driver)
 	resp, err = rrDriverUnwrapped.S3.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(rrDriverUnwrapped.Bucket),
-		Key:    aws.String(rrDriverUnwrapped.s3Path(standardFilename)),
+		Key:    aws.String(rrDriverUnwrapped.s3Path(rrFilename)),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error retrieving reduced-redundancy storage file: %v", err)


### PR DESCRIPTION
Fixes bug in TestStorageClass for s3aws driver where the "standard" file
was checked for reduced-redundnancy storage.