### PR TITLE
Dynamically Parsing the Latest Account List

### DIFF
--- a/registry/auth/htpasswd/access.go
+++ b/registry/auth/htpasswd/access.go
@@ -72,7 +72,7 @@ func (ac *accessController) Authorized(ctx context.Context, accessRecords ...aut
 		return nil, err
 	}
 
-	if err := ac.AuthenticateUser(username, password, entries); err != nil {
+	if err := ac.htpasswd.authenticateUser(username, password, entries); err != nil {
 		context.GetLogger(ctx).Errorf("error authenticating user %q: %v", username, err)
 		return nil, &challenge{
 			realm: ac.realm,
@@ -81,10 +81,6 @@ func (ac *accessController) Authorized(ctx context.Context, accessRecords ...aut
 	}
 
 	return auth.WithUser(ctx, auth.UserInfo{Name: username}), nil
-}
-
-func (ac *accessController) AuthenticateUser(username, password string) error {
-	return ac.htpasswd.authenticateUser(username, password)
 }
 
 // challenge implements the auth.Challenge interface.

--- a/registry/auth/htpasswd/htpasswd.go
+++ b/registry/auth/htpasswd/htpasswd.go
@@ -29,8 +29,8 @@ func newHTPasswd(rd io.Reader) (*htpasswd, error) {
 
 // AuthenticateUser checks a given user:password credential against the
 // receiving HTPasswd's file. If the check passes, nil is returned.
-func (htpasswd *htpasswd) authenticateUser(username string, password string) error {
-	credentials, ok := htpasswd.entries[username]
+func (htpasswd *htpasswd) authenticateUser(username string, password string, entries map[string][]byte) error {
+	credentials, ok := entries[username]
 	if !ok {
 		// timing attack paranoia
 		bcrypt.CompareHashAndPassword([]byte{}, []byte(password))


### PR DESCRIPTION
To parse the latest account list dynamically,

thus, maintainers could manage the accounts by maintaining the htpasswd file without restarting docker-registry frequently,

which is required by small organizations to build a secure docker-registry service using a simple AUTH option to manage.

Signed-off-by: CUI Wei <ghostplant@qq.com>