### PR TITLE
Add topics to the menu

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,8 +1,11 @@
 <!--[metadata]>
 +++
-title = "registry Compatibility"
+title = "Compatibility"
 description = "describes get by digest pitfall"
 keywords = ["registry, manifest, images, tags, repository, distribution, digest"]
+[menu.main]
+parent="smn_registry_ref"
+weight=9
 +++
 <![end-metadata]-->
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,8 +1,11 @@
 <!--[metadata]>
 +++
-title = "registry deprecation"
+title = "Deprecated Features"
 description = "describes deprecated functionality"
 keywords = ["registry, manifest, images, signatures, repository, distribution, digest"]
+[menu.main]
+parent="smn_registry_ref"
+weight=8
 +++
 <![end-metadata]-->
 

--- a/docs/garbage-collection.md
+++ b/docs/garbage-collection.md
@@ -3,6 +3,9 @@
 title = "Garbage Collection"
 description = "High level discussion of garbage collection"
 keywords = ["registry, garbage, images, tags, repository, distribution"]
+[menu.main]
+parent="smn_registry_ref"
+weight=4
 +++
 <![end-metadata]-->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ keywords = ["registry, on-prem, images, tags, repository, distribution"]
 aliases = ["/registry/overview/"]
 [menu.main]
 parent="smn_registry"
+weight=1
 +++
 <![end-metadata]-->
 

--- a/docs/insecure.md
+++ b/docs/insecure.md
@@ -3,6 +3,9 @@
 title = "Testing an insecure registry"
 description = "Deploying a Registry in an insecure fashion"
 keywords = ["registry, on-prem, images, tags, repository, distribution, insecure"]
+[menu.main]
+parent="smn_registry_ref"
+weight=5
 +++
 <![end-metadata]-->
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

I've added the pages to the top level registry menu, but it feels to me like the gc and test-insecure pages should go into the reference and recipes menus (respectively)

@RichardScothern ?