### PR TITLE
reorder Dockerfile steps for better layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM golang:1.6-alpine
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
 ENV DOCKER_BUILDTAGS include_oss include_gcs
 
+RUN set -ex \
+    && apk add --no-cache make git
+
 WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
-
-RUN set -ex \
-    && apk add --no-cache make git
 
 RUN make PREFIX=/go clean binaries
 


### PR DESCRIPTION
Running `apk add` before copying source into the image takes better
adavantage of layer caching when developing and regularly building the
image. This avoids source code changes invalidating the `apk add` layer
and causing that step to run on every image build.

Signed-off-by: Adam Duke <adam.v.duke@gmail.com>