### PR TITLE
command correction in documentation

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -60,7 +60,7 @@ binary can then be run with the following:
 The registry can be run with the default config using the following
 incantation:
 
-    $ $GOPATH/bin/registry $GOPATH/src/github.com/docker/distribution/cmd/registry/config-example.yml
+    $ $GOPATH/bin/registry serve $GOPATH/src/github.com/docker/distribution/cmd/registry/config-example.yml
     INFO[0000] endpoint local-5003 disabled, skipping        app.id=34bbec38-a91a-494a-9a3f-b72f9010081f version=v2.0.0-alpha.1+unknown
     INFO[0000] endpoint local-8083 disabled, skipping        app.id=34bbec38-a91a-494a-9a3f-b72f9010081f version=v2.0.0-alpha.1+unknown
     INFO[0000] listening on :5000                            app.id=34bbec38-a91a-494a-9a3f-b72f9010081f version=v2.0.0-alpha.1+unknown


### PR DESCRIPTION
the original ```$GOPATH/bin/registry $GOPATH/src/github.com/docker/distribution/cmd/registry/config-example.yml``` leads to the error like 

```
Error: unknown command "/Users/EricYang/go/src/github.com/docker/distribution/cmd/registry/config-example.yml" for "registry"
Run 'registry --help' for usage.
```

I think the correct command should be ```registry serve```