### PR TITLE
Only check validity of S3 region if not using custom endpoint

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -136,24 +136,26 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		secretKey = ""
 	}
 
+	regionEndpoint := parameters["regionendpoint"]
+	if regionEndpoint == nil {
+		regionEndpoint = ""
+	}
+
 	regionName, ok := parameters["region"]
 	if regionName == nil || fmt.Sprint(regionName) == "" {
 		return nil, fmt.Errorf("No region parameter provided")
 	}
 	region := fmt.Sprint(regionName)
-	_, ok = validRegions[region]
-	if !ok {
-		return nil, fmt.Errorf("Invalid region provided: %v", region)
+	// Don't check the region value if a custom endpoint is provided.
+	if regionEndpoint == "" {
+		if _, ok = validRegions[region]; !ok {
+			return nil, fmt.Errorf("Invalid region provided: %v", region)
+		}
 	}
 
 	bucket := parameters["bucket"]
 	if bucket == nil || fmt.Sprint(bucket) == "" {
 		return nil, fmt.Errorf("No bucket parameter provided")
-	}
-
-	regionEndpoint := parameters["regionendpoint"]
-	if regionEndpoint == nil {
-		regionEndpoint = ""
 	}
 
 	encryptBool := false


### PR DESCRIPTION
The current S3 implementation was expanded in #1512 to allow specifying a custom endpoint. Currently, this only allows talking to a custom S3 implementation with one of a few hardcoded regions.

This PR skips the check to validate the region if a custom S3 endpoint is provided, so that custom regions can be used as well.