### PR TITLE
Fix storage drivers dropping non EOF errors when listing repositories

### DIFF
--- a/registry/handlers/catalog.go
+++ b/registry/handlers/catalog.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strconv"
 
 	"github.com/docker/distribution/registry/api/errcode"
@@ -48,8 +47,9 @@ func (ch *catalogHandler) GetCatalog(w http.ResponseWriter, r *http.Request) {
 	repos := make([]string, maxEntries)
 
 	filled, err := ch.App.registry.Repositories(ch.Context, repos, lastEntry)
+	_, pathNotFound := err.(driver.PathNotFoundError)
 
-	if err == io.EOF || reflect.TypeOf(err) == reflect.TypeOf(driver.PathNotFoundError{}) {
+	if err == io.EOF || pathNotFound {
 		moreEntries = false
 	} else if err != nil && err != storage.ErrFinishedWalk {
 		ch.Errors = append(ch.Errors, errcode.ErrorCodeUnknown.WithDetail(err))

--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -18,19 +18,19 @@ var ErrFinishedWalk = errors.New("finished walk")
 // Returns a list, or partial list, of repositories in the registry.
 // Because it's a quite expensive operation, it should only be used when building up
 // an initial set of repositories.
-func (reg *registry) Repositories(ctx context.Context, repos []string, last string) (n int, errVal error) {
+func (reg *registry) Repositories(ctx context.Context, repos []string, last string) (n int, err error) {
 	var foundRepos []string
 
 	if len(repos) == 0 {
 		return 0, errors.New("no space in slice")
 	}
 
-	root, errVal := pathFor(repositoriesRootPathSpec{})
-	if errVal != nil {
-		return 0, errVal
+	root, err := pathFor(repositoriesRootPathSpec{})
+	if err != nil {
+		return 0, err
 	}
 
-	errVal = Walk(ctx, reg.blobStore.driver, root, func(fileInfo driver.FileInfo) error {
+	err = Walk(ctx, reg.blobStore.driver, root, func(fileInfo driver.FileInfo) error {
 		filePath := fileInfo.Path()
 
 		// lop the base path off
@@ -58,11 +58,11 @@ func (reg *registry) Repositories(ctx context.Context, repos []string, last stri
 	n = copy(repos, foundRepos)
 
 	// Signal that we have no more entries by setting EOF
-	if len(foundRepos) <= len(repos) && (errVal == nil || errVal == ErrSkipDir) {
-		errVal = io.EOF
+	if len(foundRepos) <= len(repos) && (err == nil || err == ErrSkipDir) {
+		err = io.EOF
 	}
 
-	return n, errVal
+	return n, err
 }
 
 // Enumerate applies ingester to each repository

--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -25,12 +25,12 @@ func (reg *registry) Repositories(ctx context.Context, repos []string, last stri
 		return 0, errors.New("no space in slice")
 	}
 
-	root, err := pathFor(repositoriesRootPathSpec{})
-	if err != nil {
-		return 0, err
+	root, errVal := pathFor(repositoriesRootPathSpec{})
+	if errVal != nil {
+		return 0, errVal
 	}
 
-	err = Walk(ctx, reg.blobStore.driver, root, func(fileInfo driver.FileInfo) error {
+	errVal = Walk(ctx, reg.blobStore.driver, root, func(fileInfo driver.FileInfo) error {
 		filePath := fileInfo.Path()
 
 		// lop the base path off
@@ -58,7 +58,7 @@ func (reg *registry) Repositories(ctx context.Context, repos []string, last stri
 	n = copy(repos, foundRepos)
 
 	// Signal that we have no more entries by setting EOF
-	if len(foundRepos) <= len(repos) && err != ErrFinishedWalk {
+	if len(foundRepos) <= len(repos) && (errVal == nil || errVal == ErrSkipDir) {
 		errVal = io.EOF
 	}
 

--- a/registry/storage/catalog_test.go
+++ b/registry/storage/catalog_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"io"
 	"testing"
 
@@ -122,4 +123,43 @@ func testEq(a, b []string, size int) bool {
 		}
 	}
 	return true
+}
+
+func setupBadWalkEnv(t *testing.T) *setupEnv {
+	d := newBadListDriver()
+	ctx := context.Background()
+	registry, err := NewRegistry(ctx, d, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableRedirect)
+	if err != nil {
+		t.Fatalf("error creating registry: %v", err)
+	}
+
+	return &setupEnv{
+		ctx:      ctx,
+		driver:   d,
+		registry: registry,
+	}
+}
+
+type badListDriver struct {
+	driver.StorageDriver
+}
+
+var _ driver.StorageDriver = &badListDriver{}
+
+func newBadListDriver() *badListDriver {
+	return &badListDriver{StorageDriver: inmemory.New()}
+}
+
+func (d *badListDriver) List(ctx context.Context, path string) ([]string, error) {
+	return nil, fmt.Errorf("List error")
+}
+
+func TestCatalogWalkError(t *testing.T) {
+	env := setupBadWalkEnv(t)
+	p := make([]string, 1)
+
+	_, err := env.registry.Repositories(env.ctx, p, "")
+	if err == io.EOF {
+		t.Errorf("Expected catalog driver list error")
+	}
 }


### PR DESCRIPTION
This fixes errors other than io.EOF from being dropped when a storage driver
lists repositories. For example, filesystem driver may point to a missing
directory and errors, which then gets subsequently dropped.
    
Signed-off-by: Edgar Lee <edgar.lee@docker.com>