### PR TITLE
Ensure we log io.Copy errors and bytes copied/total in uploads

### DIFF
--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -46,7 +46,11 @@ func copyFullPayload(responseWriter http.ResponseWriter, r *http.Request, destWr
 			// instead of showing 0 for the HTTP status.
 			responseWriter.WriteHeader(499)
 
-			ctxu.GetLogger(context).Error("client disconnected during " + action)
+			ctxu.GetLoggerWithFields(context, map[interface{}]interface{}{
+				"error":         err,
+				"copied":        copied,
+				"contentLength": r.ContentLength,
+			}, "error", "copied", "contentLength").Error("client disconnected during " + action)
 			return errors.New("client disconnected")
 		default:
 		}


### PR DESCRIPTION
If there are errors copying the request body into the temporary upload file within `copyFullPayload` we currently assume that the client disconnected and there were no distribution errors.

This change logs any io errors, bytes copied and content length for easier debugging with backends like our favourite NFS.