### PR TITLE
Fix some typos in comments and strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ It's mandatory to:
 
 Complying to these simple rules will greatly accelerate the review process, and will ensure you have a pleasant experience in contributing code to the Registry.
 
-Have a look at a great, succesful contribution: the [Ceph driver PR](https://github.com/docker/distribution/pull/443)
+Have a look at a great, successful contribution: the [Ceph driver PR](https://github.com/docker/distribution/pull/443)
 
 ## Coding Style
 

--- a/docs/apache.md
+++ b/docs/apache.md
@@ -22,9 +22,9 @@ If you just want authentication for your registry, and are happy maintaining use
 
 With the method presented here, you implement basic authentication for docker engines in a reverse proxy that sits in front of your registry.
 
-While we use a simple htpasswd file as an example, any other apache authentication backend should be fairly easy to implement once you are done with the exemple.
+While we use a simple htpasswd file as an example, any other apache authentication backend should be fairly easy to implement once you are done with the example.
 
-We also implement push restriction (to a limited user group) for the sake of the exemple. Again, you should modify this to fit your mileage. 
+We also implement push restriction (to a limited user group) for the sake of the example. Again, you should modify this to fit your mileage. 
 
 ### Gotchas
 

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -78,7 +78,7 @@ A docker engine instance would like to run verified image named
 requesting the manifest for "library/ubuntu:latest". An untrusted registry
 returns a manifest. Before proceeding to download the individual layers, the
 engine verifies the manifest's signature, ensuring that the content was
-produced from a trusted source and no tampering has occured. After each layer
+produced from a trusted source and no tampering has occurred. After each layer
 is downloaded, the engine verifies the digest of the layer, ensuring that the
 content matches that specified by the manifest.
 
@@ -943,7 +943,7 @@ results, the URL for the next block is encoded in an
 relation. The presence of the `Link` header communicates to the client that
 the entire result set has not been returned and another request must be
 issued. If the header is not present, the client can assume that all results
-have been recieved.
+have been received.
 
 > __NOTE:__ In the request template above, note that the brackets
 > are required. For example, if the url is

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -78,7 +78,7 @@ A docker engine instance would like to run verified image named
 requesting the manifest for "library/ubuntu:latest". An untrusted registry
 returns a manifest. Before proceeding to download the individual layers, the
 engine verifies the manifest's signature, ensuring that the content was
-produced from a trusted source and no tampering has occured. After each layer
+produced from a trusted source and no tampering has occurred. After each layer
 is downloaded, the engine verifies the digest of the layer, ensuring that the
 content matches that specified by the manifest.
 
@@ -943,7 +943,7 @@ results, the URL for the next block is encoded in an
 relation. The presence of the `Link` header communicates to the client that
 the entire result set has not been returned and another request must be
 issued. If the header is not present, the client can assume that all results
-have been recieved.
+have been received.
 
 > __NOTE:__ In the request template above, note that the brackets
 > are required. For example, if the url is

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -94,7 +94,7 @@ func makeTrustedKeyMap(rootKeys []libtrust.PrivateKey) map[string]libtrust.Publi
 func makeTestToken(issuer, audience string, access []*ResourceActions, rootKey libtrust.PrivateKey, depth int) (*Token, error) {
 	signingKey, err := makeSigningKeyWithChain(rootKey, depth)
 	if err != nil {
-		return nil, fmt.Errorf("unable to amke signing key with chain: %s", err)
+		return nil, fmt.Errorf("unable to make signing key with chain: %s", err)
 	}
 
 	var rawJWK json.RawMessage

--- a/registry/client/transport/http_reader.go
+++ b/registry/client/transport/http_reader.go
@@ -66,7 +66,7 @@ func (hrs *httpReadSeeker) Read(p []byte) (n int, err error) {
 		return 0, hrs.err
 	}
 
-	// If we seeked to a different position, we need to reset the
+	// If we sought to a different position, we need to reset the
 	// connection. This logic is here instead of Seek so that if
 	// a seek is undone before the next read, the connection doesn't
 	// need to be closed and reopened. A common example of this is

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -213,7 +213,7 @@ func TestProxyManifests(t *testing.T) {
 	// Stat - must check local and remote
 	exists, err := env.manifests.Exists(ctx, env.manifestDigest)
 	if err != nil {
-		t.Fatalf("Error checking existance")
+		t.Fatalf("Error checking existence")
 	}
 	if !exists {
 		t.Errorf("Unexpected non-existant manifest")

--- a/registry/proxy/scheduler/scheduler_test.go
+++ b/registry/proxy/scheduler/scheduler_test.go
@@ -45,7 +45,7 @@ func TestSchedule(t *testing.T) {
 		}
 		_, ok := remainingRepos[repoName.String()]
 		if !ok {
-			t.Fatalf("Trying to remove nonexistant repo: %s", repoName)
+			t.Fatalf("Trying to remove nonexistent repo: %s", repoName)
 		}
 		t.Log("removing", repoName)
 		delete(remainingRepos, repoName.String())
@@ -86,7 +86,7 @@ func TestRestoreOld(t *testing.T) {
 		}
 		_, ok := remainingRepos[r.String()]
 		if !ok {
-			t.Fatalf("Trying to remove nonexistant repo: %s", r)
+			t.Fatalf("Trying to remove nonexistent repo: %s", r)
 		}
 		delete(remainingRepos, r.String())
 		return nil

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -924,7 +924,7 @@ func (suite *DriverSuite) TestEventualConsistency(c *check.C) {
 	}
 
 	if misswrites > 0 {
-		c.Log("There were " + string(misswrites) + " occurences of a write not being instantly available.")
+		c.Log("There were " + string(misswrites) + " occurrences of a write not being instantly available.")
 	}
 
 	c.Assert(misswrites, check.Not(check.Equals), 1024)

--- a/registry/storage/walk_test.go
+++ b/registry/storage/walk_test.go
@@ -73,7 +73,7 @@ func TestWalkErrors(t *testing.T) {
 		}
 	}
 
-	err = Walk(ctx, d, "/nonexistant", func(fileInfo driver.FileInfo) error {
+	err = Walk(ctx, d, "/nonexistent", func(fileInfo driver.FileInfo) error {
 		return nil
 	})
 	if err == nil {


### PR DESCRIPTION
All of them were found and fixed by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>