### PR TITLE
testutil, storage: use math/rand.Read where possible

### DIFF
--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -1168,10 +1168,7 @@ func randomFilename(length int64) string {
 var randomBytes = make([]byte, 128<<20)
 
 func init() {
-	// increase the random bytes to the required maximum
-	for i := range randomBytes {
-		randomBytes[i] = byte(rand.Intn(2 << 8))
-	}
+	_, _ = rand.Read(randomBytes) // always returns len(randomBytes) and nil error
 }
 
 func randomContents(length int64) []byte {

--- a/registry/storage/filereader_test.go
+++ b/registry/storage/filereader_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"bytes"
-	"crypto/rand"
 	"io"
 	mrand "math/rand"
 	"os"
@@ -16,7 +15,7 @@ import (
 func TestSimpleRead(t *testing.T) {
 	ctx := context.Background()
 	content := make([]byte, 1<<20)
-	n, err := rand.Read(content)
+	n, err := mrand.Read(content)
 	if err != nil {
 		t.Fatalf("unexpected error building random data: %v", err)
 	}

--- a/testutil/tarfile.go
+++ b/testutil/tarfile.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"archive/tar"
 	"bytes"
-	"crypto/rand"
 	"fmt"
 	"io"
 	mrand "math/rand"
@@ -46,7 +45,7 @@ func CreateRandomTarFile() (rs io.ReadSeeker, dgst digest.Digest, err error) {
 		randomData := make([]byte, fileSize)
 
 		// Fill up the buffer with some random data.
-		n, err := rand.Read(randomData)
+		n, err := mrand.Read(randomData)
 
 		if n != len(randomData) {
 			return nil, "", fmt.Errorf("short read creating random reader: %v bytes != %v bytes", n, len(randomData))


### PR DESCRIPTION
Use the much faster math/rand.Read function where cryptographic
guarantees are not required. The unit test suite should speed up a
little bit but we've already optimized around this, so it may not
matter.

Signed-off-by: Stephen J Day <stephen.day@docker.com>