### PR TITLE
Force dependency verification

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,6 +36,9 @@ dependencies:
   # Install dependencies for every copied clone/go version
     - gvm use stable && go get github.com/tools/godep:
         pwd: $BASE_STABLE
+  # Nuke the deps and restore, to ensure we test against "the truth" (being the godeps.json file)
+    - gvm use stable && rm -Rf vendor && rm -Rf Godeps/_workspace && godep restore:
+        pwd: $BASE_STABLE
 
   post:
   # For the stable go version, additionally install linting tools


### PR DESCRIPTION
Seems like right now we have a discrepancy between the content of godeps.json and what is actually vendorized.

This forces a full nuke of the vendorized folder, and reinstall from the json source, making sure we test against that.

Should make (unfortunately) the gcs driver fail. 