### PR TITLE
[WIP] extend Swift driver with Static Large Object support

### DIFF
--- a/registry/storage/driver/swift/largeobject.go
+++ b/registry/storage/driver/swift/largeobject.go
@@ -1,0 +1,189 @@
+package swift
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ncw/swift"
+
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+)
+
+//An object that is/was uploaded in segments, which are then combined through a
+//manifest. Swift clusters support DLO (Dynamic Large Object) and sometimes SLO
+//(Static Large Object). These methods are abstracted by the `handler`
+//interface.
+type largeObject struct {
+	driver       *driver
+	swiftPath    string
+	segmentsPath string
+	segments     []swift.Object
+	handler      largeObjectHandler
+}
+
+//Creates a new empty large object. A handler is chosen according to the
+//cluster's capabilities.
+func (d *driver) makeLargeObject(swiftPath, segmentsPath string) *largeObject {
+	return &largeObject{d, swiftPath, segmentsPath, nil, &dloHandler{}}
+}
+
+//Take the return values of a `swift.Connection.Object()` call and parse the
+//manifest of this large object. If the given object is not a large object, a
+//pair of `nil` is returned.
+func (d *driver) parseLargeObject(info swift.Object, headers swift.Headers) (*largeObject, error) {
+	handlers := []largeObjectHandler{&dloHandler{}}
+
+	//see if any handler can parse this large object
+	for _, handler := range handlers {
+		obj := &largeObject{d, info.Name, "", nil, nil}
+		success, err := handler.parseLargeObject(obj, info, headers)
+		if success || err != nil {
+			obj.handler = handler
+			return obj, err
+		}
+	}
+
+	//nope, not a large object that we can handle
+	return nil, nil
+}
+
+//The combined size of all segments in bytes.
+func (obj *largeObject) Size() int64 {
+	var size int64
+	for _, segment := range obj.segments {
+		size += segment.Bytes
+	}
+	return size
+}
+
+//Where to put the next segment of this large object.
+func (obj *largeObject) NextSegmentPath() string {
+	segmentNumber := len(obj.segments) + 1
+	return fmt.Sprintf("%s/%016d", obj.segmentsPath, segmentNumber)
+}
+
+//Create a new manifest for this object which references all the segments in
+//this instance.
+func (obj *largeObject) WriteManifest() error {
+	return obj.handler.writeManifest(obj)
+}
+
+//A largeObjectHandler describes how to parse and write a particular type of
+//manifests.
+type largeObjectHandler interface {
+	//ParseLargeObject works like the global-scope method of the same name, but
+	//limited to this particular handler. It fills the segmentsPath and segments
+	//attributes on a partially initialized LargeObject.
+	parseLargeObject(obj *largeObject, info swift.Object, headers swift.Headers) (handled bool, e error)
+	//WriteManifest writes the manifest for this object, including all segments
+	//that were added to it.
+	writeManifest(obj *largeObject) error
+}
+
+type dloHandler struct{}
+
+func (h *dloHandler) parseLargeObject(obj *largeObject, info swift.Object, headers swift.Headers) (bool, error) {
+	manifest, ok := headers["X-Object-Manifest"]
+	if !ok {
+		//not a DLO
+		return false, nil
+	}
+
+	//manifest == "$container/$segmentsPath"; extract segments path
+	components := strings.SplitN(manifest, "/", 2)
+	if len(components) > 1 {
+		obj.segmentsPath = components[1]
+	}
+
+	//list segments - a simple container listing works 99.9% of the time
+	d := obj.driver
+	var err error
+	obj.segments, err = d.Conn.ObjectsAll(d.Container, &swift.ObjectsOpts{Prefix: obj.segmentsPath})
+	if err != nil {
+		if err == swift.ContainerNotFound {
+			return true, storagedriver.PathNotFoundError{Path: obj.segmentsPath}
+		}
+		return true, err
+	}
+
+	//build a lookup table by object name
+	hasObjectName := make(map[string]struct{})
+	for _, segment := range obj.segments {
+		hasObjectName[segment.Name] = struct{}{}
+	}
+
+	//The container listing might be outdated (i.e. not contain all existing
+	//segment objects yet) because of temporary inconsistency (Swift is only
+	//eventually consistent!). Check its completeness.
+	segmentNumber := 0
+	for {
+		segmentNumber++
+		segmentPath := fmt.Sprintf("%s/%016d", obj.segmentsPath, segmentNumber)
+
+		if _, seen := hasObjectName[segmentPath]; seen {
+			continue
+		}
+
+		//This segment is missing in the container listing. Use a more reliable
+		//request to check its existence. (HEAD requests on segments are
+		//guaranteed to return the correct metadata, except for the pathological
+		//case of an outage of large parts of the Swift cluster or its network,
+		//since every segment is only written once.)
+		segment, _, err := d.Conn.Object(d.Container, segmentPath)
+		switch err {
+		case nil:
+			//found new segment -> keep going, more might be missing
+			obj.segments = append(obj.segments, segment)
+			continue
+		case swift.ObjectNotFound:
+			//This segment is missing. Since we upload segments sequentially,
+			//there won't be any more segments after it.
+			return true, nil
+		default:
+			return true, err //unexpected error
+		}
+	}
+}
+
+func (h *dloHandler) writeManifest(obj *largeObject) error {
+	d := obj.driver
+	headers := make(swift.Headers)
+	headers["X-Object-Manifest"] = d.Container + "/" + obj.segmentsPath
+
+	manifest, err := d.Conn.ObjectCreate(d.Container, obj.swiftPath, false, "", contentType, headers)
+	if err != nil {
+		if err == swift.ObjectNotFound {
+			return storagedriver.PathNotFoundError{Path: obj.swiftPath}
+		}
+		return err
+	}
+
+	if err := manifest.Close(); err != nil {
+		if err == swift.ObjectNotFound {
+			return storagedriver.PathNotFoundError{Path: obj.swiftPath}
+		}
+		return err
+	}
+
+	//wait for segments to show up in container listing (which is updated
+	//asynchronously)
+	waitingTime := readAfterWriteWait
+	endTime := time.Now().Add(readAfterWriteTimeout)
+	for {
+		var info swift.Object
+		if info, _, err = d.Conn.Object(d.Container, obj.swiftPath); err == nil {
+			if info.Bytes == obj.Size() {
+				break
+			}
+			err = fmt.Errorf("Timeout expired while waiting for segments of %s to show up", obj.swiftPath)
+		}
+		if time.Now().Add(waitingTime).After(endTime) {
+			break
+		}
+		time.Sleep(waitingTime)
+		waitingTime *= 2
+	}
+
+	return err
+}

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -311,43 +311,50 @@ func (d *driver) Reader(ctx context.Context, path string, offset int64) (io.Read
 // Writer returns a FileWriter which will store the content written to it
 // at the location designated by "path" after the call to Commit.
 func (d *driver) Writer(ctx context.Context, path string, append bool) (storagedriver.FileWriter, error) {
-	var (
-		segments     []swift.Object
-		segmentsPath string
-		err          error
-	)
+	var largeObj *largeObject
 
-	if !append {
-		segmentsPath, err = d.swiftSegmentPath(path)
-		if err != nil {
-			return nil, err
-		}
-	} else {
+	if append {
+		//continue existing large object
 		info, headers, err := d.Conn.Object(d.Container, d.swiftPath(path))
 		if err == swift.ObjectNotFound {
 			return nil, storagedriver.PathNotFoundError{Path: path}
 		} else if err != nil {
 			return nil, err
 		}
-		manifest, ok := headers["X-Object-Manifest"]
-		if !ok {
-			segmentsPath, err = d.swiftSegmentPath(path)
+
+		if largeObj, err = d.parseLargeObject(info, headers); err != nil {
+			return nil, err
+		}
+
+		//...or convert existing simple object into large object
+		if largeObj == nil {
+			segmentsPath, err := d.swiftSegmentPath(path)
 			if err != nil {
 				return nil, err
 			}
-			if err := d.Conn.ObjectMove(d.Container, d.swiftPath(path), d.Container, getSegmentPath(segmentsPath, len(segments))); err != nil {
+			largeObj = d.makeLargeObject(d.swiftPath(path), segmentsPath)
+
+			//existing object becomes the first segment
+			segmentPath := largeObj.NextSegmentPath()
+			if err := d.Conn.ObjectMove(d.Container, largeObj.swiftPath, d.Container, segmentPath); err != nil {
 				return nil, err
 			}
-			segments = []swift.Object{info}
-		} else {
-			_, segmentsPath = parseManifest(manifest)
-			if segments, err = d.getAllSegments(segmentsPath); err != nil {
+			info, _, err := d.Conn.Object(d.Container, segmentPath)
+			if err != nil {
 				return nil, err
 			}
+			largeObj.segments = []swift.Object{info}
 		}
+	} else {
+		//append = false: create new large object
+		segmentsPath, err := d.swiftSegmentPath(path)
+		if err != nil {
+			return nil, err
+		}
+		largeObj = d.makeLargeObject(d.swiftPath(path), segmentsPath)
 	}
 
-	return d.newWriter(path, segmentsPath, segments), nil
+	return d.newWriter(path, largeObj), nil
 }
 
 // Stat retrieves the FileInfo for the given path, including the current size
@@ -426,10 +433,16 @@ func (d *driver) List(ctx context.Context, path string) ([]string, error) {
 // Move moves an object stored at sourcePath to destPath, removing the original
 // object.
 func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) error {
-	_, headers, err := d.Conn.Object(d.Container, d.swiftPath(sourcePath))
+	info, headers, err := d.Conn.Object(d.Container, d.swiftPath(sourcePath))
 	if err == nil {
-		if manifest, ok := headers["X-Object-Manifest"]; ok {
-			if err = d.createManifest(destPath, manifest); err != nil {
+		//if the object is a DLO or SLO, copy only the manifest
+		largeObj, err := d.parseLargeObject(info, headers)
+		if err != nil {
+			return err
+		}
+		if largeObj != nil {
+			largeObj.swiftPath = d.swiftPath(destPath)
+			if err := largeObj.WriteManifest(); err != nil {
 				return err
 			}
 			err = d.Conn.ObjectDelete(d.Container, d.swiftPath(sourcePath))
@@ -461,15 +474,14 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 		if obj.PseudoDirectory {
 			continue
 		}
-		if _, headers, err := d.Conn.Object(d.Container, obj.Name); err == nil {
-			manifest, ok := headers["X-Object-Manifest"]
-			if ok {
-				_, prefix := parseManifest(manifest)
-				segments, err := d.getAllSegments(prefix)
-				if err != nil {
-					return err
-				}
-				objects = append(objects, segments...)
+		//if obj is a large object, also delete all of its segments
+		if info, headers, err := d.Conn.Object(d.Container, obj.Name); err == nil {
+			largeObj, err := d.parseLargeObject(info, headers)
+			if err != nil {
+				return err
+			}
+			if largeObj != nil {
+				objects = append(objects, largeObj.segments...)
 			}
 		} else {
 			if err == swift.ObjectNotFound {
@@ -591,83 +603,6 @@ func (d *driver) swiftSegmentPath(path string) (string, error) {
 	return strings.TrimLeft(strings.TrimRight(d.Prefix+"/segments/"+path[0:3]+"/"+path[3:], "/"), "/"), nil
 }
 
-func (d *driver) getAllSegments(path string) ([]swift.Object, error) {
-	//a simple container listing works 99.9% of the time
-	segments, err := d.Conn.ObjectsAll(d.Container, &swift.ObjectsOpts{Prefix: path})
-	if err != nil {
-		if err == swift.ContainerNotFound {
-			return nil, storagedriver.PathNotFoundError{Path: path}
-		}
-		return nil, err
-	}
-
-	//build a lookup table by object name
-	hasObjectName := make(map[string]struct{})
-	for _, segment := range segments {
-		hasObjectName[segment.Name] = struct{}{}
-	}
-
-	//The container listing might be outdated (i.e. not contain all existing
-	//segment objects yet) because of temporary inconsistency (Swift is only
-	//eventually consistent!). Check its completeness.
-	segmentNumber := 0
-	for {
-		segmentNumber++
-		segmentPath := getSegmentPath(path, segmentNumber)
-
-		if _, seen := hasObjectName[segmentPath]; seen {
-			continue
-		}
-
-		//This segment is missing in the container listing. Use a more reliable
-		//request to check its existence. (HEAD requests on segments are
-		//guaranteed to return the correct metadata, except for the pathological
-		//case of an outage of large parts of the Swift cluster or its network,
-		//since every segment is only written once.)
-		segment, _, err := d.Conn.Object(d.Container, segmentPath)
-		switch err {
-		case nil:
-			//found new segment -> keep going, more might be missing
-			segments = append(segments, segment)
-			continue
-		case swift.ObjectNotFound:
-			//This segment is missing. Since we upload segments sequentially,
-			//there won't be any more segments after it.
-			return segments, nil
-		default:
-			return nil, err //unexpected error
-		}
-	}
-}
-
-func (d *driver) createManifest(path string, segments string) error {
-	headers := make(swift.Headers)
-	headers["X-Object-Manifest"] = segments
-	manifest, err := d.Conn.ObjectCreate(d.Container, d.swiftPath(path), false, "", contentType, headers)
-	if err != nil {
-		if err == swift.ObjectNotFound {
-			return storagedriver.PathNotFoundError{Path: path}
-		}
-		return err
-	}
-	if err := manifest.Close(); err != nil {
-		if err == swift.ObjectNotFound {
-			return storagedriver.PathNotFoundError{Path: path}
-		}
-		return err
-	}
-	return nil
-}
-
-func parseManifest(manifest string) (container string, prefix string) {
-	components := strings.SplitN(manifest, "/", 2)
-	container = components[0]
-	if len(components) > 1 {
-		prefix = components[1]
-	}
-	return container, prefix
-}
-
 func generateSecret() (string, error) {
 	var secretBytes [32]byte
 	if _, err := rand.Read(secretBytes[:]); err != nil {
@@ -676,37 +611,26 @@ func generateSecret() (string, error) {
 	return hex.EncodeToString(secretBytes[:]), nil
 }
 
-func getSegmentPath(segmentsPath string, partNumber int) string {
-	return fmt.Sprintf("%s/%016d", segmentsPath, partNumber)
-}
-
 type writer struct {
-	driver       *driver
-	path         string
-	segmentsPath string
-	size         int64
-	bw           *bufio.Writer
-	closed       bool
-	committed    bool
-	cancelled    bool
+	driver    *driver
+	path      string
+	object    *largeObject
+	bw        *bufio.Writer
+	closed    bool
+	committed bool
+	cancelled bool
 }
 
-func (d *driver) newWriter(path, segmentsPath string, segments []swift.Object) storagedriver.FileWriter {
-	var size int64
-	for _, segment := range segments {
-		size += segment.Bytes
-	}
+func (d *driver) newWriter(path string, obj *largeObject) storagedriver.FileWriter {
 	return &writer{
-		driver:       d,
-		path:         path,
-		segmentsPath: segmentsPath,
-		size:         size,
+		driver: d,
+		path:   path,
+		object: obj,
 		bw: bufio.NewWriterSize(&segmentWriter{
-			conn:          d.Conn,
-			container:     d.Container,
-			segmentsPath:  segmentsPath,
-			segmentNumber: len(segments) + 1,
-			maxChunkSize:  d.ChunkSize,
+			conn:         d.Conn,
+			container:    d.Container,
+			object:       obj,
+			maxChunkSize: d.ChunkSize,
 		}, d.ChunkSize),
 	}
 }
@@ -720,13 +644,11 @@ func (w *writer) Write(p []byte) (int, error) {
 		return 0, fmt.Errorf("already cancelled")
 	}
 
-	n, err := w.bw.Write(p)
-	w.size += int64(n)
-	return n, err
+	return w.bw.Write(p)
 }
 
 func (w *writer) Size() int64 {
-	return w.size
+	return w.object.Size()
 }
 
 func (w *writer) Close() error {
@@ -739,7 +661,7 @@ func (w *writer) Close() error {
 	}
 
 	if !w.committed && !w.cancelled {
-		if err := w.driver.createManifest(w.path, w.driver.Container+"/"+w.segmentsPath); err != nil {
+		if err := w.object.WriteManifest(); err != nil {
 			return err
 		}
 	}
@@ -771,39 +693,19 @@ func (w *writer) Commit() error {
 		return err
 	}
 
-	if err := w.driver.createManifest(w.path, w.driver.Container+"/"+w.segmentsPath); err != nil {
+	if err := w.object.WriteManifest(); err != nil {
 		return err
 	}
-
 	w.committed = true
 
-	var err error
-	waitingTime := readAfterWriteWait
-	endTime := time.Now().Add(readAfterWriteTimeout)
-	for {
-		var info swift.Object
-		if info, _, err = w.driver.Conn.Object(w.driver.Container, w.driver.swiftPath(w.path)); err == nil {
-			if info.Bytes == w.size {
-				break
-			}
-			err = fmt.Errorf("Timeout expired while waiting for segments of %s to show up", w.path)
-		}
-		if time.Now().Add(waitingTime).After(endTime) {
-			break
-		}
-		time.Sleep(waitingTime)
-		waitingTime *= 2
-	}
-
-	return err
+	return nil
 }
 
 type segmentWriter struct {
-	conn          swift.Connection
-	container     string
-	segmentsPath  string
-	segmentNumber int
-	maxChunkSize  int
+	conn         swift.Connection
+	container    string
+	object       *largeObject
+	maxChunkSize int
 }
 
 func (sw *segmentWriter) Write(p []byte) (int, error) {
@@ -813,13 +715,32 @@ func (sw *segmentWriter) Write(p []byte) (int, error) {
 		if offset+chunkSize > len(p) {
 			chunkSize = len(p) - offset
 		}
-		_, err := sw.conn.ObjectPut(sw.container, getSegmentPath(sw.segmentsPath, sw.segmentNumber), bytes.NewReader(p[offset:offset+chunkSize]), false, "", contentType, nil)
+		segmentPath := sw.object.NextSegmentPath()
+		headers, err := sw.conn.ObjectPut(sw.container, segmentPath, bytes.NewReader(p[offset:offset+chunkSize]), false, "", contentType, nil)
 		if err != nil {
 			return n, err
 		}
 
-		sw.segmentNumber++
 		n += chunkSize
+
+		//ObjectPut does not construct a swift.Object although the headers
+		//contain all the data
+		info := swift.Object{
+			Name:               segmentPath,
+			ContentType:        contentType,
+			ServerLastModified: headers["Last-Modified"],
+			Hash:               headers["Etag"],
+		}
+		if value := headers["Content-Length"]; value != "" {
+			if info.Bytes, err = strconv.ParseInt(value, 10, 64); err != nil {
+				return n, err
+			}
+		}
+		if info.LastModified, err = time.Parse(http.TimeFormat, info.ServerLastModified); err != nil {
+			return n, err
+		}
+
+		sw.object.segments = append(sw.object.segments, info)
 	}
 
 	return n, nil


### PR DESCRIPTION
As explained in https://github.com/docker/distribution/issues/1013#issuecomment-212396244, all my previous stabilisation patches for the Swift driver did not really help much. They did help, in that I'm only seeing one remaining error, but the overall error rate is about the same. The remedy is to not rely on those notoriously inconsistent -- pardon: "eventually consistent ;) -- container listings and use Static Large Objects (SLO) instead of Dynamic Large Objects (DLO).

@lebauce had a PR for this already (#1229), but it's not mergeable after quite some restructuring in the Swift driver. I decided to start on a clean slate. The plan:

- [X] refactor out the DLO-specific code into a `largeObjectHandler` interface
- [ ] add a second implementation of that interface that reads/writes SLO
- [ ] run tests to see that I didn't break anything

As you can see, I'm not finished yet. I'm putting this PR up early to get some feedback on the direction that I'm heading, so that we can get this merged quickly once I'm done. I will amend the PR with new commits as I go forward, and squash the branch at the end for you to merge.