### PR TITLE
manifestServiceListener.Get to pass down options parameter

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -574,6 +574,9 @@ type Proxy struct {
 	// RemoteURL is the URL of the remote registry
 	RemoteURL string `yaml:"remoteurl"`
 
+	// Token Authentication URL. Defaults into "https://auth.docker.io/token" if not specified
+	AuthURL string `yaml:"authurl"`
+
 	// Username of the hub user
 	Username string `yaml:"username"`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,6 +246,7 @@ information about each option that appears later in this page.
           threshold: 3
     proxy:
       remoteurl: https://registry-1.docker.io
+      authurl:  [https://auth.docker.io/token]
       username: [username]
       password: [password]
     compatibility:
@@ -1757,6 +1758,7 @@ The TCP address to connect to, including a port number.
 
     proxy:
       remoteurl: https://registry-1.docker.io
+      authurl:  [https://auth.docker.io/token]
       username: [username]
       password: [password]
 
@@ -1779,6 +1781,17 @@ Proxy enables a registry to be configured as a pull through cache to the officia
      The URL of the official Docker Hub
     </td>
   </tr>
+  <tr>
+    <td>
+      <code>authurl</code>
+    </td>
+    <td>
+      no
+    </td>
+    <td>
+     The URL of a token Authentication service
+    </td>
+  </tr> 
   <tr>
     <td>
       <code>username</code>

--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -78,7 +78,7 @@ func (msl *manifestServiceListener) Delete(ctx context.Context, dgst digest.Dige
 }
 
 func (msl *manifestServiceListener) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
-	sm, err := msl.ManifestService.Get(ctx, dgst)
+	sm, err := msl.ManifestService.Get(ctx, dgst, options...)
 	if err == nil {
 		if err := msl.parent.listener.ManifestPulled(msl.parent.Repository.Named(), sm, options...); err != nil {
 			context.GetLogger(ctx).Errorf("error dispatching manifest pull to listener: %v", err)

--- a/registry/proxy/proxyauth.go
+++ b/registry/proxy/proxyauth.go
@@ -33,9 +33,13 @@ func (c credentials) SetRefreshToken(u *url.URL, service, token string) {
 }
 
 // configureAuth stores credentials for challenge responses
-func configureAuth(username, password string) (auth.CredentialStore, error) {
+func configureAuth(username, password, authURL string) (auth.CredentialStore, error) {
+	if authURL == "" {
+		authURL = tokenURL
+	}
+
 	creds := map[string]userpass{
-		tokenURL: {
+		authURL: {
 			username: username,
 			password: password,
 		},

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -91,7 +91,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 		return nil, err
 	}
 
-	cs, err := configureAuth(config.Username, config.Password)
+	cs, err := configureAuth(config.Username, config.Password, config.AuthURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hello,

While digging into the code for poxyingRegistry I discovered this bug: manifestServiceListener.Get doesn't pass down options parameter. It's not a problem for local repositories which do not use that parameter but it is a problem for problem for proxiedRepository where that parameter needs to be passed to the client code to properly retrieve remote manifests.

Signed-off-by: Serge Dubrouski <sergeyfd@gmail.com>