### PR TITLE
Swift driver now bulk deletes in chunks specified by the server

### DIFF
--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -539,7 +539,7 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 		}
 	}
 
-	if d.BulkDeleteSupport && len(objects) > 0 {
+	if d.BulkDeleteSupport && len(objects) > 0 && d.BulkDeleteMaxDeletes > 0 {
 		filenames := make([]string, len(objects))
 		for i, obj := range objects {
 			filenames[i] = obj.Name

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -91,9 +91,9 @@ type swiftInfo struct {
 	Tempurl struct {
 		Methods []string `mapstructure:"methods"`
 	}
-	Bulk_Delete struct {
+	BulkDelete struct {
 		MaxDeletesPerRequest int `mapstructure:"max_deletes_per_request"`
-	}
+	} `mapstructure:"bulk_delete"`
 }
 
 func init() {
@@ -226,7 +226,7 @@ func New(params Parameters) (*Driver, error) {
 			d.TempURLContainerKey = info.Swift.Version >= "2.3.0"
 			d.TempURLMethods = info.Tempurl.Methods
 			if d.BulkDeleteSupport {
-				d.BulkDeleteMaxDeletes = info.Bulk_Delete.MaxDeletesPerRequest
+				d.BulkDeleteMaxDeletes = info.BulkDelete.MaxDeletesPerRequest
 			}
 		}
 	} else {

--- a/registry/storage/driver/swift/swift_test.go
+++ b/registry/storage/driver/swift/swift_test.go
@@ -215,32 +215,31 @@ func TestFilenameChunking(t *testing.T) {
 		},
 	}
 	for i, expected := range expecteds {
-		if actual := chunkFilenames(input, i+1); !reflect.DeepEqual(actual, expected) {
+		actual, err := chunkFilenames(input, i+1)
+		if !reflect.DeepEqual(actual, expected) {
 			t.Fatalf("chunk %v didn't match expected value %v", actual, expected)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error chunking filenames: %v", err)
 		}
 	}
 
 	// Test nil input
-	if actual := chunkFilenames(nil, 5); len(actual) != 0 {
+	actual, err := chunkFilenames(nil, 5)
+	if len(actual) != 0 {
 		t.Fatal("chunks were returned when passed nil")
 	}
+	if err != nil {
+		t.Fatalf("unexpected error chunking filenames: %v", err)
+	}
 
-	// Test invalid sizes panic
-	func() {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Fatal("expected panic for max size 0")
-			}
-		}()
-		chunkFilenames(nil, 0)
-	}()
-
-	func() {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Fatal("expected panic for max size -1")
-			}
-		}()
-		chunkFilenames(nil, -1)
-	}()
+	// Test 0 and < 0 sizes
+	actual, err = chunkFilenames(nil, 0)
+	if err == nil {
+		t.Fatal("expected error for size = 0")
+	}
+	actual, err = chunkFilenames(nil, -1)
+	if err == nil {
+		t.Fatal("expected error for size = -1")
+	}
 }

--- a/registry/storage/driver/swift/swift_test.go
+++ b/registry/storage/driver/swift/swift_test.go
@@ -187,31 +187,31 @@ func TestFilenameChunking(t *testing.T) {
 	// Test valid input and sizes
 	input := []string{"a", "b", "c", "d", "e"}
 	expecteds := [][][]string{
-		[][]string{
-			[]string{"a"},
-			[]string{"b"},
-			[]string{"c"},
-			[]string{"d"},
-			[]string{"e"},
+		{
+			{"a"},
+			{"b"},
+			{"c"},
+			{"d"},
+			{"e"},
 		},
-		[][]string{
-			[]string{"a", "b"},
-			[]string{"c", "d"},
-			[]string{"e"},
+		{
+			{"a", "b"},
+			{"c", "d"},
+			{"e"},
 		},
-		[][]string{
-			[]string{"a", "b", "c"},
-			[]string{"d", "e"},
+		{
+			{"a", "b", "c"},
+			{"d", "e"},
 		},
-		[][]string{
-			[]string{"a", "b", "c", "d"},
-			[]string{"e"},
+		{
+			{"a", "b", "c", "d"},
+			{"e"},
 		},
-		[][]string{
-			[]string{"a", "b", "c", "d", "e"},
+		{
+			{"a", "b", "c", "d", "e"},
 		},
-		[][]string{
-			[]string{"a", "b", "c", "d", "e"},
+		{
+			{"a", "b", "c", "d", "e"},
 		},
 	}
 	for i, expected := range expecteds {


### PR DESCRIPTION
The current implementation attempts to delete all objects provided at once. Swift servers are configured with a max_deletes_per_request, and if the number of objects exceeds that then it returns a 413 and errors.

Use the limit provided by Swift and delete in chunks of that size.

Resolves docker/distribution#1914