### PR TITLE
registry: type too many requests error

### DIFF
--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -63,6 +63,16 @@ var (
 		Description:    "Returned when a service is not available",
 		HTTPStatusCode: http.StatusServiceUnavailable,
 	})
+
+	// ErrorCodeTooManyRequests is returned if a client attempts too many
+	// times to contact a service endpoint.
+	ErrorCodeTooManyRequests = Register("errcode", ErrorDescriptor{
+		Value:   "TOOMANYREQUESTS",
+		Message: "too many requests",
+		Description: `Returned when a client attempts to contact a
+		service too many times`,
+		HTTPStatusCode: http.StatusTooManyRequests,
+	})
 )
 
 var nextCode = 1000

--- a/registry/client/errors.go
+++ b/registry/client/errors.go
@@ -51,10 +51,14 @@ func parseHTTPErrorResponse(statusCode int, r io.Reader) error {
 	}
 	err = json.Unmarshal(body, &detailsErr)
 	if err == nil && detailsErr.Details != "" {
-		if statusCode == http.StatusUnauthorized {
+		switch statusCode {
+		case http.StatusUnauthorized:
 			return errcode.ErrorCodeUnauthorized.WithMessage(detailsErr.Details)
+		case http.StatusTooManyRequests:
+			return errcode.ErrorCodeTooManyRequests.WithMessage(detailsErr.Details)
+		default:
+			return errcode.ErrorCodeUnknown.WithMessage(detailsErr.Details)
 		}
-		return errcode.ErrorCodeUnknown.WithMessage(detailsErr.Details)
 	}
 
 	if err := json.Unmarshal(body, &errors); err != nil {


### PR DESCRIPTION
ping @aaronlehmann 

This patch adds an error type to be later checked also in docker/docker if the registry
is replying with 429.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>