### PR TITLE
Add cn-north-1 to valid check

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -80,6 +80,7 @@ func init() {
 		"ap-northeast-1",
 		"ap-northeast-2",
 		"sa-east-1",
+		"cn-north-1",
 	} {
 		validRegions[region] = struct{}{}
 	}


### PR DESCRIPTION
Signed-off-by: jhaohai <jhaohai@foxmail.com>

Add cn-north-1 to the valid check because the aws driver supports this region in fact.

closes #1649