### PR TITLE
don't swallow errors in Swift driver's GetContent()

### DIFF
--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -280,7 +280,7 @@ func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
 	if err == swift.ObjectNotFound {
 		return nil, storagedriver.PathNotFoundError{Path: path}
 	}
-	return content, nil
+	return content, err
 }
 
 // PutContent stores the []byte content at a location designated by "path".


### PR DESCRIPTION
In 326c3a9c49486f4c5dbb16508f08b6b766bd4852, which was only intended to be a refactoring commit, the behavior of this block subtly changed so that unknown types of errors would be swallowed instead of propagated.

I noticed this while investigating an error similar to #1539 aka docker/docker#21290. It appears that during GetContent() for a hashstate, the Swift proxy produces an unexpected error. Since this error was silently swallowed, an empty []byte is used to restart the hash, then producing the digest of the empty string instead of the layer's digest.

This PR will not fix the issue, but it should make the actual error more visible by propagating it into `blobWriter#resumeDigest' and 'blobWriter#validateBlob', respectively.

/cc @lebauce