### PR TITLE
Revert to using the full URL, as the OSS checker doesn't have access …

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ You should use the Registry if you want to:
 
 Users looking for a zero maintenance, ready-to-go solution are encouraged to head-over to the [Docker Hub](https://hub.docker.com), which provides a free-to-use, hosted Registry, plus additional features (organization accounts, automated builds, and more).
 
-Users looking for a commercially supported version of the Registry should look into [Docker Trusted Registry](/docker-trusted-registry/overview.md).
+Users looking for a commercially supported version of the Registry should look into [Docker Trusted Registry](https://docs.docker.com/docker-trusted-registry/overview/).
 
 ## Requirements
 


### PR DESCRIPTION
…to the non-OSS docs

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>