### PR TITLE
Downgrade token auth JWT logging from error to info

### DIFF
--- a/registry/auth/token/token.go
+++ b/registry/auth/token/token.go
@@ -95,7 +95,7 @@ func NewToken(rawToken string) (*Token, error) {
 
 	defer func() {
 		if err != nil {
-			log.Errorf("error while unmarshalling raw token: %s", err)
+			log.Infof("error while unmarshalling raw token: %s", err)
 		}
 	}()
 
@@ -135,13 +135,13 @@ func NewToken(rawToken string) (*Token, error) {
 func (t *Token) Verify(verifyOpts VerifyOptions) error {
 	// Verify that the Issuer claim is a trusted authority.
 	if !contains(verifyOpts.TrustedIssuers, t.Claims.Issuer) {
-		log.Errorf("token from untrusted issuer: %q", t.Claims.Issuer)
+		log.Infof("token from untrusted issuer: %q", t.Claims.Issuer)
 		return ErrInvalidToken
 	}
 
 	// Verify that the Audience claim is allowed.
 	if !contains(verifyOpts.AcceptedAudiences, t.Claims.Audience) {
-		log.Errorf("token intended for another audience: %q", t.Claims.Audience)
+		log.Infof("token intended for another audience: %q", t.Claims.Audience)
 		return ErrInvalidToken
 	}
 
@@ -150,32 +150,32 @@ func (t *Token) Verify(verifyOpts VerifyOptions) error {
 
 	ExpWithLeeway := time.Unix(t.Claims.Expiration, 0).Add(Leeway)
 	if currentTime.After(ExpWithLeeway) {
-		log.Errorf("token not to be used after %s - currently %s", ExpWithLeeway, currentTime)
+		log.Infof("token not to be used after %s - currently %s", ExpWithLeeway, currentTime)
 		return ErrInvalidToken
 	}
 
 	NotBeforeWithLeeway := time.Unix(t.Claims.NotBefore, 0).Add(-Leeway)
 	if currentTime.Before(NotBeforeWithLeeway) {
-		log.Errorf("token not to be used before %s - currently %s", NotBeforeWithLeeway, currentTime)
+		log.Infof("token not to be used before %s - currently %s", NotBeforeWithLeeway, currentTime)
 		return ErrInvalidToken
 	}
 
 	// Verify the token signature.
 	if len(t.Signature) == 0 {
-		log.Error("token has no signature")
+		log.Info("token has no signature")
 		return ErrInvalidToken
 	}
 
 	// Verify that the signing key is trusted.
 	signingKey, err := t.VerifySigningKey(verifyOpts)
 	if err != nil {
-		log.Error(err)
+		log.Info(err)
 		return ErrInvalidToken
 	}
 
 	// Finally, verify the signature of the token using the key which signed it.
 	if err := signingKey.Verify(strings.NewReader(t.Raw), t.Header.SigningAlg, t.Signature); err != nil {
-		log.Errorf("unable to verify token signature: %s", err)
+		log.Infof("unable to verify token signature: %s", err)
 		return ErrInvalidToken
 	}
 


### PR DESCRIPTION
The token auth package logs JWT validation and verification failures at
the `error` level.  But from the server's perspective, these aren't
errors.  They're the expected response to bad input.  Logging them at
the `info` level better reflects that distinction.

The motivation here is increasing SNR at the `error` level for registry operators.