### PR TITLE
Handle responce from ceph correctly if no Last-Modifed header specified 

### DIFF
--- a/vendor/github.com/ncw/swift/swift.go
+++ b/vendor/github.com/ncw/swift/swift.go
@@ -1737,9 +1737,11 @@ func (c *Connection) Object(container string, objectName string) (info Object, h
 			return
 		}
 	}
-	info.ServerLastModified = resp.Header.Get("Last-Modified")
-	if info.LastModified, err = time.Parse(http.TimeFormat, info.ServerLastModified); err != nil {
-		return
+	if resp.Header.Get("Last-Modified") != "" {
+		info.ServerLastModified = resp.Header.Get("Last-Modified")
+		if info.LastModified, err = time.Parse(http.TimeFormat, info.ServerLastModified); err != nil {
+			return
+		}
 	}
 	info.Hash = resp.Header.Get("Etag")
 	return

--- a/vendor/github.com/ncw/swift/swift.go
+++ b/vendor/github.com/ncw/swift/swift.go
@@ -1737,6 +1737,9 @@ func (c *Connection) Object(container string, objectName string) (info Object, h
 			return
 		}
 	}
+	//HACK
+	//Currently ceph doestn't return Last-Modified header for DLO manifest without any segments
+	//Currently it affects all versions of ceph http://tracker.ceph.com/issues/15812
 	if resp.Header.Get("Last-Modified") != "" {
 		info.ServerLastModified = resp.Header.Get("Last-Modified")
 		if info.LastModified, err = time.Parse(http.TimeFormat, info.ServerLastModified); err != nil {


### PR DESCRIPTION
Handle rare case when ceph doesn't return Last-Modified for HEAD requests in case DLO manifest doesn't have any segments

Signed-off-by: Gleb Schukin <gs1983@gmail.com>