### PR TITLE
Dynamically Parsing the Latest Account List

### DIFF
--- a/registry/auth/htpasswd/htpasswd.go
+++ b/registry/auth/htpasswd/htpasswd.go
@@ -18,19 +18,16 @@ type htpasswd struct {
 }
 
 // newHTPasswd parses the reader and returns an htpasswd or an error.
-func newHTPasswd(rd io.Reader) (*htpasswd, error) {
-	entries, err := parseHTPasswd(rd)
-	if err != nil {
-		return nil, err
-	}
-
+func newHTPasswd() (*htpasswd, error) {
+	entries := map[string][]byte{}
+	
 	return &htpasswd{entries: entries}, nil
 }
 
 // AuthenticateUser checks a given user:password credential against the
 // receiving HTPasswd's file. If the check passes, nil is returned.
-func (htpasswd *htpasswd) authenticateUser(username string, password string) error {
-	credentials, ok := htpasswd.entries[username]
+func (htpasswd *htpasswd) authenticateUser(username string, password string, entries map[string][]byte) error {
+	credentials, ok := entries[username]
 	if !ok {
 		// timing attack paranoia
 		bcrypt.CompareHashAndPassword([]byte{}, []byte(password))


### PR DESCRIPTION
To parse the latest account list dynamically,

thus, maintainers could manage the accounts by maintaining the htpasswd file without restarting docker-registry frequently,

which is required by small organizations to build a secure docker-registry service using a simple AUTH option to manage.

Signed-off-by: CUI Wei <ghostplant@qq.com>