### PR TITLE
Add transport field to notifications endpoint config

### DIFF
--- a/notifications/endpoint.go
+++ b/notifications/endpoint.go
@@ -12,6 +12,7 @@ type EndpointConfig struct {
 	Timeout   time.Duration
 	Threshold int
 	Backoff   time.Duration
+	Transport *http.Transport
 }
 
 // defaults set any zero-valued fields to a reasonable default.
@@ -26,6 +27,10 @@ func (ec *EndpointConfig) defaults() {
 
 	if ec.Backoff <= 0 {
 		ec.Backoff = time.Second
+	}
+
+	if ec.Transport == nil {
+		ec.Transport = http.DefaultTransport.(*http.Transport)
 	}
 }
 
@@ -54,7 +59,7 @@ func NewEndpoint(name, url string, config EndpointConfig) *Endpoint {
 	// Configures the inmemory queue, retry, http pipeline.
 	endpoint.Sink = newHTTPSink(
 		endpoint.url, endpoint.Timeout, endpoint.Headers,
-		endpoint.metrics.httpStatusListener())
+		endpoint.Transport, endpoint.metrics.httpStatusListener())
 	endpoint.Sink = newRetryingSink(endpoint.Sink, endpoint.Threshold, endpoint.Backoff)
 	endpoint.Sink = newEventQueue(endpoint.Sink, endpoint.metrics.eventQueueListener())
 

--- a/notifications/http.go
+++ b/notifications/http.go
@@ -26,13 +26,16 @@ type httpSink struct {
 
 // newHTTPSink returns an unreliable, single-flight http sink. Wrap in other
 // sinks for increased reliability.
-func newHTTPSink(u string, timeout time.Duration, headers http.Header, listeners ...httpStatusListener) *httpSink {
+func newHTTPSink(u string, timeout time.Duration, headers http.Header, transport *http.Transport, listeners ...httpStatusListener) *httpSink {
+	if transport == nil {
+		transport = http.DefaultTransport.(*http.Transport)
+	}
 	return &httpSink{
 		url:       u,
 		listeners: listeners,
 		client: &http.Client{
 			Transport: &headerRoundTripper{
-				Transport: http.DefaultTransport.(*http.Transport),
+				Transport: transport,
 				headers:   headers,
 			},
 			Timeout: timeout,


### PR DESCRIPTION
The EndpointConfig struct in the notifications package has some config
fields for a notification endpoint. This commit adds the ability to pass
in an *http.Transport to use when notifying that endpoint of an event.
This is especially useful for endpoints that use self-signed CAs.