### PR TITLE
Add failing test case for reference.SplitHostname

### DIFF
--- a/reference/reference_test.go
+++ b/reference/reference_test.go
@@ -276,6 +276,11 @@ func TestSplitHostname(t *testing.T) {
 			name:     "test_com/foo",
 		},
 		{
+			input:    "docker/migrator",
+			hostname: "",
+			name:     "docker/migrator",
+		},
+		{
 			input:    "test:8080/foo",
 			hostname: "test:8080",
 			name:     "foo",


### PR DESCRIPTION
See https://github.com/docker/distribution/pull/963/files/b07d759241defb2f345e95ed04bfdeb8ac010ab2#r66186285 for background context.

This adds a failing test case for the issue mentioned there.
