### PR TITLE
registry: do not use http.StatusTooManyRequests

### DIFF
--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -71,7 +71,10 @@ var (
 		Message: "too many requests",
 		Description: `Returned when a client attempts to contact a
 		service too many times`,
-		HTTPStatusCode: http.StatusTooManyRequests,
+		// FIXME: go1.5 doesn't export http.StatusTooManyRequests while
+		// go1.6 does. Update the hardcoded value to the constant once
+		// Docker updates golang version to 1.6.
+		HTTPStatusCode: 429,
 	})
 )
 

--- a/registry/client/errors.go
+++ b/registry/client/errors.go
@@ -54,7 +54,10 @@ func parseHTTPErrorResponse(statusCode int, r io.Reader) error {
 		switch statusCode {
 		case http.StatusUnauthorized:
 			return errcode.ErrorCodeUnauthorized.WithMessage(detailsErr.Details)
-		case http.StatusTooManyRequests:
+		// FIXME: go1.5 doesn't export http.StatusTooManyRequests while
+		// go1.6 does. Update the hardcoded value to the constant once
+		// Docker updates golang version to 1.6.
+		case 429:
 			return errcode.ErrorCodeTooManyRequests.WithMessage(detailsErr.Details)
 		default:
 			return errcode.ErrorCodeUnknown.WithMessage(detailsErr.Details)


### PR DESCRIPTION
go1.5 doesn't export http.StatusTooManyRequests while
go1.6 does. Fix this by hardcoding the status code for now.

ping @aaronlehmann @cpuguy83 @icecrime - we probably could update go to 1.6 but....

Signed-off-by: Antonio Murdaca <runcom@redhat.com>