### PR TITLE
update plugin MediaType

### DIFF
--- a/manifest/schema2/manifest.go
+++ b/manifest/schema2/manifest.go
@@ -18,7 +18,7 @@ const (
 	MediaTypeConfig = "application/vnd.docker.container.image.v1+json"
 
 	// MediaTypePluginConfig specifies the mediaType for plugin configuration.
-	MediaTypePluginConfig = "application/vnd.docker.plugin.v0+json"
+	MediaTypePluginConfig = "application/vnd.docker.plugin.image.v0+json"
 
 	// MediaTypeLayer is the mediaType used for layers referenced by the
 	// manifest.


### PR DESCRIPTION
`application/vnd.docker.plugins.v1.2+json` is already used in the engine. the only difference with this one was `s`. It's confusing.

Let's add `.distribution` to make it clear it's used in distribution.