### PR TITLE
[Swift] wait for DLO segments to show up when Close()ing the writer

### DIFF
--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -742,6 +742,9 @@ func (w *writer) Close() error {
 		if err := w.driver.createManifest(w.path, w.driver.Container+"/"+w.segmentsPath); err != nil {
 			return err
 		}
+		if err := w.waitForSegmentsToShowUp(); err != nil {
+			return err
+		}
 	}
 	w.closed = true
 
@@ -776,10 +779,14 @@ func (w *writer) Commit() error {
 	}
 
 	w.committed = true
+	return w.waitForSegmentsToShowUp()
+}
 
+func (w *writer) waitForSegmentsToShowUp() error {
 	var err error
 	waitingTime := readAfterWriteWait
 	endTime := time.Now().Add(readAfterWriteTimeout)
+
 	for {
 		var info swift.Object
 		if info, _, err = w.driver.Conn.Object(w.driver.Container, w.driver.swiftPath(w.path)); err == nil {


### PR DESCRIPTION
Not just when `Commit()`ing the result. This fixes some errors I observed when the layer (i.e. the DLO) is `Stat()`ted immediately after closing, and reports the wrong file size because the container listing is not yet up-to-date (usually recognized by the error message "digest invalid: provided digest did not match uploaded content").

Related to #1013 and maybe to #1539 aka docker/docker#21290.