### PR TITLE
Fix the build.

### DIFF
--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -22,10 +22,13 @@ type registry struct {
 	resumableDigestEnabled       bool
 	schema1SigningKey            libtrust.PrivateKey
 	blobDescriptorServiceFactory distribution.BlobDescriptorServiceFactory
-	manifestURLs                 struct {
-		allow *regexp.Regexp
-		deny  *regexp.Regexp
-	}
+	manifestURLs                 manifestURLs
+}
+
+// manifestURLs holds regular expressions for controlling manifest URL whitelisting
+type manifestURLs struct {
+	allow *regexp.Regexp
+	deny  *regexp.Regexp
 }
 
 // RegistryOption is the type used for functional options for NewRegistry.
@@ -245,9 +248,10 @@ func (repo *repository) Manifests(ctx context.Context, options ...distribution.M
 			blobStore:         blobStore,
 		},
 		schema2Handler: &schema2ManifestHandler{
-			ctx:        ctx,
-			repository: repo,
-			blobStore:  blobStore,
+			ctx:          ctx,
+			repository:   repo,
+			blobStore:    blobStore,
+			manifestURLs: repo.registry.manifestURLs,
 		},
 		manifestListHandler: &manifestListHandler{
 			ctx:        ctx,

--- a/registry/storage/schema2manifesthandler.go
+++ b/registry/storage/schema2manifesthandler.go
@@ -1,11 +1,10 @@
 package storage
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
-
-	"encoding/json"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
@@ -21,9 +20,10 @@ var (
 
 //schema2ManifestHandler is a ManifestHandler that covers schema2 manifests.
 type schema2ManifestHandler struct {
-	repository distribution.Repository
-	blobStore  distribution.BlobStore
-	ctx        context.Context
+	repository   distribution.Repository
+	blobStore    distribution.BlobStore
+	ctx          context.Context
+	manifestURLs manifestURLs
 }
 
 var _ ManifestHandler = &schema2ManifestHandler{}
@@ -97,8 +97,8 @@ func (ms *schema2ManifestHandler) verifyManifest(ctx context.Context, mnfst sche
 				if len(fsLayer.URLs) == 0 {
 					err = errMissingURL
 				}
-				allow := ms.repository.manifestURLs.allow
-				deny := ms.repository.manifestURLs.deny
+				allow := ms.manifestURLs.allow
+				deny := ms.manifestURLs.deny
 				for _, u := range fsLayer.URLs {
 					var pu *url.URL
 					pu, err = url.Parse(u)


### PR DESCRIPTION
Pass the manifestURL directly into the schema2 manifest handler instead of
accessing through the repository as the reference has since become an
interface.

cc @nwt 

Signed-off-by: Richard Scothern <richard.scothern@docker.com>