### PR TITLE
[swift] support different user-domain and tenant-domain

### DIFF
--- a/docs/storage-drivers/swift.md
+++ b/docs/storage-drivers/swift.md
@@ -107,7 +107,7 @@ An implementation of the `storagedriver.StorageDriver` interface that uses [Open
       no
     </td>
     <td>
-      Your Openstack domain name for Identity v3 API. You can either use <code>domain</code> or <code>domainid</code>.
+      Your user's Openstack domain name for Identity v3 API. You can either use <code>domain</code> or <code>domainid</code>.
     </td>
   </tr>
   <tr>
@@ -118,7 +118,29 @@ An implementation of the `storagedriver.StorageDriver` interface that uses [Open
       no
     </td>
     <td>
-      Your Openstack domain id for Identity v3 API. You can either use <code>domain</code> or <code>domainid</code>.
+      Your user's Openstack domain id for Identity v3 API. You can either use <code>domain</code> or <code>domainid</code>.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>tenantdomain</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      Your tenant's Openstack domain name for Identity v3 API. Only necessary if different from the <code>domain</code>. You can either use <code>tenantdomain</code> or <code>tenantdomainid</code>.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>tenantdomainid</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+      Your tenant's Openstack domain id for Identity v3 API. Only necessary if different from the <code>domain</code>. You can either use <code>tenantdomain</code> or <code>tenantdomainid</code>.
     </td>
   </tr>
   <tr>

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -67,6 +67,8 @@ type Parameters struct {
 	TenantID            string
 	Domain              string
 	DomainID            string
+	TenantDomain        string
+	TenantDomainID      string
 	TrustID             string
 	Region              string
 	AuthVersion         int
@@ -182,6 +184,8 @@ func New(params Parameters) (*Driver, error) {
 		TenantId:       params.TenantID,
 		Domain:         params.Domain,
 		DomainId:       params.DomainID,
+		TenantDomain:   params.TenantDomain,
+		TenantDomainId: params.TenantDomainID,
 		TrustId:        params.TrustID,
 		EndpointType:   swift.EndpointType(params.EndpointType),
 		Transport:      transport,

--- a/registry/storage/driver/swift/swift_test.go
+++ b/registry/storage/driver/swift/swift_test.go
@@ -30,6 +30,8 @@ func init() {
 		tenantID           string
 		domain             string
 		domainID           string
+		tenantDomain       string
+		tenantDomainID     string
 		trustID            string
 		container          string
 		region             string
@@ -51,6 +53,8 @@ func init() {
 	tenantID = os.Getenv("SWIFT_TENANT_ID")
 	domain = os.Getenv("SWIFT_DOMAIN_NAME")
 	domainID = os.Getenv("SWIFT_DOMAIN_ID")
+	tenantDomain = os.Getenv("SWIFT_DOMAIN_NAME")
+	tenantDomainID = os.Getenv("SWIFT_DOMAIN_ID")
 	trustID = os.Getenv("SWIFT_TRUST_ID")
 	container = os.Getenv("SWIFT_CONTAINER_NAME")
 	region = os.Getenv("SWIFT_REGION_NAME")
@@ -87,6 +91,8 @@ func init() {
 			tenantID,
 			domain,
 			domainID,
+			tenantDomain,
+			tenantDomainID,
 			trustID,
 			region,
 			AuthVersion,


### PR DESCRIPTION
This is already supported by [ncw/swift](https://github.com/ncw/swift), so we just need to pass the parameters from the storage driver to the backend.