### PR TITLE
Fix description of StorageDriver.WriteStream

### DIFF
--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -57,7 +57,6 @@ type StorageDriver interface {
 	// WriteStream stores the contents of the provided io.ReadCloser at a
 	// location designated by the given path.
 	// May be used to resume writing a stream by providing a nonzero offset.
-	// The offset must be no larger than the CurrentSize for this path.
 	WriteStream(ctx context.Context, path string, offset int64, reader io.Reader) (nn int64, err error)
 
 	// Stat retrieves the FileInfo for the given path, including the current


### PR DESCRIPTION
May be my English is bad and I did not understand ( actually I read twice :smile:  ), but a test case
https://github.com/docker/distribution/blob/master/registry/storage/driver/testsuites/testsuites.go#L439
does not meet the requirement that offset must be less than size.