### PR TITLE
GCS: FileWriter.Size: return offset + buffer size for Writers that are not closed

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -494,7 +494,7 @@ func (w *writer) Write(p []byte) (int, error) {
 // Size returns the number of bytes written to this FileWriter.
 func (w *writer) Size() int64 {
 	if !w.closed {
-		return w.size + int64(w.buffSize)
+		return w.offset + int64(w.buffSize)
 	}
 	return w.size
 }


### PR DESCRIPTION
@RichardScothern @manuelmazzuola 