### PR TITLE
Avoid formatting errors with %#v

### DIFF
--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -246,7 +246,7 @@ func (buh *blobUploadHandler) PutBlobUploadComplete(w http.ResponseWriter, r *ht
 			case distribution.ErrBlobInvalidLength, distribution.ErrBlobDigestUnsupported:
 				buh.Errors = append(buh.Errors, v2.ErrorCodeBlobUploadInvalid.WithDetail(err))
 			default:
-				ctxu.GetLogger(buh).Errorf("unknown error completing upload: %#v", err)
+				ctxu.GetLogger(buh).Errorf("unknown error completing upload: %v", err)
 				buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 			}
 

--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -64,7 +64,7 @@ func (bs *blobStore) Put(ctx context.Context, mediaType string, p []byte) (distr
 		// content already present
 		return desc, nil
 	} else if err != distribution.ErrBlobUnknown {
-		context.GetLogger(ctx).Errorf("blobStore: error stating content (%v): %#v", dgst, err)
+		context.GetLogger(ctx).Errorf("blobStore: error stating content (%v): %v", dgst, err)
 		// real error, return it
 		return distribution.Descriptor{}, err
 	}


### PR DESCRIPTION
Today I came across the following log message in our distribution servers:

`time="2016-07-01T13:18:37Z" level=error msg="unknown error completing upload: driver.Error{DriverName:\"swift\", Enclosed:(*errors.errorString)(0xc82029a2d0)}" go.version=...`

As you can see the `Enclosed` part is not really useful in an error message as we cannot see the original error string. This happens due to the original error being formatted with `%#v`. This pull request changes two occurrences I found of errors being formatted with `%#v` to `%v`. The latter will correctly output the string returned by `Error()`.