### PR TITLE
registry/handlers: set the version on apiBase

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -817,9 +817,11 @@ func (app *App) nameRequired(r *http.Request) bool {
 // api. This can support auth roundtrips to support docker login.
 func apiBase(w http.ResponseWriter, r *http.Request) {
 	const emptyJSON = "{}"
+
 	// Provide a simple /v2/ 200 OK response with empty json response.
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Content-Length", fmt.Sprint(len(emptyJSON)))
+	w.Header().Set("docker-distribution-version", version.Version)
 
 	fmt.Fprint(w, emptyJSON)
 }


### PR DESCRIPTION
It's sometimes useful for clients to check what's the version of the targeted
registry.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>