### PR TITLE
Pass through known errors

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -634,6 +634,8 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 					context.Errors = append(context.Errors, v2.ErrorCodeNameUnknown.WithDetail(err))
 				case distribution.ErrRepositoryNameInvalid:
 					context.Errors = append(context.Errors, v2.ErrorCodeNameInvalid.WithDetail(err))
+				case errcode.Error:
+					context.Errors = append(context.Errors, err)
 				}
 
 				if err := errcode.ServeJSON(w, context.Errors); err != nil {

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -239,6 +239,8 @@ func (buh *blobUploadHandler) PutBlobUploadComplete(w http.ResponseWriter, r *ht
 		switch err := err.(type) {
 		case distribution.ErrBlobInvalidDigest:
 			buh.Errors = append(buh.Errors, v2.ErrorCodeDigestInvalid.WithDetail(err))
+		case errcode.Error:
+			buh.Errors = append(buh.Errors, err)
 		default:
 			switch err {
 			case distribution.ErrAccessDenied:

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -283,6 +283,8 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 					}
 				}
 			}
+		case errcode.Error:
+			imh.Errors = append(imh.Errors, err)
 		default:
 			imh.Errors = append(imh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		}

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -41,6 +41,8 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 		switch err := err.(type) {
 		case distribution.ErrRepositoryUnknown:
 			th.Errors = append(th.Errors, v2.ErrorCodeNameUnknown.WithDetail(map[string]string{"name": th.Repository.Named().Name()}))
+		case errcode.Error:
+			th.Errors = append(th.Errors, err)
 		default:
 			th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		}


### PR DESCRIPTION
This addresses the "That's an easy fix, though" part of #1682.

With this change, a repository middleware can return a [`errcode.Error`](https://godoc.org/github.com/docker/distribution/registry/api/errcode#Error) which will be shown to the user when interacting with `docker`.