### PR TITLE
Properly validate multi-URL foreign layers

### DIFF
--- a/registry/storage/schema2manifesthandler.go
+++ b/registry/storage/schema2manifesthandler.go
@@ -107,6 +107,7 @@ func (ms *schema2ManifestHandler) verifyManifest(ctx context.Context, mnfst sche
 					pu, err = url.Parse(u)
 					if err != nil || (pu.Scheme != "http" && pu.Scheme != "https") || pu.Fragment != "" {
 						err = errInvalidURL
+						break
 					}
 				}
 			}

--- a/registry/storage/schema2manifesthandler_test.go
+++ b/registry/storage/schema2manifesthandler_test.go
@@ -80,6 +80,11 @@ func TestVerifyManifestForeignLayer(t *testing.T) {
 		},
 		{
 			foreignLayer,
+			[]string{"", "https://foo/bar"},
+			errInvalidURL,
+		},
+		{
+			foreignLayer,
 			[]string{"http://foo/bar"},
 			nil,
 		},


### PR DESCRIPTION
The existing code effectively ignored errors from all but the last of a
foreign layer's URLs.

Signed-off-by: Noah Treuhaft <noah.treuhaft@docker.com>