### PR TITLE
Add oauth support to registry client auth

### DIFF
--- a/registry/proxy/proxyauth.go
+++ b/registry/proxy/proxyauth.go
@@ -25,6 +25,13 @@ func (c credentials) Basic(u *url.URL) (string, string) {
 	return up.username, up.password
 }
 
+func (c credentials) RefreshToken(u *url.URL, service string) string {
+	return ""
+}
+
+func (c credentials) SetRefreshToken(u *url.URL, service, token string) {
+}
+
 // configureAuth stores credentials for challenge responses
 func configureAuth(username, password string) (auth.CredentialStore, error) {
 	creds := map[string]userpass{


### PR DESCRIPTION
Extends credentialstore interface to support oauth token servers.

Implements the behavior defined in #1418 