### PR TITLE
function copyContent() cause socket leak.

### DIFF
--- a/registry/proxy/proxyblobstore.go
+++ b/registry/proxy/proxyblobstore.go
@@ -55,6 +55,8 @@ func (pbs *proxyBlobStore) copyContent(ctx context.Context, dgst digest.Digest, 
 		return distribution.Descriptor{}, err
 	}
 
+	defer remoteReader.Close()
+
 	_, err = io.CopyN(writer, remoteReader, desc.Size)
 	if err != nil {
 		return distribution.Descriptor{}, err


### PR DESCRIPTION
# Problem Describe
  if registry was deployed as a pull through cache ,function copeContent() may cause a socket leak when docker user canceled its pull operation.
  use `netstat -tnp` command ,you will see output like this below, registry`s socket recv_q blocked with data
  
```
  Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
  tcp        0 1754584 127.0.0.1:3128          127.0.0.1:34097         ESTABLISHED 10/ssh
  tcp        0 1757960 127.0.0.1:3128          127.0.0.1:34124         ESTABLISHED 10/ssh
  tcp   971464      0 127.0.0.1:34097         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp        0      0 192.168.0.2:45885       166.111.206.63:80       TIME_WAIT   -
  tcp   990992      0 127.0.0.1:34156         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp   5674571      0 127.0.0.1:34015         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp   914136      0 127.0.0.1:34124         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp        0 1756088 127.0.0.1:3128          127.0.0.1:34201         ESTABLISHED 10/ssh
  tcp        0 1745032 127.0.0.1:3128          127.0.0.1:34197         ESTABLISHED 10/ssh
  tcp        0 1729448 127.0.0.1:3128          127.0.0.1:34139         ESTABLISHED 10/ssh
  tcp   959672      0 127.0.0.1:34205         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp   973917      0 127.0.0.1:34173         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp        0 1756800 127.0.0.1:3128          127.0.0.1:34205         ESTABLISHED 10/ssh
  tcp        0 1730997 127.0.0.1:3128          127.0.0.1:34015         ESTABLISHED 10/ssh
  tcp        0 1756800 127.0.0.1:3128          127.0.0.1:34156         ESTABLISHED 10/ssh
  tcp   982640      0 127.0.0.1:34197         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp        0      0 192.168.0.2:46668       52.3.135.95:443         ESTABLISHED 11/registry
  tcp   956323      0 127.0.0.1:34139         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp        0 1726464 127.0.0.1:3128          127.0.0.1:34173         ESTABLISHED 10/ssh
  tcp        0 2519968 127.0.0.1:3128          127.0.0.1:34062         ESTABLISHED 10/ssh
  tcp        0      0 192.168.0.2:41039       52.6.165.240:443        ESTABLISHED 11/registry
  tcp        0      0 192.168.0.2:40979       133.242.8.20:80         TIME_WAIT   -
  tcp   922144      0 127.0.0.1:34062         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp        0      0 192.168.0.2:52873       47.90.35.86:22          ESTABLISHED 10/ssh
  tcp        0      0 192.168.0.2:39529       128.31.0.66:80          TIME_WAIT   -
  tcp   975088      0 127.0.0.1:34147         127.0.0.1:3128          ESTABLISHED 11/registry
  tcp        0 1756384 127.0.0.1:3128          127.0.0.1:34147         ESTABLISHED 10/ssh
  tcp   992336      0 127.0.0.1:34201         127.0.0.1:3128          ESTABLISHED 11/registry
```

# Reproduce
* Config registry as a pull through cache server and run.
* execute `$docker pull kaixhin/cuda-mxnet` . the reason for choosing image kaixhin/cuda-mxnet is its big size.
* when pull started and not complete ,use ctrl+c to interrupt docker pull
* login to registry server, use `$netstat -tpn `you will see a lot of stuck connections.
* as repeat the pull and cancel procedure, the number of stuck connections will continues growing up which will eventual slow down server.

# However
However, the remote registry will send a rst package to our registry server if they find our connection has gone stuck. this would finally release the connection. But it is still not a good habit to not close connection after an error occurred or data transfer finished: 
And , when use socks5 as a local proxy to deal with gfw, the connection still goes stuck even if the remote registry has send us a rst package, because ssh socks5 does not send this rst package back to us. In this case stuck connections cannot be handled util we close the connection explicit.

# Fix 
close connection while not used.

Signed-off-by: yaoyao.xyy <yaoyao.xyy@alibaba-inc.com>