### PR TITLE
Pass in `app` as context to apply{N}Middleware

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -258,7 +258,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		}
 	}
 
-	app.registry, err = applyRegistryMiddleware(app.Context, app.registry, config.Middleware["registry"])
+	app.registry, err = applyRegistryMiddleware(app, app.registry, config.Middleware["registry"])
 	if err != nil {
 		panic(err)
 	}
@@ -647,7 +647,7 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 				repository,
 				app.eventBridge(context, r))
 
-			context.Repository, err = applyRepoMiddleware(context.Context, context.Repository, app.Config.Middleware["repository"])
+			context.Repository, err = applyRepoMiddleware(app, context.Repository, app.Config.Middleware["repository"])
 			if err != nil {
 				ctxu.GetLogger(context).Errorf("error initializing repository middleware: %v", err)
 				context.Errors = append(context.Errors, errcode.ErrorCodeUnknown.WithDetail(err))


### PR DESCRIPTION
This lets us access registry config within middleware for additional
configuration of whatever it is that you're overriding.

Currently needed for overriding the metadata service within repository middleware: the metadata service needs to see whether deletes are enabled, whether it's a cache, the signing key for v1 compat etc.