### PR TITLE
Dynamically Parsing the Latest Account List

### DIFF
--- a/registry/auth/htpasswd/access.go
+++ b/registry/auth/htpasswd/access.go
@@ -16,6 +16,7 @@ import (
 
 type accessController struct {
 	realm    string
+	path     string
 	htpasswd *htpasswd
 }
 
@@ -43,7 +44,7 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 		return nil, err
 	}
 
-	return &accessController{realm: realm.(string), htpasswd: h}, nil
+	return &accessController{realm: realm.(string), path: path.(string), htpasswd: h}, nil
 }
 
 func (ac *accessController) Authorized(ctx context.Context, accessRecords ...auth.Access) (context.Context, error) {

--- a/registry/auth/htpasswd/access.go
+++ b/registry/auth/htpasswd/access.go
@@ -60,7 +60,18 @@ func (ac *accessController) Authorized(ctx context.Context, accessRecords ...aut
 		}
 	}
 
-	if err := ac.AuthenticateUser(username, password); err != nil {
+	// Dynamically parsing the latest account list
+	f, err := os.Open(ac.path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	entries, err := parseHTPasswd(f)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ac.AuthenticateUser(username, password, entries); err != nil {
 		context.GetLogger(ctx).Errorf("error authenticating user %q: %v", username, err)
 		return nil, &challenge{
 			realm: ac.realm,

--- a/registry/auth/htpasswd/htpasswd.go
+++ b/registry/auth/htpasswd/htpasswd.go
@@ -29,8 +29,8 @@ func newHTPasswd(rd io.Reader) (*htpasswd, error) {
 
 // AuthenticateUser checks a given user:password credential against the
 // receiving HTPasswd's file. If the check passes, nil is returned.
-func (htpasswd *htpasswd) authenticateUser(username string, password string) error {
-	credentials, ok := htpasswd.entries[username]
+func (htpasswd *htpasswd) authenticateUser(username string, password string, entries map[string][]byte) error {
+	credentials, ok := entries[username]
 	if !ok {
 		// timing attack paranoia
 		bcrypt.CompareHashAndPassword([]byte{}, []byte(password))


### PR DESCRIPTION
To parse the latest account list dynamically,

thus, maintainers could manage the accounts by maintaining the htpasswd file without restarting docker-registry frequently,

which is required by small organizations to build a secure docker-registry service using a simple AUTH option to manage.

===
CUI Wei <ghostplant@qq.com>