### PR TITLE
Support for custom authentication URL in proxying registry

### DIFF
--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -91,7 +91,7 @@ func NewRegistryPullThroughCache(ctx context.Context, registry distribution.Name
 		return nil, err
 	}
 
-	cs, err := configureAuth(config.Username, config.Password)
+	cs, err := configureAuth(config.Username, config.Password, config.RemoteURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch allows configuring custom URL for token authentication service in the proxyingRegistry. This allows creating mirrors for private registries that use token based authentication. 

Signed-off-by: Serge Dubrouski <sergeyfd@gmail.com>