### PR TITLE
Respect errors returned from middleware code

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -8,6 +8,10 @@ import (
 	"github.com/docker/distribution/digest"
 )
 
+// ErrAccessDenied is returned when an access to a requested resource is
+// denied.
+var ErrAccessDenied = errors.New("access denied")
+
 // ErrManifestNotModified is returned when a conditional manifest GetByTag
 // returns nil due to the client indicating it has the latest version
 var ErrManifestNotModified = errors.New("manifest not modified")

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -253,6 +253,8 @@ func (buh *blobUploadHandler) PutBlobUploadComplete(w http.ResponseWriter, r *ht
 			buh.Errors = append(buh.Errors, v2.ErrorCodeDigestInvalid.WithDetail(err))
 		default:
 			switch err {
+			case distribution.ErrAccessDenied:
+				buh.Errors = append(buh.Errors, errcode.ErrorCodeDenied)
 			case distribution.ErrUnsupported:
 				buh.Errors = append(buh.Errors, errcode.ErrorCodeUnsupported)
 			case distribution.ErrBlobInvalidLength, distribution.ErrBlobDigestUnsupported:

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -253,6 +253,10 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 			imh.Errors = append(imh.Errors, errcode.ErrorCodeUnsupported)
 			return
 		}
+		if err == distribution.ErrAccessDenied {
+			imh.Errors = append(imh.Errors, errcode.ErrorCodeDenied)
+			return
+		}
 		switch err := err.(type) {
 		case distribution.ErrManifestVerification:
 			for _, verificationError := range err {


### PR DESCRIPTION
Middleware code may return error targeted for client application with
specified HTTP code (e.g. 403 Forbidden). Error handler should respect
it.