### PR TITLE
Add configuration option to disable access logging

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -22,6 +22,12 @@ type Configuration struct {
 	// Log supports setting various parameters related to the logging
 	// subsystem.
 	Log struct {
+		// AccessLog configures access logging.
+		AccessLog struct {
+			// Disabled disables access logging.
+			Disabled bool `yaml:"disabled,omitempty"`
+		} `yaml:"accesslog,omitempty"`
+
 		// Level is the granularity at which registry operations are logged.
 		Level Loglevel `yaml:"level"`
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -19,6 +19,9 @@ func Test(t *testing.T) { TestingT(t) }
 var configStruct = Configuration{
 	Version: "0.1",
 	Log: struct {
+		AccessLog struct {
+			Disabled bool `yaml:"disabled,omitempty"`
+		} `yaml:"accesslog,omitempty"`
 		Level     Loglevel               `yaml:"level"`
 		Formatter string                 `yaml:"formatter,omitempty"`
 		Fields    map[string]interface{} `yaml:"fields,omitempty"`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,8 @@ information about each option that appears later in this page.
 
     version: 0.1
     log:
+      accesslog:
+        disabled: true
       level: debug
       formatter: text
       fields:
@@ -280,6 +282,8 @@ system outputs everything to stdout. You can adjust the granularity and format
 with this configuration section.
 
     log:
+      accesslog:
+        disabled: true
       level: debug
       formatter: text
       fields:
@@ -318,7 +322,7 @@ with this configuration section.
       <code>logstash</code>. The default is <code>text</code>.
     </td>
   </tr>
-    <tr>
+  <tr>
     <td>
       <code>fields</code>
     </td>
@@ -330,7 +334,18 @@ with this configuration section.
       the context. This is useful for identifying log messages source after
       being mixed in other systems.
     </td>
+  </tr>
 </table>
+
+### accesslog
+
+    accesslog:
+      disabled: true
+
+Within `log`, `accesslog` configures the behavior of the access logging
+system. By default, the access logging system outputs to stdout in
+[Combined Log Format](https://httpd.apache.org/docs/2.4/logs.html#combined).
+Access logging can be disabled by setting the boolean flag `disabled` to `true`.
 
 ## hooks
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -91,7 +91,9 @@ func NewRegistry(ctx context.Context, config *configuration.Configuration) (*Reg
 	handler = alive("/", handler)
 	handler = health.Handler(handler)
 	handler = panicHandler(handler)
-	handler = gorhandlers.CombinedLoggingHandler(os.Stdout, handler)
+	if !config.Log.AccessLog.Disabled {
+		handler = gorhandlers.CombinedLoggingHandler(os.Stdout, handler)
+	}
 
 	server := &http.Server{
 		Handler: handler,


### PR DESCRIPTION
Access logging is great.  Access logging you can turn off is even
better.  This change adds a configuration option for that.