### PR TITLE
remoteURL parameter error cause  challenge cache not working which eventually lead to client manifest request timeout

### DIFF
--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -203,7 +203,7 @@ func (r *remoteAuthChallenger) tryEstablishChallenges(ctx context.Context) error
 
 	remoteURL := r.remoteURL
 	remoteURL.Path = "/v2/"
-	challenges, err := r.cm.GetChallenges(r.remoteURL)
+	challenges, err := r.cm.GetChallenges(remoteURL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Problem 
In file proxyregistry.go ```remoteURL``` parameter error cause ```challenge map cache ``` not working,critical area consume to much time, which eventually lead to client manifest request timeout(90s) in massive(which i test 80 concurrent) concurrent manifest request situation. this directly lead to docker pull error.

# Cause
GetChallenges(key),this key should be remoteURL not r.remoteURL ,because AddResponse(key) key=remoteURL. 
this little error cause Challenge cache Map not working ,which the r.Lock() `s critical area consume to much time ,and in massive concurrent situation which will lead to client request timeout.  we observe this timeout in our product environment.

# Reproduce
1. first bound ``` ekv59auv.mirror.aliyuncs.com``` to you registry mirror ip in your /etc/hosts
2. use the following python code to reproduce .
``` 
#!/usr/bin/env python
# -*- coding:utf-8 -*-

import threading,logging,sys

import requests,random,uuid


class ConCurrentTask(threading.Thread):
    URL_PREFIX = "https://ekv59auv.mirror.aliyuncs.com/v2/library/"
    IMAGES = [("ubuntu","latest"),("busybox","latest")]

    def __init__(self):
        threading.Thread.__init__(self)

    def run(self):
        return self.do(*self.random())

    def do(self,image,tag,id):
        logging.info("start request manifest: id = %s",id)
        res = requests.get("%s/%s/manifests/%s?id=%s"%(self.URL_PREFIX,image,tag,id))
        if res.status_code == 200:
            logging.info("request manifest finished success : id = %s, image = %s, tag = %s, body = %s"%(id,image,tag,len(res.text)))
        else:
            logging.error("request manifest finished error: id = %s, image = %s, tag = %s, error_code = %s"%(id,image,tag,res.status_code))

    def random(self):
        i = random.randint(0,len(self.IMAGES)-1)
        return self.IMAGES[i][0], self.IMAGES[i][1], uuid.uuid1()

def setup_logging():
    fort = logging.Formatter('[ %(asctime)s %(name)s - %(levelname)s ]:::: %(message)s')
    chand= logging.StreamHandler(sys.stdout)
    chand.setFormatter(fort)

    root = logging.getLogger()
    root.addHandler(chand)
    root.setLevel(logging.INFO)

def main():
    NUM_TASK = 100
    setup_logging()
    tasks = [ ConCurrentTask() for i in range(NUM_TASK)]
    for t in tasks:
        t.start()

    for t in tasks:
        t.join()


if __name__ == "__main__":
    main()


```
# Fix
1. modify the r.remoteURL to remoteURL,this can fix the timeout problem. i test with 1000 cocurrent request,it now works fine.
2. further more, i was thinking to remove r.Lock() and defer r.Unlock(),as we already have a sync.RWLock for challenge map protection,but this still need to be tested,
```
// tryEstablishChallenges will attempt to get a challenge type for the upstream if none currently exist
func (r *remoteAuthChallenger) tryEstablishChallenges(ctx context.Context) error {
	=======================
	//r.Lock()
	//defer r.Unlock()
	=======================
	context.GetLogger(ctx).Debugf("tryEstablishChallenges: get lock success")
	remoteURL := r.remoteURL
	remoteURL.Path = "/v2/"
	challenges, err := r.cm.GetChallenges(remoteURL)
	if err != nil {
		return err
	}

	context.GetLogger(ctx).Debugf("tryEstablishChallenges: cm.GetChallenges()=Len(%d)",len(challenges))
	if len(challenges) > 0 {
		return nil
	}

```

Signed-off-by: spacexnice <yaoyao.xyy@alibaba-inc.com>