### PR TITLE
Add note about required let's encrypt port

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1066,6 +1066,11 @@ and proxy connections to the registry server.
 The `letsencrypt` struct within `tls` is **optional**. Use this to configure TLS
 certificates provided by [Let's Encrypt](https://letsencrypt.org/how-it-works/).
 
+>**NOTE**: When using Let's Encrypt ensure that the outward facing address is
+> accessible on port `443`. The registry defaults to listening on `5000`, if
+> run as a container consider adding the flag `-p 443:5000` to the `docker run`
+> command or similar setting in cloud configuration.
+
 <table>
   <tr>
     <th>Parameter</th>


### PR DESCRIPTION
Let's Encrypt uses tls-sni to validate the certificate on the standard https port 443. If the registry is outwardly listening on a different port Let's Encrypt will not issue a certificate.