### PR TITLE
Use Alpine Linux as the parent image for the registry.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM golang:1.6
-
-RUN apt-get update && \
-    apt-get install -y apache2-utils && \
-    rm -rf /var/lib/apt/lists/*
+FROM golang:1.6-alpine
 
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
 ENV DOCKER_BUILDTAGS include_oss include_gcs
@@ -10,6 +6,10 @@ ENV DOCKER_BUILDTAGS include_oss include_gcs
 WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
+
+RUN set -ex \
+    && apk add --no-cache make git
+
 RUN make PREFIX=/go clean binaries
 
 VOLUME ["/var/lib/registry"]


### PR DESCRIPTION
Signed-off-by: Richard Scothern <richard.scothern@docker.com>