### PR TITLE
Add 'objectAcl' Option to the S3 Storage Backend

### DIFF
--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -200,7 +200,7 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
 
 `storageclass`: (optional) The storage class applied to each registry file. Defaults to STANDARD. Valid options are STANDARD and REDUCED_REDUNDANCY.
 
-`objectacl`: (optional) The canned object ACL to be applied to each registry file. Defaults to `private`. If you are using a bucket owned by another AWS account, it is recommended that you set this to `bucket-owner-full-control` so that the bucket owner can access your files. Other valid options are available in the [AWS S3 documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
+`objectacl`: (optional) The canned object ACL to be applied to each registry object. Defaults to `private`. If you are using a bucket owned by another AWS account, it is recommended that you set this to `bucket-owner-full-control` so that the bucket owner can access your objects. Other valid options are available in the [AWS S3 documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
 
 ## S3 permission scopes
 

--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -160,6 +160,17 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
       The S3 storage class applied to each registry file. The default value is STANDARD.
     </td>
   </tr>
+  <tr>
+    <td>
+      <code>objectacl</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      The S3 Canned ACL for objects. The default value is "private".
+    </td>
+  </tr>
 </table>
 
 
@@ -188,6 +199,8 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
 `rootdirectory`: (optional) The root directory tree in which all registry files will be stored. Defaults to the empty string (bucket root).
 
 `storageclass`: (optional) The storage class applied to each registry file. Defaults to STANDARD. Valid options are STANDARD and REDUCED_REDUNDANCY.
+
+`objectacl`: (optional) The canned object ACL to be applied to each registry file. Defaults to `private`. If you are using a bucket owned by another AWS account, it is recommended that you set this to `bucket-owner-full-control` so that the bucket owner can access your files. Other valid options are available in the [AWS S3 documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
 
 ## S3 permission scopes
 

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -67,6 +67,7 @@ type DriverParameters struct {
 	RootDirectory  string
 	StorageClass   string
 	UserAgent      string
+	ObjectAcl      string
 }
 
 func init() {
@@ -107,6 +108,7 @@ type driver struct {
 	KeyID         string
 	RootDirectory string
 	StorageClass  string
+	ObjectAcl     string
 }
 
 type baseEmbed struct {
@@ -248,6 +250,11 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		userAgent = ""
 	}
 
+	objectAcl := parameters["objectacl"]
+	if objectAcl == nil {
+		objectAcl = "private"
+	}
+
 	params := DriverParameters{
 		fmt.Sprint(accessKey),
 		fmt.Sprint(secretKey),
@@ -261,6 +268,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		fmt.Sprint(rootDirectory),
 		storageClass,
 		fmt.Sprint(userAgent),
+		fmt.Sprint(objectAcl),
 	}
 
 	return New(params)
@@ -321,6 +329,7 @@ func New(params DriverParameters) (*Driver, error) {
 		KeyID:         params.KeyID,
 		RootDirectory: params.RootDirectory,
 		StorageClass:  params.StorageClass,
+		ObjectAcl:     params.ObjectAcl,
 	}
 
 	return &Driver{
@@ -688,7 +697,7 @@ func (d *driver) getContentType() *string {
 }
 
 func (d *driver) getACL() *string {
-	return aws.String("private")
+	return aws.String(d.ObjectAcl)
 }
 
 func (d *driver) getStorageClass() *string {

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -53,6 +53,9 @@ const listMax = 1000
 // validRegions maps known s3 region identifiers to region descriptors
 var validRegions = map[string]struct{}{}
 
+// validObjectAcls contains known s3 object Acls
+var validObjectAcls = map[string]struct{}{}
+
 //DriverParameters A struct that encapsulates all of the driver parameters after all values have been set
 type DriverParameters struct {
 	AccessKey      string
@@ -86,6 +89,18 @@ func init() {
 		"us-gov-west-1",
 	} {
 		validRegions[region] = struct{}{}
+	}
+
+	for _, objectAcl := range []string{
+		s3.ObjectCannedACLPrivate,
+		s3.ObjectCannedACLPublicRead,
+		s3.ObjectCannedACLPublicReadWrite,
+		s3.ObjectCannedACLAuthenticatedRead,
+		s3.ObjectCannedACLAwsExecRead,
+		s3.ObjectCannedACLBucketOwnerRead,
+		s3.ObjectCannedACLBucketOwnerFullControl,
+	} {
+		validObjectAcls[objectAcl] = struct{}{}
 	}
 
 	// Register this as the default s3 driver in addition to s3aws
@@ -250,9 +265,18 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		userAgent = ""
 	}
 
-	objectAcl := parameters["objectacl"]
-	if objectAcl == nil {
-		objectAcl = "private"
+	objectAcl := s3.ObjectCannedACLPrivate
+	objectAclParam := parameters["objectacl"]
+	if objectAclParam != nil {
+		objectAclString, ok := objectAclParam.(string)
+		if !ok {
+			return nil, fmt.Errorf("Invalid valid for objectacl parameter: %v", objectAclParam)
+		}
+
+		if _, ok = validObjectAcls[objectAclString]; !ok {
+			return nil, fmt.Errorf("Invalid valid for objectacl parameter: %v", objectAclParam)
+		}
+		objectAcl = objectAclString
 	}
 
 	params := DriverParameters{
@@ -268,7 +292,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		fmt.Sprint(rootDirectory),
 		storageClass,
 		fmt.Sprint(userAgent),
-		fmt.Sprint(objectAcl),
+		objectAcl,
 	}
 
 	return New(params)

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -270,11 +270,11 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	if objectAclParam != nil {
 		objectAclString, ok := objectAclParam.(string)
 		if !ok {
-			return nil, fmt.Errorf("Invalid valid for objectacl parameter: %v", objectAclParam)
+			return nil, fmt.Errorf("Invalid value for objectacl parameter: %v", objectAclParam)
 		}
 
 		if _, ok = validObjectAcls[objectAclString]; !ok {
-			return nil, fmt.Errorf("Invalid valid for objectacl parameter: %v", objectAclParam)
+			return nil, fmt.Errorf("Invalid value for objectacl parameter: %v", objectAclParam)
 		}
 		objectAcl = objectAclString
 	}

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -30,6 +30,7 @@ func init() {
 	keyID := os.Getenv("S3_KEY_ID")
 	secure := os.Getenv("S3_SECURE")
 	region := os.Getenv("AWS_REGION")
+	objectAcl := os.Getenv("S3_OBJECT_ACL")
 	root, err := ioutil.TempDir("", "driver-")
 	regionEndpoint := os.Getenv("REGION_ENDPOINT")
 	if err != nil {
@@ -67,6 +68,7 @@ func init() {
 			rootDirectory,
 			storageClass,
 			driverName + "-test",
+			objectAcl,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
Adds `objectAcl` as a new option for the S3 storage backend to allow registry operators to specify a canned object ACL for each object stored in S3. 

This solves the issue where a registry in AWS Account A is set to use an S3 bucket owned by AWS Account B. By default, all objects are set to `private`, which means that Account B cannot view or modify the uploaded files in their own bucket. If the object ACL option is set to `bucket-owner-full-control` on the registry, then there would be no problem.

closes #1865 
closes #1730