### PR TITLE
Untag manifests for DELETE API calls by tag

### DIFF
--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -1920,7 +1920,7 @@ func testManifestDelete(t *testing.T, env *testEnv, args manifestArgs) {
 	resp, err = httpDelete(manifestTagURL)
 	checkErr(t, err, "deleting manifest by atag")
 	checkResponse(t, "deleting manifest by atag", resp, http.StatusNotFound)
-	
+
 	// Delete by atag
 	resp, err = httpDelete(manifestBTagURL)
 	checkErr(t, err, "deleting manifest by btag")

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -15,9 +15,9 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/auth"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/gorilla/handlers"
 	"github.com/opencontainers/go-digest"
-	storagedriver "github.com/docker/distribution/registry/storage/driver"	
 )
 
 // These constants determine which architecture and OS to choose from a
@@ -416,14 +416,18 @@ func (imh *manifestHandler) applyResourcePolicy(manifest distribution.Manifest) 
 
 // DeleteManifest removes the manifest with the given digest from the registry.
 func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Request) {
-	ctxu.GetLogger(imh).Debugf("DeleteImageManifest. Tag: %s Digest: %s", imh.Tag, imh.Digest)
+	ctxu.GetLoggerWithFields(imh,
+		map[interface{}]interface{}{
+			"tag":    imh.Tag,
+			"digest": imh.Digest,
+		}, "tag", "digest").Debugf("DeleteManifest")
 
 	manifests, err := imh.Repository.Manifests(imh)
 	if err != nil {
 		imh.Errors = append(imh.Errors, err)
 		return
 	}
-	
+
 	if imh.Tag != "" {
 		// Proxy supports Untag so it has to be disabled here.
 		if imh.App.isCache {
@@ -444,7 +448,7 @@ func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Reques
 				return
 			}
 		}
-				
+
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -423,8 +423,7 @@ func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Reques
 		imh.Errors = append(imh.Errors, err)
 		return
 	}
-
-	tagService := imh.Repository.Tags(imh)
+	
 	if imh.Tag != "" {
 		// Proxy supports Untag so it has to be disabled here.
 		if imh.App.isCache {
@@ -432,6 +431,7 @@ func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
+		tagService := imh.Repository.Tags(imh)
 		err := tagService.Untag(imh.Context, imh.Tag)
 		if err != nil {
 			switch err.(type) {
@@ -468,6 +468,7 @@ func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	tagService := imh.Repository.Tags(imh)
 	referencedTags, err := tagService.Lookup(imh, distribution.Descriptor{Digest: imh.Digest})
 	if err != nil {
 		imh.Errors = append(imh.Errors, err)


### PR DESCRIPTION
This is a proposed implementation for #1954 that would help close #1811  #1859

Documentation will have to be updated as well if this is an accepted API change.
