### PR TITLE
Add osversion and osvariant to platform specification

### DIFF
--- a/docs/spec/manifest-v2-2.md
+++ b/docs/spec/manifest-v2-2.md
@@ -89,6 +89,17 @@ image manifest based on the Content-Type returned in the HTTP response.
             The os field specifies the operating system, for example
             `linux` or `windows`.
 
+        - **`os.version`** *string*
+
+            The optional os.version field specifies the operating system version,
+            for example `10.0.10586`.
+
+        - **`os.features`** *array*
+
+            The optional os.features field specifies an array of strings,
+            each listing a required OS feature (for example on Windows
+            `win32k`).
+
         - **`variant`** *string*
 
             The optional variant field specifies a variant of the CPU, for

--- a/manifest/manifestlist/manifestlist.go
+++ b/manifest/manifestlist/manifestlist.go
@@ -47,11 +47,19 @@ type PlatformSpec struct {
 	// OS specifies the operating system, for example `linux` or `windows`.
 	OS string `json:"os"`
 
+	// OSVersion is an optional field specifying the operating system
+	// version, for example `10.0.10586`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
 	// Variant is an optional field specifying a variant of the CPU, for
 	// example `ppc64le` to specify a little-endian version of a PowerPC CPU.
 	Variant string `json:"variant,omitempty"`
 
-	// Features is an optional field specifuing an array of strings, each
+	// Features is an optional field specifying an array of strings, each
 	// listing a required CPU feature (for example `sse4` or `aes`).
 	Features []string `json:"features,omitempty"`
 }


### PR DESCRIPTION
These are needed to differentiate incompatible Windows versions. In the short run, Windows will need os, osvariant, and osversion matching. Eventually we should be able to avoid matching on osvariant.

cc/@aaronlehmann