### PR TITLE
Makefile: remove AUTHORS from default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ endif
 GO_LDFLAGS=-ldflags "-X `go list ./version`.Version=$(VERSION)"
 
 .PHONY: clean all fmt vet lint build test binaries
-.DEFAULT: default
-all: AUTHORS clean fmt vet fmt lint build test binaries
+.DEFAULT: all
+all: fmt vet fmt lint build test binaries
 
 AUTHORS: .mailmap .git/HEAD
 	 git log --format='%aN <%aE>' | sort -fu > $@


### PR DESCRIPTION
While it is generally good practice to look before jumping, many
developers enjoy running `make` without reading the Makefile and
indiscriminately use `git add -A`. This behavior, coupled with
generating AUTHORS in the default target result in garbage in various
PRs and extra round trips to remove said garbage.

Signed-off-by: Stephen J Day <stephen.day@docker.com>