### PR TITLE
Added support to specifiy custom endpoint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,7 @@ information about each option that appears later in this page.
         accesskey: awsaccesskey
         secretkey: awssecretkey
         region: us-west-1
+        regionendpoint: http://myobjects.local
         bucket: bucketname
         encrypt: true
         secure: true
@@ -358,6 +359,7 @@ Permitted values are `error`, `warn`, `info` and `debug`. The default is
         accesskey: awsaccesskey
         secretkey: awssecretkey
         region: us-west-1
+        regionendpoint: http://myobjects.local
         bucket: bucketname
         encrypt: true
         secure: true
@@ -435,7 +437,7 @@ You must configure one backend; if you configure more, the registry returns an e
   </tr>
   <tr>
     <td><code>s3</code></td>
-    <td>Uses Amazon's Simple Storage Service (S3).
+    <td>Uses Amazon's Simple Storage Service (S3) and compatible Storage Services.
     See the <a href="storage-drivers/s3.md">driver's reference documentation</a>.
     </td>
   </tr>

--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -9,7 +9,7 @@ keywords = ["registry, service, driver, images, storage,  S3"]
 
 # S3 storage driver
 
-An implementation of the `storagedriver.StorageDriver` interface which uses Amazon S3 for object storage.
+An implementation of the `storagedriver.StorageDriver` interface which uses Amazon S3 or S3 compatible services for object storage.
 
 ## Parameters
 
@@ -51,6 +51,17 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
     <td>
       The AWS region in which your bucket exists. For the moment, the Go AWS
       library in use does not use the newer DNS based bucket routing.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>regionendpoint</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      Endpoint for S3 compatible storage services (Minio, etc)
     </td>
   </tr>
     <tr>
@@ -145,6 +156,8 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
 **Note** You can provide empty strings for your access and secret keys if you plan on running the driver on an ec2 instance and will handle authentication with the instance's credentials.
 
 `region`: The name of the aws region in which you would like to store objects (for example `us-east-1`). For a list of regions, you can look at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
+
+`regionendpoint`: (optional) Endpoint URL for S3 compatible APIs. This should not be provided when using Amazon S3.
 
 `bucket`: The name of your S3 bucket where you wish to store objects. The bucket must exist prior to the driver initialization.
 

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -30,6 +30,7 @@ func init() {
 	secure := os.Getenv("S3_SECURE")
 	region := os.Getenv("AWS_REGION")
 	root, err := ioutil.TempDir("", "driver-")
+	regionEndpoint := os.Getenv("REGION_ENDPOINT")
 	if err != nil {
 		panic(err)
 	}
@@ -57,6 +58,7 @@ func init() {
 			secretKey,
 			bucket,
 			region,
+			regionEndpoint,
 			encryptBool,
 			secureBool,
 			minChunkSize,


### PR DESCRIPTION
Main purpose of this PR is to enhance the support to provide custom endpoint url which can be used to connect to other S3 compatibly storage services like [Minio](https://github.com/minio/minio).

I also want to know if there is any reason preventing from adding the extra condition to create a bucket if it doesn't exist similar to https://github.com/docker/distribution/blob/master/registry/storage/driver/azure/azure.go#L87