### PR TITLE
fix simpleAuthChallge concurrent problem

### DIFF
--- a/registry/client/auth/authchallenge.go
+++ b/registry/client/auth/authchallenge.go
@@ -49,9 +49,9 @@ func NewSimpleChallengeManager() ChallengeManager {
 	}
 }
 
-type simpleChallengeManager struct{
+type simpleChallengeManager struct {
 	sync.RWMutex
-	Challanges  map[string][]Challenge
+	Challanges map[string][]Challenge
 }
 
 func (m *simpleChallengeManager) GetChallenges(endpoint url.URL) ([]Challenge, error) {

--- a/registry/client/auth/authchallenge.go
+++ b/registry/client/auth/authchallenge.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 )
 
 // Challenge carries information from a WWW-Authenticate response header.
@@ -43,19 +44,26 @@ type ChallengeManager interface {
 // perform requests on the endpoints or cache the responses
 // to a backend.
 func NewSimpleChallengeManager() ChallengeManager {
-	return simpleChallengeManager{}
+	return &simpleChallengeManager{
+		Challanges: make(map[string][]Challenge),
+	}
 }
 
-type simpleChallengeManager map[string][]Challenge
+type simpleChallengeManager struct{
+	sync.RWMutex
+	Challanges  map[string][]Challenge
+}
 
-func (m simpleChallengeManager) GetChallenges(endpoint url.URL) ([]Challenge, error) {
+func (m *simpleChallengeManager) GetChallenges(endpoint url.URL) ([]Challenge, error) {
 	endpoint.Host = strings.ToLower(endpoint.Host)
 
-	challenges := m[endpoint.String()]
+	m.RLock()
+	defer m.RUnlock()
+	challenges := m.Challanges[endpoint.String()]
 	return challenges, nil
 }
 
-func (m simpleChallengeManager) AddResponse(resp *http.Response) error {
+func (m *simpleChallengeManager) AddResponse(resp *http.Response) error {
 	challenges := ResponseChallenges(resp)
 	if resp.Request == nil {
 		return fmt.Errorf("missing request reference")
@@ -65,7 +73,9 @@ func (m simpleChallengeManager) AddResponse(resp *http.Response) error {
 		Host:   strings.ToLower(resp.Request.URL.Host),
 		Scheme: resp.Request.URL.Scheme,
 	}
-	m[urlCopy.String()] = challenges
+	m.Lock()
+	defer m.Unlock()
+	m.Challanges[urlCopy.String()] = challenges
 	return nil
 }
 

--- a/registry/client/auth/authchallenge_test.go
+++ b/registry/client/auth/authchallenge_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"sync"
 )
 
 func TestAuthChallengeParse(t *testing.T) {
@@ -43,6 +44,7 @@ func TestAuthChallengeParse(t *testing.T) {
 func TestAuthChallengeNormalization(t *testing.T) {
 	testAuthChallengeNormalization(t, "reg.EXAMPLE.com")
 	testAuthChallengeNormalization(t, "bɿɒʜɔiɿ-ɿɘƚƨim-ƚol-ɒ-ƨʞnɒʜƚ.com")
+	testAuthChallengeConcurrent(t, "reg.EXAMPLE.com")
 }
 
 func testAuthChallengeNormalization(t *testing.T, host string) {
@@ -78,4 +80,59 @@ func testAuthChallengeNormalization(t *testing.T, host string) {
 	if len(c) == 0 {
 		t.Fatal("Expected challenge for lower-cased-host URL")
 	}
+}
+
+
+func testAuthChallengeConcurrent(t *testing.T, host string) {
+
+	scm := NewSimpleChallengeManager()
+
+	url, err := url.Parse(fmt.Sprintf("http://%s/v2/", host))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := &http.Response{
+		Request: &http.Request{
+			URL: url,
+		},
+		Header:     make(http.Header),
+		StatusCode: http.StatusUnauthorized,
+	}
+	resp.Header.Add("WWW-Authenticate", fmt.Sprintf("Bearer realm=\"https://%s/token\",service=\"registry.example.com\"", host))
+	var s sync.WaitGroup
+	s.Add(2)
+	go func() {
+		i := 200
+		for {
+			//time.Sleep(500 * time.Millisecond)
+			err = scm.AddResponse(resp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			i = i -1
+			if i < 0{
+				break
+			}
+		}
+		s.Done()
+	}()
+	go func() {
+		lowered := *url
+		lowered.Host = strings.ToLower(lowered.Host)
+		k:= 200
+		for {
+			_, err := scm.GetChallenges(lowered)
+			if err != nil {
+				t.Fatal(err)
+			}
+			k = k -1
+			if k < 0{
+				break
+			}
+		}
+
+		s.Done()
+	}()
+	s.Wait()
 }

--- a/registry/client/auth/authchallenge_test.go
+++ b/registry/client/auth/authchallenge_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"testing"
 	"sync"
+	"testing"
 )
 
 func TestAuthChallengeParse(t *testing.T) {
@@ -82,7 +82,6 @@ func testAuthChallengeNormalization(t *testing.T, host string) {
 	}
 }
 
-
 func testAuthChallengeConcurrent(t *testing.T, host string) {
 
 	scm := NewSimpleChallengeManager()
@@ -104,7 +103,7 @@ func testAuthChallengeConcurrent(t *testing.T, host string) {
 	s.Add(2)
 	go func() {
 
-		for i:=0 ; i<200; i++ {
+		for i := 0; i < 200; i++ {
 			err = scm.AddResponse(resp)
 			if err != nil {
 				t.Fatal(err)
@@ -115,7 +114,7 @@ func testAuthChallengeConcurrent(t *testing.T, host string) {
 	go func() {
 		lowered := *url
 		lowered.Host = strings.ToLower(lowered.Host)
-		for k := 0; k < 200 ; k++ {
+		for k := 0; k < 200; k++ {
 			_, err := scm.GetChallenges(lowered)
 			if err != nil {
 				t.Fatal(err)

--- a/registry/client/auth/authchallenge_test.go
+++ b/registry/client/auth/authchallenge_test.go
@@ -103,16 +103,11 @@ func testAuthChallengeConcurrent(t *testing.T, host string) {
 	var s sync.WaitGroup
 	s.Add(2)
 	go func() {
-		i := 200
-		for {
-			//time.Sleep(500 * time.Millisecond)
+
+		for i:=0 ; i<200; i++ {
 			err = scm.AddResponse(resp)
 			if err != nil {
 				t.Fatal(err)
-			}
-			i = i -1
-			if i < 0{
-				break
 			}
 		}
 		s.Done()
@@ -120,18 +115,12 @@ func testAuthChallengeConcurrent(t *testing.T, host string) {
 	go func() {
 		lowered := *url
 		lowered.Host = strings.ToLower(lowered.Host)
-		k:= 200
-		for {
+		for k := 0; k < 200 ; k++ {
 			_, err := scm.GetChallenges(lowered)
 			if err != nil {
 				t.Fatal(err)
 			}
-			k = k -1
-			if k < 0{
-				break
-			}
 		}
-
 		s.Done()
 	}()
 	s.Wait()

--- a/registry/client/auth/authchallenge_test.go
+++ b/registry/client/auth/authchallenge_test.go
@@ -102,25 +102,24 @@ func testAuthChallengeConcurrent(t *testing.T, host string) {
 	var s sync.WaitGroup
 	s.Add(2)
 	go func() {
-
+		defer s.Done()
 		for i := 0; i < 200; i++ {
 			err = scm.AddResponse(resp)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 		}
-		s.Done()
 	}()
 	go func() {
+		defer s.Done()
 		lowered := *url
 		lowered.Host = strings.ToLower(lowered.Host)
 		for k := 0; k < 200; k++ {
 			_, err := scm.GetChallenges(lowered)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 		}
-		s.Done()
 	}()
 	s.Wait()
 }


### PR DESCRIPTION
Signed-off-by: spacexnice <yaoyao.xyy@alibaba-inc.com>
## Problem
go1.6`s  map does not support cocurrent read and write , which will cause fatal error: concurrent map read and map write and panic , then the whole registry was shutdown.
this can be reproduce by the unitest case which i commited.
## Attachment
```
fatal error: concurrent map read and map write

goroutine 8 [running]:
runtime.throw(0x4e6e80, 0x21)
	/usr/local/go/src/runtime/panic.go:547 +0x90 fp=0xc820026580 sp=0xc820026568
runtime.mapaccess1_faststr(0x353fc0, 0xc8201951d0, 0xc820221300, 0x1a, 0xc820294088)
	/usr/local/go/src/runtime/hashmap_fast.go:202 +0x5b fp=0xc8200265e0 sp=0xc820026580
github.com/spacexnice/distribution/registry/client/auth.(*simpleChallengeManager).GetChallenges(0xc820028378, 0xc820220760, 0x4, 0x0, 0x0, 0x0, 0xc82026c440, 0xf, 0xc820220776, 0x4, ...)
	/Users/space/work/p_trunk/src/github.com/spacexnice/distribution/registry/client/auth/authchallenge.go:61 +0xba fp=0xc820026620 sp=0xc8200265e0
github.com/spacexnice/distribution/registry/client/auth.testAuthChallengeConcurrent.func2(0xc82027a380, 0xd08a60, 0xc820028378, 0xc82000c480, 0xc82026c420)
	/Users/space/work/p_trunk/src/github.com/spacexnice/distribution/registry/client/auth/authchallenge_test.go:125 +0xbf fp=0xc820026798 sp=0xc820026620
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1998 +0x1 fp=0xc8200267a0 sp=0xc820026798
created by github.com/spacexnice/distribution/registry/client/auth.testAuthChallengeConcurrent
	/Users/space/work/p_trunk/src/github.com/spacexnice/distribution/registry/client/auth/authchallenge_test.go:136 +0x6a2
```
## Fix
fix:  add a sync.RWMutex to simpleChallangeManager class.