### PR TITLE
Utulize config log format within gc

### DIFF
--- a/registry/garbagecollect.go
+++ b/registry/garbagecollect.go
@@ -17,9 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func markAndSweep(storageDriver driver.StorageDriver) error {
-	ctx := context.Background()
-
+func markAndSweep(ctx context.Context, storageDriver driver.StorageDriver) error {
 	// Construct a registry
 	registry, err := storage.NewRegistry(ctx, storageDriver)
 	if err != nil {
@@ -141,7 +139,14 @@ var GCCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = markAndSweep(driver)
+		ctx := context.Background()
+		ctx, err = configureLogging(ctx, config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to configure logging with config: %s", err)
+			os.Exit(1)
+		}
+
+		err = markAndSweep(ctx, driver)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to garbage collect: %v", err)
 			os.Exit(1)

--- a/registry/garbagecollect_test.go
+++ b/registry/garbagecollect_test.go
@@ -161,7 +161,7 @@ func TestNoDeletionNoEffect(t *testing.T) {
 	}
 
 	// Run GC
-	err = markAndSweep(inmemoryDriver)
+	err = markAndSweep(context.Background(), inmemoryDriver)
 	if err != nil {
 		t.Fatalf("Failed mark and sweep: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestDeletionHasEffect(t *testing.T) {
 	manifests.Delete(ctx, image3.manifestDigest)
 
 	// Run GC
-	err = markAndSweep(inmemoryDriver)
+	err = markAndSweep(context.Background(), inmemoryDriver)
 	if err != nil {
 		t.Fatalf("Failed mark and sweep: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestOrphanBlobDeleted(t *testing.T) {
 	uploadRandomSchema2Image(t, repo)
 
 	// Run GC
-	err = markAndSweep(inmemoryDriver)
+	err = markAndSweep(context.Background(), inmemoryDriver)
 	if err != nil {
 		t.Fatalf("Failed mark and sweep: %v", err)
 	}


### PR DESCRIPTION
This ensures that the GC command uses the same logging format as specified in the registry's YAML config.