### PR TITLE
GCS: FileWriter.Size: include number of buffered bytes if the FileWriter is not closed

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -493,6 +493,9 @@ func (w *writer) Write(p []byte) (int, error) {
 
 // Size returns the number of bytes written to this FileWriter.
 func (w *writer) Size() int64 {
+	if !w.closed {
+		return w.size + int64(w.buffSize)
+	}
 	return w.size
 }
 


### PR DESCRIPTION
@RichardScothern This is a quick patch for #1698. Note that this PR targets the release/2.4 branch instead of master. I am not sure this is the right way of submitting a "hot fix" to a release.

@aaronlehmann The cause of the problem is that the registry calls the FileWriter.Size function of the GCS driver before closing the FileWriter. The Size function of the GCS driver used to report the number of bytes that were correctly saved to cloud storage. This excludes any bytes that are buffered in memory. The registry seems to expect that the Size function returns the size including the buffered bytes, regardless of whether these bytes will ever make it to the backing storage (the future Close call may occasionally fail).

In my opinion Size should report only the bytes that are guaranteed to have made it to the backing storage. However, changing that requires changes to the registry code and possible the other storage drivers. So for now, I think this PR is a good enough patch to ensure the GCS driver works again.



 