### PR TITLE
Use multipart upload API in S3 Move method

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,9 @@ information about each option that appears later in this page.
         secure: true
         v4auth: true
         chunksize: 5242880
+        multipartcopychunksize: 33554432
+        multipartcopymaxconcurrency: 100
+        multipartcopythresholdsize: 33554432
         rootdirectory: /s3/object/name/prefix
       swift:
         username: username
@@ -380,6 +383,9 @@ Permitted values are `error`, `warn`, `info` and `debug`. The default is
         secure: true
         v4auth: true
         chunksize: 5242880
+        multipartcopychunksize: 33554432
+        multipartcopymaxconcurrency: 100
+        multipartcopythresholdsize: 33554432
         rootdirectory: /s3/object/name/prefix
       swift:
         username: username

--- a/docs/storage-drivers/s3.md
+++ b/docs/storage-drivers/s3.md
@@ -140,6 +140,42 @@ An implementation of the `storagedriver.StorageDriver` interface which uses Amaz
   </tr>
   <tr>
     <td>
+      <code>multipartcopychunksize</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+       Chunk size for all but the last Upload Part - Copy
+       operation of a copy that uses the multipart upload API.
+   </td>
+  </tr>
+  <tr>
+    <td>
+      <code>multipartcopymaxconcurrency</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+       Maximum number of concurrent Upload Part - Copy operations for a
+       copy that uses the multipart upload API.
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <code>multipartcopythresholdsize</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+       Objects above this size will be copied using the multipart upload API.
+       PUT Object - Copy is used for objects at or below this size.
+    </td>
+  </tr>
+  <tr>
+    <td>
       <code>rootdirectory</code>
     </td>
     <td>


### PR DESCRIPTION
This change to the S3 Move method uses S3's multipart upload API to copy
objects whose size exceeds a threshold.  Parts are copied concurrently.
The level of concurrency, part size, and threshold are all configurable
with reasonable defaults.

Using the multipart upload API has two benefits.

* The S3 Move method can now handle objects over 5 GB
closes #886.

* Moving most objects, and espectially large ones, is faster.  For
  example, moving a 1 GB object averaged 30 seconds but now averages 10.

Signed-off-by: Noah Treuhaft <noah.treuhaft@docker.com>