### PR TITLE
Makefile: don't look for golint and godep in specific places

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,8 @@ GO15VENDOREXPERIMENT := 1
 PKGS := $(shell go list -tags "${DOCKER_BUILDTAGS}" ./... | grep -v ^github.com/docker/distribution/vendor/)
 
 # Resolving binary dependencies for specific targets
-GOLINT_BIN := $(GOPATH)/bin/golint
-GOLINT := $(shell [ -x $(GOLINT_BIN) ] && echo $(GOLINT_BIN) || echo '')
-
-GODEP_BIN := $(GOPATH)/bin/godep
-GODEP := $(shell [ -x $(GODEP_BIN) ] && echo $(GODEP_BIN) || echo '')
+GOLINT := $(shell which golint || echo '')
+GODEP := $(shell which godep || echo '')
 
 ${PREFIX}/bin/registry: $(wildcard **/*.go)
 	@echo "+ $@"


### PR DESCRIPTION
Using $GOPATH/bin/godep or $GOPATH/bin/golint is problematic because
$GOPATH can contain multiple colon-separated paths.

We should just run these like normal binaries. The user should make sure
their $PATH contains $GOPATH/bin, if necessary. This is part of normal
Go setup.