### PR TITLE
 Update missing blob error checking with latest Azure API

### DIFF
--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -382,8 +382,8 @@ func (d *driver) listBlobs(container, virtPath string) ([]string, error) {
 }
 
 func is404(err error) bool {
-	statusCodeErr, ok := err.(azure.UnexpectedStatusCodeError)
-	return ok && statusCodeErr.Got() == http.StatusNotFound
+	statusCodeErr, ok := err.(azure.AzureStorageServiceError)
+	return ok && statusCodeErr.StatusCode == http.StatusNotFound
 }
 
 type writer struct {


### PR DESCRIPTION
Change c03b5fc5ee9e4364cc216c712ab8a53daf3b1273 vendored a newer version of the Azure storage API which uses different error structures.  Missing blob errors were not being caught correctly.

Ran unit tests in short mode with a 'free' Azure account.

Signed-off-by: Richard Scothern <richard.scothern@docker.com>