### PR TITLE
Fix signature handling with GC.

### DIFF
--- a/docs/gc.md
+++ b/docs/gc.md
@@ -8,21 +8,34 @@ keywords = ["registry, garbage, images, tags, repository, distribution"]
 
 # What Garbage Collection Does
 
-Garbage collection is a process that delete blobs to which no manifests refer.
-It runs in two phases. First, in the 'mark' phase, the process scans all the 
-manifests in the registry. From these manifests, it constructs a set of content 
-address digests. This set is the 'mark set' and denotes the set of blobs to *not*
-delete. Secondly, in the 'sweep' phase, the process scans all the blobs and if 
-a blob's content address digest is not in the mark set, the process will delete 
-it.
+"Garbage collection deletes blobs which no manifests reference. Manifests and
+blobs which are deleted by their digest through the Registry API will become
+eligible for garbage collection, but the actual blobs will not be removed from
+storage until garbage collection is run.
 
+# How Garbage Collection Works
+
+Garbage collection runs in two phases. First, in the 'mark' phase, the process
+scans all the manifests in the registry. From these manifests, it constructs a
+set of content address digests. This set is the 'mark set' and denotes the set
+of blobs to *not* delete. Secondly, in the 'sweep' phase, the process scans all
+the blobs and if a blob's content address digest is not in the mark set, the
+process will delete it.
+
+> **NOTE** You should ensure that the registry is in read-only mode or not running at
+> all. If you were to upload an image while garbage collection is running, there is the
+> risk that the image's layers will be mistakenly deleted, leading to a corrupted image.
+
+This type of garbage collection is known as stop-the-world garbage collection.  In
+future registry versions the intention is that garbage collection will be an 
+automated background action and this manual process will no longer apply.
 
 # How to Run
 
 You can run garbage collection by running
 
-	docker run --rm registry-image-name garbage-collect /etc/docker/registry/config.yml
+`docker run --rm registry-image-name garbage-collect /etc/docker/registry/config.yml`
 
-NOTE: You should ensure that the registry itself is in read-only mode or not running at
-all. If you were to upload an image while garbage collection is running, there is the
-risk that the image's layers will be mistakenly deleted, leading to a corrupted image.
+Additionally, garbage collection can be run in `dry-run` mode, which will print
+the progress of the mark and sweep phases without removing any data.
+

--- a/registry/garbagecollect.go
+++ b/registry/garbagecollect.go
@@ -19,8 +19,7 @@ import (
 
 func emit(format string, a ...interface{}) {
 	if dryRun {
-		fmt.Printf(format, a...)
-		fmt.Println("")
+		fmt.Printf(format+"\n", a...)
 	}
 }
 
@@ -122,8 +121,8 @@ func markAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 	// Construct vacuum
 	vacuum := storage.NewVacuum(ctx, storageDriver)
 	for dgst := range deleteSet {
+		emit("blob eligible for deletion: %s", dgst)
 		if dryRun {
-			emit("deleting %s", dgst)
 			continue
 		}
 		err = vacuum.RemoveBlob(string(dgst))
@@ -169,7 +168,7 @@ var GCCmd = &cobra.Command{
 
 		k, err := libtrust.GenerateECP256PrivateKey()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s", err)
+			fmt.Fprint(os.Stderr, err)
 			os.Exit(1)
 		}
 

--- a/registry/garbagecollect_test.go
+++ b/registry/garbagecollect_test.go
@@ -161,7 +161,7 @@ func TestNoDeletionNoEffect(t *testing.T) {
 	}
 
 	// Run GC
-	err = markAndSweep(context.Background(), inmemoryDriver)
+	err = markAndSweep(context.Background(), inmemoryDriver, registry)
 	if err != nil {
 		t.Fatalf("Failed mark and sweep: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestDeletionHasEffect(t *testing.T) {
 	manifests.Delete(ctx, image3.manifestDigest)
 
 	// Run GC
-	err = markAndSweep(context.Background(), inmemoryDriver)
+	err = markAndSweep(context.Background(), inmemoryDriver, registry)
 	if err != nil {
 		t.Fatalf("Failed mark and sweep: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestOrphanBlobDeleted(t *testing.T) {
 	uploadRandomSchema2Image(t, repo)
 
 	// Run GC
-	err = markAndSweep(context.Background(), inmemoryDriver)
+	err = markAndSweep(context.Background(), inmemoryDriver, registry)
 	if err != nil {
 		t.Fatalf("Failed mark and sweep: %v", err)
 	}

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -161,16 +161,15 @@ func (ms *manifestStore) GetSignatures(ctx context.Context, manifestDigest diges
 		return nil, err
 	}
 
-	signaturesPath = path.Join(signaturesPath, "sha256")
-
-	signaturePaths, err := ms.blobStore.driver.List(ctx, signaturesPath)
+	alg := string(digest.SHA256)
+	signaturePaths, err := ms.blobStore.driver.List(ctx, path.Join(signaturesPath, alg))
 	if err != nil {
 		return nil, err
 	}
 
 	var digests []digest.Digest
 	for _, sigPath := range signaturePaths {
-		sigdigest, err := digest.ParseDigest("sha256:" + path.Base(sigPath))
+		sigdigest, err := digest.ParseDigest(alg + ":" + path.Base(sigPath))
 		if err != nil {
 			// merely found not a digest
 			continue

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/registry/storage/driver"
 )
 
 // A ManifestHandler gets and puts manifests of a particular type.
@@ -161,13 +162,20 @@ func (ms *manifestStore) GetSignatures(ctx context.Context, manifestDigest diges
 		return nil, err
 	}
 
+	var digests []digest.Digest
 	alg := string(digest.SHA256)
 	signaturePaths, err := ms.blobStore.driver.List(ctx, path.Join(signaturesPath, alg))
-	if err != nil {
+
+	switch err.(type) {
+	case nil:
+		break
+	case driver.PathNotFoundError:
+		// Manifest may have been pushed with signature store disabled
+		return digests, nil
+	default:
 		return nil, err
 	}
 
-	var digests []digest.Digest
 	for _, sigPath := range signaturePaths {
 		sigdigest, err := digest.ParseDigest(alg + ":" + path.Base(sigPath))
 		if err != nil {


### PR DESCRIPTION
Fix signature handling with GC.
    
If a schema 1 manifest is uploaded with the `disablesignaturestore` option set
to true, then no signatures will exist.  Handle this case.
    
If a schema 1 manifest is pushed, deleted, garbage collected and pushed again, the
repository will contain signature links from the first version, but the blobs will
not exist.  Disable the signature store in the garbage-collect command so
signatures are not fetched.

Also, add a dry-run mode.
    
Signed-off-by: Richard Scothern <richard.scothern@docker.com>