### PR TITLE
manifestServiceListener.Get to pass down options parameter

### DIFF
--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -78,7 +78,7 @@ func (msl *manifestServiceListener) Delete(ctx context.Context, dgst digest.Dige
 }
 
 func (msl *manifestServiceListener) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
-	sm, err := msl.ManifestService.Get(ctx, dgst)
+	sm, err := msl.ManifestService.Get(ctx, dgst, options...)
 	if err == nil {
 		if err := msl.parent.listener.ManifestPulled(msl.parent.Repository.Named(), sm, options...); err != nil {
 			context.GetLogger(ctx).Errorf("error dispatching manifest pull to listener: %v", err)


### PR DESCRIPTION
options parameter gets lost in the manifestServiceListener.Get. That causes issues for proxyManifestStore,Get which needs options to pass down to client.

Signed-off-by: Serge Dubrouski <sergeyfd@gmail.com>