### PR TITLE
registry: client: auth: type errors

### DIFF
--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -15,9 +15,15 @@ import (
 	"github.com/docker/distribution/registry/client/transport"
 )
 
-// ErrNoBasicAuthCredentials is returned if a request can't be authorized with
-// basic auth due to lack of credentials.
-var ErrNoBasicAuthCredentials = errors.New("no basic auth credentials")
+var (
+	// ErrNoBasicAuthCredentials is returned if a request can't be authorized with
+	// basic auth due to lack of credentials.
+	ErrNoBasicAuthCredentials = errors.New("no basic auth credentials")
+
+	// ErrNoToken is returned if a request is successful but the body does not
+	// contain an authorization token.
+	ErrNoToken = errors.New("authorization server did not include a token in the response")
+)
 
 const defaultClientID = "registry-client"
 
@@ -402,7 +408,7 @@ func (th *tokenHandler) fetchTokenWithBasicAuth(realm *url.URL, service string, 
 	}
 
 	if tr.Token == "" {
-		return "", time.Time{}, errors.New("authorization server did not include a token in the response")
+		return "", time.Time{}, ErrNoToken
 	}
 
 	if tr.ExpiresIn < minimumTokenLifetimeSeconds {


### PR DESCRIPTION
/cc @aaronlehmann - this is one of the many errors, in my opinion, for which we do not have to retry in docker

This is related to https://github.com/docker/docker/pull/21283#issuecomment-198120408 and followup comments.

Basically, in Docker we keep retrying in those cases where it would be more appropriate to give up because the token service is clearly misconfigured if it returns StautsOK w/o meaningful information. This PR will provide strong error types to Docker to compare with.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>