### PR TITLE
Extend schema2 manifest with dependencies array

### DIFF
--- a/manifest/schema2/builder.go
+++ b/manifest/schema2/builder.go
@@ -11,21 +11,25 @@ type builder struct {
 	// bs is a BlobService used to publish the configuration blob.
 	bs distribution.BlobService
 
+	// configMediaType is media type used to describe configuration
+	configMediaType string
+
 	// configJSON references
 	configJSON []byte
 
-	// layers is a list of layer descriptors that gets built by successive
-	// calls to AppendReference.
-	layers []distribution.Descriptor
+	// dependencies is a list of descriptors that gets built by successive
+	// calls to AppendReference. In case of image configuration these are layers.
+	dependencies []distribution.Descriptor
 }
 
 // NewManifestBuilder is used to build new manifests for the current schema
 // version. It takes a BlobService so it can publish the configuration blob
 // as part of the Build process.
-func NewManifestBuilder(bs distribution.BlobService, configJSON []byte) distribution.ManifestBuilder {
+func NewManifestBuilder(bs distribution.BlobService, configMediaType string, configJSON []byte) distribution.ManifestBuilder {
 	mb := &builder{
-		bs:         bs,
-		configJSON: make([]byte, len(configJSON)),
+		bs:              bs,
+		configMediaType: configMediaType,
+		configJSON:      make([]byte, len(configJSON)),
 	}
 	copy(mb.configJSON, configJSON)
 
@@ -36,9 +40,15 @@ func NewManifestBuilder(bs distribution.BlobService, configJSON []byte) distribu
 func (mb *builder) Build(ctx context.Context) (distribution.Manifest, error) {
 	m := Manifest{
 		Versioned: SchemaVersion,
-		Layers:    make([]distribution.Descriptor, len(mb.layers)),
 	}
-	copy(m.Layers, mb.layers)
+	dependencies := make([]distribution.Descriptor, len(mb.dependencies))
+	copy(dependencies, mb.dependencies)
+
+	if mb.configMediaType == MediaTypeImageConfig {
+		m.Layers = dependencies
+	} else {
+		m.Dependencies = dependencies
+	}
 
 	configDigest := digest.FromBytes(mb.configJSON)
 
@@ -48,7 +58,7 @@ func (mb *builder) Build(ctx context.Context) (distribution.Manifest, error) {
 	case nil:
 		// Override MediaType, since Put always replaces the specified media
 		// type with application/octet-stream in the descriptor it returns.
-		m.Config.MediaType = MediaTypeConfig
+		m.Config.MediaType = mb.configMediaType
 		return FromStruct(m)
 	case distribution.ErrBlobUnknown:
 		// nop
@@ -57,10 +67,10 @@ func (mb *builder) Build(ctx context.Context) (distribution.Manifest, error) {
 	}
 
 	// Add config to the blob store
-	m.Config, err = mb.bs.Put(ctx, MediaTypeConfig, mb.configJSON)
+	m.Config, err = mb.bs.Put(ctx, mb.configMediaType, mb.configJSON)
 	// Override MediaType, since Put always replaces the specified media
 	// type with application/octet-stream in the descriptor it returns.
-	m.Config.MediaType = MediaTypeConfig
+	m.Config.MediaType = mb.configMediaType
 	if err != nil {
 		return nil, err
 	}
@@ -70,11 +80,11 @@ func (mb *builder) Build(ctx context.Context) (distribution.Manifest, error) {
 
 // AppendReference adds a reference to the current ManifestBuilder.
 func (mb *builder) AppendReference(d distribution.Describable) error {
-	mb.layers = append(mb.layers, d.Descriptor())
+	mb.dependencies = append(mb.dependencies, d.Descriptor())
 	return nil
 }
 
 // References returns the current references added to this builder.
 func (mb *builder) References() []distribution.Descriptor {
-	return mb.layers
+	return mb.dependencies
 }

--- a/manifest/schema2/builder_test.go
+++ b/manifest/schema2/builder_test.go
@@ -166,7 +166,7 @@ func TestBuilder(t *testing.T) {
 	}
 
 	bs := &mockBlobService{descriptors: make(map[digest.Digest]distribution.Descriptor)}
-	builder := NewManifestBuilder(bs, imgJSON)
+	builder := NewManifestBuilder(bs, MediaTypeImageConfig, imgJSON)
 
 	for _, d := range descriptors {
 		if err := builder.AppendReference(d); err != nil {
@@ -195,7 +195,7 @@ func TestBuilder(t *testing.T) {
 	if target.Digest != configDigest {
 		t.Fatalf("unexpected digest in target: %s", target.Digest.String())
 	}
-	if target.MediaType != MediaTypeConfig {
+	if target.MediaType != MediaTypeImageConfig {
 		t.Fatalf("unexpected media type in target: %s", target.MediaType)
 	}
 	if target.Size != 3153 {

--- a/manifest/schema2/manifest.go
+++ b/manifest/schema2/manifest.go
@@ -14,8 +14,11 @@ const (
 	// MediaTypeManifest specifies the mediaType for the current version.
 	MediaTypeManifest = "application/vnd.docker.distribution.manifest.v2+json"
 
-	// MediaTypeConfig specifies the mediaType for the image configuration.
-	MediaTypeConfig = "application/vnd.docker.container.image.v1+json"
+	// MediaTypeImageConfig specifies the mediaType for the image configuration.
+	MediaTypeImageConfig = "application/vnd.docker.container.image.v1+json"
+
+	// MediaTypeBundleConfig specifies the mediaType for the bundle configuration.
+	MediaTypeBundleConfig = "application/vnd.docker.service.bundle.v1+json"
 
 	// MediaTypePluginConfig specifies the mediaType for plugin configuration.
 	MediaTypePluginConfig = "application/vnd.docker.plugin.image.v0+json"
@@ -64,7 +67,10 @@ type Manifest struct {
 
 	// Layers lists descriptors for the layers referenced by the
 	// configuration.
-	Layers []distribution.Descriptor `json:"layers"`
+	Layers []distribution.Descriptor `json:"layers,omitempty"`
+
+	// Dependencies lists descriptors for any dependant references.
+	Dependencies []distribution.Descriptor `json:"dependencies,omitempty"`
 }
 
 // References returnes the descriptors of this manifests references.

--- a/manifest/schema2/manifest_test.go
+++ b/manifest/schema2/manifest_test.go
@@ -32,7 +32,7 @@ func TestManifest(t *testing.T) {
 		Config: distribution.Descriptor{
 			Digest:    "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
 			Size:      985,
-			MediaType: MediaTypeConfig,
+			MediaType: MediaTypeImageConfig,
 		},
 		Layers: []distribution.Descriptor{
 			{
@@ -82,7 +82,7 @@ func TestManifest(t *testing.T) {
 	if target.Digest != "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b" {
 		t.Fatalf("unexpected digest in target: %s", target.Digest.String())
 	}
-	if target.MediaType != MediaTypeConfig {
+	if target.MediaType != MediaTypeImageConfig {
 		t.Fatalf("unexpected media type in target: %s", target.MediaType)
 	}
 	if target.Size != 985 {

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -1218,7 +1218,7 @@ func testManifestAPISchema2(t *testing.T, env *testEnv, imageName reference.Name
 		Config: distribution.Descriptor{
 			Digest:    "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
 			Size:      3253,
-			MediaType: schema2.MediaTypeConfig,
+			MediaType: schema2.MediaTypeImageConfig,
 		},
 		Layers: []distribution.Descriptor{
 			{

--- a/registry/storage/schema2manifesthandler_test.go
+++ b/registry/storage/schema2manifesthandler_test.go
@@ -20,7 +20,7 @@ func TestVerifyManifestForeignLayer(t *testing.T) {
 	repo := makeRepository(t, registry, "test")
 	manifestService := makeManifestService(t, repo)
 
-	config, err := repo.Blobs(ctx).Put(ctx, schema2.MediaTypeConfig, nil)
+	config, err := repo.Blobs(ctx).Put(ctx, schema2.MediaTypeImageConfig, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testutil/manifests.go
+++ b/testutil/manifests.go
@@ -73,7 +73,7 @@ func MakeSchema1Manifest(digests []digest.Digest) (distribution.Manifest, error)
 func MakeSchema2Manifest(repository distribution.Repository, digests []digest.Digest) (distribution.Manifest, error) {
 	ctx := context.Background()
 	blobStore := repository.Blobs(ctx)
-	builder := schema2.NewManifestBuilder(blobStore, []byte{})
+	builder := schema2.NewManifestBuilder(blobStore, schema2.MediaTypeImageConfig, []byte{})
 	for _, digest := range digests {
 		builder.AppendReference(distribution.Descriptor{Digest: digest})
 	}


### PR DESCRIPTION
Allows distributing objects that do not necessarily use layers as the dependent descriptors.

Modify manifest builder so it can be used to build manifests with different configuration media types.

Left out docs changes per discussion with @dmcgowan as we plan to ship the first uses of this in Docker as experimental features.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
