### PR TITLE
Changes the client Tags All() method to follow links

### DIFF
--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -947,6 +948,78 @@ func TestManifestTags(t *testing.T) {
 		t.Fatalf("unexpected tags returned: %v", expected)
 	}
 	// TODO(dmcgowan): Check for error cases
+}
+
+func TestManifestTagsPaginated(t *testing.T) {
+	s := httptest.NewServer(http.NotFoundHandler())
+	defer s.Close()
+
+	repo, _ := reference.ParseNamed("test.example.com/repo/tags/list")
+	tagsList := []string{"tag1", "tag2", "funtag"}
+	var m testutil.RequestResponseMap
+	for i := 0; i < 3; i++ {
+		body, err := json.Marshal(map[string]interface{}{
+			"name": "test.example.com/repo/tags/list",
+			"tags": []string{tagsList[i]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		queryParams := make(map[string][]string)
+		if i > 0 {
+			queryParams["n"] = []string{"1"}
+			queryParams["last"] = []string{tagsList[i-1]}
+		}
+		headers := http.Header(map[string][]string{
+			"Content-Length": {fmt.Sprint(len(body))},
+			"Last-Modified":  {time.Now().Add(-1 * time.Second).Format(time.ANSIC)},
+		})
+		if i < 2 {
+			headers.Set("Link", "<"+s.URL+"/v2/"+repo.Name()+"/tags/list?n=1&last="+tagsList[i]+`>; rel="next"`)
+		}
+		m = append(m, testutil.RequestResponseMapping{
+			Request: testutil.Request{
+				Method:      "GET",
+				Route:       "/v2/" + repo.Name() + "/tags/list",
+				QueryParams: queryParams,
+			},
+			Response: testutil.Response{
+				StatusCode: http.StatusOK,
+				Body:       body,
+				Headers:    headers,
+			},
+		})
+	}
+
+	s.Config.Handler = testutil.NewHandler(m)
+
+	r, err := NewRepository(context.Background(), repo, s.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	tagService := r.Tags(ctx)
+
+	tags, err := tagService.All(ctx)
+	if err != nil {
+		t.Fatal(tags, err)
+	}
+	if len(tags) != 3 {
+		t.Fatalf("Wrong number of tags returned: %d, expected 3", len(tags))
+	}
+
+	expected := map[string]struct{}{
+		"tag1":   {},
+		"tag2":   {},
+		"funtag": {},
+	}
+	for _, t := range tags {
+		delete(expected, t)
+	}
+	if len(expected) != 0 {
+		t.Fatalf("unexpected tags returned: %v", expected)
+	}
 }
 
 func TestManifestUnauthorized(t *testing.T) {


### PR DESCRIPTION
This returns all tags even when the registry forces pagination.