### PR TITLE
Explicitly reference the response limit on _catalog

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1013,7 +1013,8 @@ The response will be in the following format:
     }
 
 For repositories with a large number of tags, this response may be quite
-large. If such a response is expected, one should use the pagination.
+large. If such a response is expected, one should use the pagination. By
+default the response is limited to 100 entries.
 
 #### Pagination
 


### PR DESCRIPTION
When requesting a catalog, the response is by default limited to 100 entries. This commits updates the documentation to make it explicit, otherwise people would expect to get all the entries.