### PR TITLE
Fix wording for dry-run flag in usage message for garbage collector.

### DIFF
--- a/registry/garbagecollect.go
+++ b/registry/garbagecollect.go
@@ -135,7 +135,7 @@ func markAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 }
 
 func init() {
-	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything expect remove the blobs")
+	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
 }
 
 var dryRun bool


### PR DESCRIPTION
I believe it should be "except" instead of "expect".

Signed-off-by: Serge Dubrouski <sergeyfd@gmail.com>