### PR TITLE
1. Only create hashstate folder when fails to upload blob data.

### DIFF
--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -57,8 +57,6 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 		return distribution.Descriptor{}, err
 	}
 
-	bw.Close()
-
 	canonical, err := bw.validateBlob(ctx, desc)
 	if err != nil {
 		return distribution.Descriptor{}, err
@@ -72,15 +70,18 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 		return distribution.Descriptor{}, err
 	}
 
-	if err := bw.removeResources(ctx); err != nil {
-		return distribution.Descriptor{}, err
-	}
-
 	err = bw.blobStore.blobAccessController.SetDescriptor(ctx, canonical.Digest, canonical)
 	if err != nil {
 		return distribution.Descriptor{}, err
 	}
 
+	if err = bw.fileWriter.Close(); err != nil {
+		return distribution.Descriptor{}, err
+	}
+
+	if err := bw.removeResources(ctx); err != nil {
+		return distribution.Descriptor{}, err
+	}
 	bw.committed = true
 	return canonical, nil
 }
@@ -138,7 +139,7 @@ func (bw *blobWriter) ReadFrom(r io.Reader) (n int64, err error) {
 
 func (bw *blobWriter) Close() error {
 	if bw.committed {
-		return errors.New("blobwriter close after commit")
+		return nil
 	}
 
 	if err := bw.storeHashState(bw.blobStore.ctx); err != nil {


### PR DESCRIPTION
2. Close the file handle before remove temp uploads files.

Signed-off-by: yuzou <zouyu7@huawei.com>