### PR TITLE
Remove escape sequences from `$` signs

### DIFF
--- a/docs/recipes/nginx.md
+++ b/docs/recipes/nginx.md
@@ -88,7 +88,7 @@ http {
   ## The registry always sets this header.
   ## In the case of nginx performing auth, the header will be unset
   ## since nginx is auth-ing before proxying.
-  map \$upstream_http_docker_distribution_api_version \$docker_distribution_api_version {
+  map $upstream_http_docker_distribution_api_version $docker_distribution_api_version {
     'registry/2.0' '';
     default registry/2.0;
   }
@@ -116,7 +116,7 @@ http {
     location /v2/ {
       # Do not allow connections from docker 1.5 and earlier
       # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
-      if (\$http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*\$" ) {
+      if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*\$" ) {
         return 404;
       }
 
@@ -129,10 +129,10 @@ http {
       add_header 'Docker-Distribution-Api-Version' \$docker_distribution_api_version always;
 
       proxy_pass                          http://docker-registry;
-      proxy_set_header  Host              \$http_host;   # required for docker client's sake
-      proxy_set_header  X-Real-IP         \$remote_addr; # pass on real client's IP
-      proxy_set_header  X-Forwarded-For   \$proxy_add_x_forwarded_for;
-      proxy_set_header  X-Forwarded-Proto \$scheme;
+      proxy_set_header  Host              $http_host;   # required for docker client's sake
+      proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+      proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
       proxy_read_timeout                  900;
     }
   }


### PR DESCRIPTION
With escape sequences in place, the Nginx config file is syntactically incorrect.