### PR TITLE
Integration tests support for docker 1.12

### DIFF
--- a/contrib/docker-integration/malevolent.bats
+++ b/contrib/docker-integration/malevolent.bats
@@ -12,7 +12,7 @@ function setup() {
 }
 
 @test "Test malevolent proxy pass through" {
-	docker_t tag -f $base:latest $host/$base/nochange:latest
+	docker_t tag $base:latest $host/$base/nochange:latest
 	run docker_t push $host/$base/nochange:latest
 	echo $output
 	[ "$status" -eq 0 ]
@@ -26,7 +26,7 @@ function setup() {
 @test "Test malevolent image name change" {
 	imagename="$host/$base/rename"
 	image="$imagename:lastest"
-	docker_t tag -f $base:latest $image
+	docker_t tag $base:latest $image
 	run docker_t push $image
 	[ "$status" -eq 0 ]
 	has_digest "$output"
@@ -133,7 +133,7 @@ function setup() {
 	has_digest "$output"
 
 	image2="$host/$base/image2/alteredid:$poison2"
-	docker_t tag -f $image1 $image2
+	docker_t tag $image1 $image2
 	run docker_t push $image2
 	echo "$output"
 	[ "$status" -eq 0 ]

--- a/contrib/docker-integration/run_multiversion.sh
+++ b/contrib/docker-integration/run_multiversion.sh
@@ -53,13 +53,13 @@ time docker pull distribution/golem-runner:0.1-bats
 time docker pull docker:1.9.1-dind
 time docker pull docker:1.10.3-dind
 time docker pull docker:1.11.1-dind
-time docker pull docker:1.12.0-rc3-dind
+time docker pull docker:1.12.3-dind
 
 golem -cache $cachedir \
 	-i "golem-distribution:latest,$distimage,$distversion" \
 	-i "golem-dind:latest,docker:1.9.1-dind,1.9.1" \
 	-i "golem-dind:latest,docker:1.10.3-dind,1.10.3" \
 	-i "golem-dind:latest,docker:1.11.1-dind,1.11.1" \
-	-i "golem-dind:latest,docker:1.12.0-rc3-dind,1.12.0" \
+	-i "golem-dind:latest,docker:1.12.3-dind,1.12.0" \
 	$DIR
 

--- a/contrib/docker-integration/run_multiversion.sh
+++ b/contrib/docker-integration/run_multiversion.sh
@@ -46,7 +46,6 @@ echo "Testing image $distimage with distribution version $distversion"
 # These images are defined in golem.conf
 time docker pull nginx:1.9
 time docker pull golang:1.6
-time docker pull registry:0.9.1
 time docker pull dmcgowan/token-server:simple
 time docker pull dmcgowan/token-server:oauth
 time docker pull distribution/golem-runner:0.1-bats
@@ -54,11 +53,13 @@ time docker pull distribution/golem-runner:0.1-bats
 time docker pull docker:1.9.1-dind
 time docker pull docker:1.10.3-dind
 time docker pull docker:1.11.1-dind
+time docker pull docker:1.12.0-rc3-dind
 
 golem -cache $cachedir \
 	-i "golem-distribution:latest,$distimage,$distversion" \
 	-i "golem-dind:latest,docker:1.9.1-dind,1.9.1" \
 	-i "golem-dind:latest,docker:1.10.3-dind,1.10.3" \
 	-i "golem-dind:latest,docker:1.11.1-dind,1.11.1" \
+	-i "golem-dind:latest,docker:1.12.0-rc3-dind,1.12.0" \
 	$DIR
 

--- a/contrib/docker-integration/tls.bats
+++ b/contrib/docker-integration/tls.bats
@@ -19,7 +19,7 @@ function setup() {
 }
 
 @test "Test valid certificates" {
-	docker_t tag -f $image $hostname:5440/$image
+	docker_t tag $image $hostname:5440/$image
 	run docker_t push $hostname:5440/$image
 	[ "$status" -eq 0 ]
 	has_digest "$output"
@@ -28,7 +28,7 @@ function setup() {
 @test "Test basic auth" {
 	basic_auth_version_check
 	login $hostname:5441
-	docker_t tag -f $image $hostname:5441/$image
+	docker_t tag $image $hostname:5441/$image
 	run docker_t push $hostname:5441/$image
 	[ "$status" -eq 0 ]
 	has_digest "$output"
@@ -60,14 +60,14 @@ function setup() {
 }
 
 @test "Test TLS client auth" {
-	docker_t tag -f $image $hostname:5442/$image
+	docker_t tag $image $hostname:5442/$image
 	run docker_t push $hostname:5442/$image
 	[ "$status" -eq 0 ]
 	has_digest "$output"
 }
 
 @test "Test TLS client with invalid certificate authority fails" {
-	docker_t tag -f $image $hostname:5443/$image
+	docker_t tag $image $hostname:5443/$image
 	run docker_t push $hostname:5443/$image
 	[ "$status" -ne 0 ]
 }
@@ -75,14 +75,14 @@ function setup() {
 @test "Test basic auth with TLS client auth" {
 	basic_auth_version_check
 	login $hostname:5444
-	docker_t tag -f $image $hostname:5444/$image
+	docker_t tag $image $hostname:5444/$image
 	run docker_t push $hostname:5444/$image
 	[ "$status" -eq 0 ]
 	has_digest "$output"
 }
 
 @test "Test unknown certificate authority fails" {
-	docker_t tag -f $image $hostname:5445/$image
+	docker_t tag $image $hostname:5445/$image
 	run docker_t push $hostname:5445/$image
 	[ "$status" -ne 0 ]
 }
@@ -90,19 +90,19 @@ function setup() {
 @test "Test basic auth with unknown certificate authority fails" {
 	run login $hostname:5446
 	[ "$status" -ne 0 ]
-	docker_t tag -f $image $hostname:5446/$image
+	docker_t tag $image $hostname:5446/$image
 	run docker_t push $hostname:5446/$image
 	[ "$status" -ne 0 ]
 }
 
 @test "Test TLS client auth to server with unknown certificate authority fails" {
-	docker_t tag -f $image $hostname:5447/$image
+	docker_t tag $image $hostname:5447/$image
 	run docker_t push $hostname:5447/$image
 	[ "$status" -ne 0 ]
 }
 
 @test "Test failure to connect to server fails to fallback to SSLv3" {
-	docker_t tag -f $image $hostname:5448/$image
+	docker_t tag $image $hostname:5448/$image
 	run docker_t push $hostname:5448/$image
 	[ "$status" -ne 0 ]
 }


### PR DESCRIPTION
Remove use of `tag -f` since it is no longer allowed in 1.12 and not needed for any of the currently tested versions of Docker. Additionally don't add the email flag on login starting in docker 1.11.

Do not merge until Docker 1.12 has been released. Periodic failure caused by startup time for 1.12 taking longer than previous versions. A wait may need to be added to the tests.
