### PR TITLE
Expose awsConfig.WithS3ForcePathStyle (Enables AWS S3 transfer acceleration)

### DIFF
--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -158,6 +158,18 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
       The S3 storage class applied to each registry file. The default value is STANDARD.
     </td>
   </tr>
+  <tr>
+    <td>
+      <code>s3forcepathstyle</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      Indicates whether to force [S3 Path Style method](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingExamples). A boolean value. The
+      default is <code>false</code> if you do not specify a value for <code>regionendpoint</code>, and <code>true</code> if you do set <code>regionendpoint</code>.
+    </td>
+  </tr>
 </table>
 
 

--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -166,8 +166,11 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
       no
     </td>
     <td>
-      Indicates whether to force [S3 Path Style method](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingExamples). A boolean value. The
-      default is <code>false</code> if you do not specify a value for <code>regionendpoint</code>, and <code>true</code> if you do set <code>regionendpoint</code>.
+      Indicates whether to force S3 Path Style. A boolean value. The default is 
+      <code>false</code> if you do not specify a value for <code>regionendpoint</code>,
+      and <code>true</code> if you do set <code>regionendpoint</code>. See 
+      [AWS Virtual Hosting of Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html)
+      for more information.
     </td>
   </tr>
 </table>

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -55,19 +55,19 @@ var validRegions = map[string]struct{}{}
 
 //DriverParameters A struct that encapsulates all of the driver parameters after all values have been set
 type DriverParameters struct {
-	AccessKey         string
-	SecretKey         string
-	Bucket            string
-	Region            string
-	RegionEndpoint    string
-	Encrypt           bool
-	KeyID             string
-	Secure            bool
-	ChunkSize         int64
-	RootDirectory     string
-	StorageClass      string
-	UserAgent         string
-	s3ForcePathStyle  bool
+	AccessKey        string
+	SecretKey        string
+	Bucket           string
+	Region           string
+	RegionEndpoint   string
+	Encrypt          bool
+	KeyID            string
+	Secure           bool
+	ChunkSize        int64
+	RootDirectory    string
+	StorageClass     string
+	UserAgent        string
+	s3ForcePathStyle bool
 }
 
 func init() {
@@ -248,25 +248,25 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		userAgent = ""
 	}
 
-        s3ForcePathStyle := false
-        s3forcepathstyle := parameters["s3forcepathstyle"]
-        switch s3forcepathstyle := s3forcepathstyle.(type) {
-        case string:
-                b, err := strconv.ParseBool(s3forcepathstyle)
-                if err != nil {
-                        return nil, fmt.Errorf("The s3forcepathstyle parameter should be a boolean")
-                }
-                s3ForcePathStyle = b
-        case bool:
-                s3ForcePathStyle = s3forcepathstyle
-        case nil:
-                // Default to true if regionEndpoint is configured but s3forcepathstyle is not specifically set
-	        if regionEndpoint != "" {
-                        s3ForcePathStyle = true
-                }
-        default:
-                return nil, fmt.Errorf("The s3forcepathstyle parameter should be a boolean")
-        }
+	s3ForcePathStyle := false
+	s3forcepathstyle := parameters["s3forcepathstyle"]
+	switch s3forcepathstyle := s3forcepathstyle.(type) {
+	case string:
+		b, err := strconv.ParseBool(s3forcepathstyle)
+		if err != nil {
+			return nil, fmt.Errorf("The s3forcepathstyle parameter should be a boolean")
+		}
+		s3ForcePathStyle = b
+	case bool:
+		s3ForcePathStyle = s3forcepathstyle
+	case nil:
+		// Default to true if regionEndpoint is configured but s3forcepathstyle is not specifically set
+		if regionEndpoint != "" {
+			s3ForcePathStyle = true
+		}
+	default:
+		return nil, fmt.Errorf("The s3forcepathstyle parameter should be a boolean")
+	}
 
 	params := DriverParameters{
 		fmt.Sprint(accessKey),

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -248,7 +248,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		userAgent = ""
 	}
 
-	s3ForcePathStyle := false
+	s3ForcePathStyleBool := false
 	s3forcepathstyle := parameters["s3forcepathstyle"]
 	switch s3forcepathstyle := s3forcepathstyle.(type) {
 	case string:
@@ -256,13 +256,13 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		if err != nil {
 			return nil, fmt.Errorf("The s3forcepathstyle parameter should be a boolean")
 		}
-		s3ForcePathStyle = b
+		s3ForcePathStyleBool = b
 	case bool:
-		s3ForcePathStyle = s3forcepathstyle
+		s3ForcePathStyleBool = s3forcepathstyle
 	case nil:
 		// Default to true if regionEndpoint is configured but s3forcepathstyle is not specifically set
 		if regionEndpoint != "" {
-			s3ForcePathStyle = true
+			s3ForcePathStyleBool = true
 		}
 	default:
 		return nil, fmt.Errorf("The s3forcepathstyle parameter should be a boolean")
@@ -281,7 +281,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		fmt.Sprint(rootDirectory),
 		storageClass,
 		fmt.Sprint(userAgent),
-		s3ForcePathStyle,
+		s3ForcePathStyleBool,
 	}
 
 	return New(params)

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -32,6 +32,7 @@ func init() {
 	region := os.Getenv("AWS_REGION")
 	root, err := ioutil.TempDir("", "driver-")
 	regionEndpoint := os.Getenv("REGION_ENDPOINT")
+	s3ForcePathStyle := os.Getenv("S3_FORCE_PATH_STYLE")
 	if err != nil {
 		panic(err)
 	}
@@ -54,6 +55,14 @@ func init() {
 			}
 		}
 
+		s3ForcePathStyleBool := false
+		if s3ForcePathStyle != "" {
+			s3ForcePathStyleBool, err = strconv.ParseBool(s3ForcePathStyle)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		parameters := DriverParameters{
 			accessKey,
 			secretKey,
@@ -67,6 +76,7 @@ func init() {
 			rootDirectory,
 			storageClass,
 			driverName + "-test",
+			s3ForcePathStyleBool,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
Previously `S3ForcePathStyle` used the AWS S3 SDK default (false), unless a `regionendpoint` was configured.

This change maintains the previous behaviour, but provides a configuration option for the user to override S3ForcePathStyle.

For example, this means that you can use [S3 Transfer Acceleration](http://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html) by setting this config (includes disabling S3ForcePathStyle) :

```
storage:
    s3:
        accesskey: <access-key>
        secretkey: "<secret-key>"
        region: <region>
        regionendpoint: s3-accelerate.amazonaws.com
        bucket: <bucket-name>
        s3forcepathstyle: false
        secure: true
        v4auth: true
        ...

```
