### PR TITLE
Add a foreign layer URL host whitelist

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -172,6 +172,24 @@ type Configuration struct {
 			TrustKey string `yaml:"signingkeyfile,omitempty"`
 		} `yaml:"schema1,omitempty"`
 	} `yaml:"compatibility,omitempty"`
+
+	// Validation configures validation options for the registry.
+	Validation struct {
+		// Enabled enables the other options in this section.
+		Enabled bool `yaml:"enabled,omitempty"`
+		// Manifests configures manifest validation.
+		Manifests struct {
+			// URLs configures validation for URLs in pushed manifests.
+			URLs struct {
+				// Allow specifies regular expressions (https://godoc.org/regexp/syntax)
+				// that URLs in pushed manifests must match.
+				Allow []string `yaml:"allow,omitempty"`
+				// Deny specifies regular expressions (https://godoc.org/regexp/syntax)
+				// that URLs in pushed manifests must not match.
+				Deny []string `yaml:"deny,omitempty"`
+			} `yaml:"urls,omitempty"`
+		} `yaml:"manifests,omitempty"`
+	} `yaml:"validation,omitempty"`
 }
 
 // LogHook is composed of hook Level and Type.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,6 +246,14 @@ information about each option that appears later in this page.
     compatibility:
       schema1:
         signingkeyfile: /etc/registry/key.json
+    validation:
+      enabled: true
+      manifests:
+        urls:
+          allow:
+            - ^https?://([^/]+\.)*example\.com/
+          deny:
+            - ^https?://www\.example\.com/
 
 In some instances a configuration option is **optional** but it contains child
 options marked as **required**. This indicates that you can omit the parent with
@@ -1771,7 +1779,7 @@ To enable pulling private repositories (e.g. `batman/robin`) a username and pass
         signingkeyfile: /etc/registry/key.json
 
 Configure handling of older and deprecated features. Each subsection
-defines a such a feature with configurable behavior.
+defines such a feature with configurable behavior.
 
 ### Schema1
 
@@ -1795,6 +1803,39 @@ defines a such a feature with configurable behavior.
     </td>
   </tr>
 </table>
+
+## Validation
+
+    validation:
+      enabled: true
+      manifests:
+        urls:
+          allow:
+            - ^https?://([^/]+\.)*example\.com/
+          deny:
+            - ^https?://www\.example\.com/
+
+### Enabled
+
+Use the `enabled` flag to enable the other options in the `validation`
+section. They are disabled by default.
+
+### Manifests
+
+Use the `manifest` subsection to configure manifest validation.
+
+#### URLs
+
+The `allow` and `deny` options are both lists of
+[regular expressions](https://godoc.org/regexp/syntax) that restrict the URLs in
+pushed manifests.
+
+If `allow` is unset, pushing a manifest containing URLs will fail.
+
+If `allow` is set, pushing a manifest will succeed only if all URLs within match
+one of the `allow` regular expressions and one of the following holds:
+1. `deny` is unset.
+2. `deny` is set but no URLs within the manifest match any of the `deny` regular expressions.
 
 ## Example: Development configuration
 

--- a/registry/storage/garbagecollect_test.go
+++ b/registry/storage/garbagecollect_test.go
@@ -21,13 +21,14 @@ type image struct {
 	layers         map[digest.Digest]io.ReadSeeker
 }
 
-func createRegistry(t *testing.T, driver driver.StorageDriver) distribution.Namespace {
+func createRegistry(t *testing.T, driver driver.StorageDriver, options ...RegistryOption) distribution.Namespace {
 	ctx := context.Background()
 	k, err := libtrust.GenerateECP256PrivateKey()
 	if err != nil {
 		t.Fatal(err)
 	}
-	registry, err := NewRegistry(ctx, driver, EnableDelete, Schema1SigningKey(k))
+	options = append([]RegistryOption{EnableDelete, Schema1SigningKey(k)}, options...)
+	registry, err := NewRegistry(ctx, driver, options...)
 	if err != nil {
 		t.Fatalf("Failed to construct namespace")
 	}

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"regexp"
+
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/reference"
@@ -20,6 +22,10 @@ type registry struct {
 	resumableDigestEnabled       bool
 	schema1SigningKey            libtrust.PrivateKey
 	blobDescriptorServiceFactory distribution.BlobDescriptorServiceFactory
+	manifestURLs                 struct {
+		allow *regexp.Regexp
+		deny  *regexp.Regexp
+	}
 }
 
 // RegistryOption is the type used for functional options for NewRegistry.
@@ -44,6 +50,22 @@ func EnableDelete(registry *registry) error {
 func DisableDigestResumption(registry *registry) error {
 	registry.resumableDigestEnabled = false
 	return nil
+}
+
+// ManifestURLsAllowRegexp is a functional option for NewRegistry.
+func ManifestURLsAllowRegexp(r *regexp.Regexp) RegistryOption {
+	return func(registry *registry) error {
+		registry.manifestURLs.allow = r
+		return nil
+	}
+}
+
+// ManifestURLsDenyRegexp is a functional option for NewRegistry.
+func ManifestURLsDenyRegexp(r *regexp.Regexp) RegistryOption {
+	return func(registry *registry) error {
+		registry.manifestURLs.deny = r
+		return nil
+	}
 }
 
 // Schema1SigningKey returns a functional option for NewRegistry. It sets the

--- a/registry/storage/schema2manifesthandler.go
+++ b/registry/storage/schema2manifesthandler.go
@@ -102,10 +102,12 @@ func (ms *schema2ManifestHandler) verifyManifest(ctx context.Context, mnfst sche
 				if len(fsLayer.URLs) == 0 {
 					err = errMissingURL
 				}
+				allow := ms.repository.manifestURLs.allow
+				deny := ms.repository.manifestURLs.deny
 				for _, u := range fsLayer.URLs {
 					var pu *url.URL
 					pu, err = url.Parse(u)
-					if err != nil || (pu.Scheme != "http" && pu.Scheme != "https") || pu.Fragment != "" {
+					if err != nil || (pu.Scheme != "http" && pu.Scheme != "https") || pu.Fragment != "" || (allow != nil && !allow.MatchString(u)) || (deny != nil && deny.MatchString(u)) {
 						err = errInvalidURL
 						break
 					}


### PR DESCRIPTION
Until we have some experience hosting foreign layer manifests, the Hub
operators wish to limit foreign layers on Hub to those hosted by
Microsoft. To that end, this change adds a registry configuration option
to whitelist hosts that may appear in foreign layer URLs of pushed
manifests, and it modifies manifest validation to reject pushes
containing foreign layer URLs whose host is not whitelisted.

Signed-off-by: Noah Treuhaft <noah.treuhaft@docker.com>