### PR TITLE
Re-add support for non-resumable digests

### DIFF
--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -77,7 +77,7 @@ func blobUploadDispatcher(ctx *Context, r *http.Request) http.Handler {
 
 		if size := upload.Size(); size != buh.State.Offset {
 			defer upload.Close()
-			ctxu.GetLogger(ctx).Infof("upload resumed at wrong offest: %d != %d", size, buh.State.Offset)
+			ctxu.GetLogger(ctx).Errorf("upload resumed at wrong offest: %d != %d", size, buh.State.Offset)
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				buh.Errors = append(buh.Errors, v2.ErrorCodeBlobUploadInvalid.WithDetail(err))
 				upload.Cancel(buh)

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -86,10 +86,10 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 	return canonical, nil
 }
 
-// Rollback the blob upload process, releasing any resources associated with
+// Cancel the blob upload process, releasing any resources associated with
 // the writer and canceling the operation.
 func (bw *blobWriter) Cancel(ctx context.Context) error {
-	context.GetLogger(ctx).Debug("(*blobWriter).Rollback")
+	context.GetLogger(ctx).Debug("(*blobWriter).Cancel")
 	if err := bw.fileWriter.Cancel(); err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func (bw *blobWriter) Close() error {
 		return errors.New("blobwriter close after commit")
 	}
 
-	if err := bw.storeHashState(bw.blobStore.ctx); err != nil {
+	if err := bw.storeHashState(bw.blobStore.ctx); err != nil && err != errResumableDigestNotAvailable {
 		return err
 	}
 

--- a/registry/storage/blobwriter_nonresumable.go
+++ b/registry/storage/blobwriter_nonresumable.go
@@ -7,7 +7,7 @@ import (
 )
 
 // resumeHashAt is a noop when resumable digest support is disabled.
-func (bw *blobWriter) resumeDigestAt(ctx context.Context, offset int64) error {
+func (bw *blobWriter) resumeDigest(ctx context.Context) error {
 	return errResumableDigestNotAvailable
 }
 


### PR DESCRIPTION
If resumable digest support is disabled, detect this when closing the blobwriter and allow the close to continue.  Also update the name of the function.

closes #1717 

Signed-off-by: Richard Scothern <richard.scothern@docker.com>