### PR TITLE
s3-goamz: only check S3 region w/o custom endpoint

### DIFF
--- a/registry/storage/driver/s3-goamz/s3_test.go
+++ b/registry/storage/driver/s3-goamz/s3_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/testsuites"
-	"github.com/docker/goamz/aws"
 	"github.com/docker/goamz/s3"
 
 	"gopkg.in/check.v1"
@@ -28,7 +27,8 @@ func init() {
 	encrypt := os.Getenv("S3_ENCRYPT")
 	secure := os.Getenv("S3_SECURE")
 	v4auth := os.Getenv("S3_USE_V4_AUTH")
-	region := os.Getenv("AWS_REGION")
+	regionName := os.Getenv("AWS_REGION")
+	regionEndpoint := os.Getenv("AWS_REGION_ENDPOINT")
 	root, err := ioutil.TempDir("", "driver-")
 	if err != nil {
 		panic(err)
@@ -64,7 +64,8 @@ func init() {
 			accessKey,
 			secretKey,
 			bucket,
-			aws.GetRegion(region),
+			regionName,
+			regionEndpoint,
 			encryptBool,
 			secureBool,
 			v4AuthBool,
@@ -79,7 +80,7 @@ func init() {
 
 	// Skip S3 storage driver tests if environment variable parameters are not provided
 	skipS3 = func() string {
-		if accessKey == "" || secretKey == "" || region == "" || bucket == "" || encrypt == "" {
+		if accessKey == "" || secretKey == "" || regionName == "" || bucket == "" || encrypt == "" {
 			return "Must set AWS_ACCESS_KEY, AWS_SECRET_KEY, AWS_REGION, S3_BUCKET, and S3_ENCRYPT to run S3 tests"
 		}
 		return ""


### PR DESCRIPTION
This allows users of the s3-goamz driver to also set custom endpoints
without patching the registry source code.

A similar change was done for the new s3-aws driver earlier with
dbb6e28da26452f89dff7b5d1c99063079795033

Signed-off-by: Michael Schubert schu@exoscale.ch
