### PR TITLE
Ensure GC continues marking if _manifests is nonexistent

### DIFF
--- a/registry/garbagecollect.go
+++ b/registry/garbagecollect.go
@@ -96,6 +96,17 @@ func markAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 			return nil
 		})
 
+		if err != nil {
+			// In certain situations such as unfinished uploads, deleting all
+			// tags in S3 or removing the _manifests folder manually, this
+			// error may be of type PathNotFound.
+			//
+			// In these cases we can continue marking other manifests safely.
+			if _, ok := err.(driver.PathNotFoundError); ok {
+				return nil
+			}
+		}
+
 		return err
 	})
 


### PR DESCRIPTION
The S3 driver removes `_manifests` after deleting the last tag within a repository. This causes the `manifestEnumerator` to return a PathNotFoundError. This currently causes GC to stop running.

We can safely ignore this error and move on to the next repository — if a repo has no manifests we continue marking.