### PR TITLE
added heading to get more focus into the headers that need to be set

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -117,6 +117,7 @@ instances. Configuring different redis instances will work (at the time
 of writing), but will not be optimal if the instances are not shared, causing
 more requests to be directed to the backend.
 
+#### Important/Required HTTP-Headers
 Getting the headers correct is very important. For all responses to any
 request under the "/v2/" url space, the `Docker-Distribution-API-Version`
 header should be set to the value "registry/2.0", even for a 4xx response.


### PR DESCRIPTION
I was setting up a v2 registry and it took me much time to get the information that the 'Docker-Distribution-Api-Version' header must be set. I added a heading to the readme to drive more attention to this segment.