### PR TITLE
Use correct media type for config blob in schema2 manifest

### DIFF
--- a/manifest/schema2/builder.go
+++ b/manifest/schema2/builder.go
@@ -55,6 +55,9 @@ func (mb *builder) Build(ctx context.Context) (distribution.Manifest, error) {
 
 	// Add config to the blob store
 	m.Config, err = mb.bs.Put(ctx, MediaTypeConfig, mb.configJSON)
+	// Override MediaType, since Put always replaces the specified media
+	// type with application/octet-stream in the descriptor it returns.
+	m.Config.MediaType = MediaTypeConfig
 	if err != nil {
 		return nil, err
 	}

--- a/manifest/schema2/builder_test.go
+++ b/manifest/schema2/builder_test.go
@@ -32,7 +32,7 @@ func (bs *mockBlobService) Put(ctx context.Context, mediaType string, p []byte) 
 	d := distribution.Descriptor{
 		Digest:    digest.FromBytes(p),
 		Size:      int64(len(p)),
-		MediaType: mediaType,
+		MediaType: "application/octet-stream",
 	}
 	bs.descriptors[d.Digest] = d
 	return d, nil


### PR DESCRIPTION
The schema2 manifest builder fills in this part of the manifest based on
the descriptor it gets back from `BlobIngester`'s `Put` method. It passes
the correct media type to `Put`, but `Put` ends up replacing this value with
`application/octet-stream` in its return value.

This commit works around the issue in the manifest builder. Arguably `Put`
should not be changing the media type in its return value, but this
commit is a targeted fix to keep it very low-risk for possible inclusion
in Docker 1.11.

Fixes #1621 (but maybe we should open a separate issue for the media
type behavior in the distribution client, and the unnecessary stat).