### PR TITLE
Override media type returned from Stat for existing manifests.

### DIFF
--- a/manifest/schema2/builder.go
+++ b/manifest/schema2/builder.go
@@ -46,6 +46,9 @@ func (mb *builder) Build(ctx context.Context) (distribution.Manifest, error) {
 	m.Config, err = mb.bs.Stat(ctx, configDigest)
 	switch err {
 	case nil:
+		// Override MediaType, since Put always replaces the specified media
+		// type with application/octet-stream in the descriptor it returns.
+		m.Config.MediaType = MediaTypeConfig
 		return FromStruct(m)
 	case distribution.ErrBlobUnknown:
 		// nop


### PR DESCRIPTION
Closes #1771

When a manifest configuration blob already exists, the media type will be set to `application/octet-stream` by the registry, causing the manifest to be re-pushed under a different digest.

Signed-off-by: Richard Scothern <richard.scothern@docker.com>