### PR TITLE
Update to fix lint errors

### DIFF
--- a/contrib/token-server/main.go
+++ b/contrib/token-server/main.go
@@ -183,6 +183,18 @@ func filterAccessList(ctx context.Context, scope string, requestedAccessList []a
 	return grantedAccessList
 }
 
+type acctSubject struct{}
+
+func (acctSubject) String() string { return "acctSubject" }
+
+type requestedAccess struct{}
+
+func (requestedAccess) String() string { return "requestedAccess" }
+
+type grantedAccess struct{}
+
+func (grantedAccess) String() string { return "grantedAccess" }
+
 // getToken handles authenticating the request and authorizing access to the
 // requested scopes.
 func (ts *tokenServer) getToken(ctx context.Context, w http.ResponseWriter, r *http.Request) {
@@ -225,17 +237,17 @@ func (ts *tokenServer) getToken(ctx context.Context, w http.ResponseWriter, r *h
 
 	username := context.GetStringValue(ctx, "auth.user.name")
 
-	ctx = context.WithValue(ctx, "acctSubject", username)
-	ctx = context.WithLogger(ctx, context.GetLogger(ctx, "acctSubject"))
+	ctx = context.WithValue(ctx, acctSubject{}, username)
+	ctx = context.WithLogger(ctx, context.GetLogger(ctx, acctSubject{}))
 
 	context.GetLogger(ctx).Info("authenticated client")
 
-	ctx = context.WithValue(ctx, "requestedAccess", requestedAccessList)
-	ctx = context.WithLogger(ctx, context.GetLogger(ctx, "requestedAccess"))
+	ctx = context.WithValue(ctx, requestedAccess{}, requestedAccessList)
+	ctx = context.WithLogger(ctx, context.GetLogger(ctx, requestedAccess{}))
 
 	grantedAccessList := filterAccessList(ctx, username, requestedAccessList)
-	ctx = context.WithValue(ctx, "grantedAccess", grantedAccessList)
-	ctx = context.WithLogger(ctx, context.GetLogger(ctx, "grantedAccess"))
+	ctx = context.WithValue(ctx, grantedAccess{}, grantedAccessList)
+	ctx = context.WithLogger(ctx, context.GetLogger(ctx, grantedAccess{}))
 
 	token, err := ts.issuer.CreateJWT(username, service, grantedAccessList)
 	if err != nil {
@@ -347,17 +359,17 @@ func (ts *tokenServer) postToken(ctx context.Context, w http.ResponseWriter, r *
 		return
 	}
 
-	ctx = context.WithValue(ctx, "acctSubject", subject)
-	ctx = context.WithLogger(ctx, context.GetLogger(ctx, "acctSubject"))
+	ctx = context.WithValue(ctx, acctSubject{}, subject)
+	ctx = context.WithLogger(ctx, context.GetLogger(ctx, acctSubject{}))
 
 	context.GetLogger(ctx).Info("authenticated client")
 
-	ctx = context.WithValue(ctx, "requestedAccess", requestedAccessList)
-	ctx = context.WithLogger(ctx, context.GetLogger(ctx, "requestedAccess"))
+	ctx = context.WithValue(ctx, requestedAccess{}, requestedAccessList)
+	ctx = context.WithLogger(ctx, context.GetLogger(ctx, requestedAccess{}))
 
 	grantedAccessList := filterAccessList(ctx, subject, requestedAccessList)
-	ctx = context.WithValue(ctx, "grantedAccess", grantedAccessList)
-	ctx = context.WithLogger(ctx, context.GetLogger(ctx, "grantedAccess"))
+	ctx = context.WithValue(ctx, grantedAccess{}, grantedAccessList)
+	ctx = context.WithLogger(ctx, context.GetLogger(ctx, grantedAccess{}))
 
 	token, err := ts.issuer.CreateJWT(subject, service, grantedAccessList)
 	if err != nil {

--- a/registry/auth/silly/access_test.go
+++ b/registry/auth/silly/access_test.go
@@ -16,7 +16,7 @@ func TestSillyAccessController(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.WithValue(nil, "http.request", r)
+		ctx := context.WithRequest(context.Background(), r)
 		authCtx, err := ac.Authorized(ctx)
 		if err != nil {
 			switch err := err.(type) {

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -354,7 +354,7 @@ func TestAccessController(t *testing.T) {
 		Action: "baz",
 	}
 
-	ctx := context.WithValue(nil, "http.request", req)
+	ctx := context.WithRequest(context.Background(), req)
 	authCtx, err := accessController.Authorized(ctx, testAccess)
 	challenge, ok := err.(auth.Challenge)
 	if !ok {

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -76,8 +76,8 @@ const noStorageClass = "NONE"
 // validRegions maps known s3 region identifiers to region descriptors
 var validRegions = map[string]struct{}{}
 
-// validObjectAcls contains known s3 object Acls
-var validObjectAcls = map[string]struct{}{}
+// validObjectACLs contains known s3 object Acls
+var validObjectACLs = map[string]struct{}{}
 
 //DriverParameters A struct that encapsulates all of the driver parameters after all values have been set
 type DriverParameters struct {
@@ -97,7 +97,7 @@ type DriverParameters struct {
 	RootDirectory               string
 	StorageClass                string
 	UserAgent                   string
-	ObjectAcl                   string
+	ObjectACL                   string
 }
 
 func init() {
@@ -118,7 +118,7 @@ func init() {
 		validRegions[region] = struct{}{}
 	}
 
-	for _, objectAcl := range []string{
+	for _, objectACL := range []string{
 		s3.ObjectCannedACLPrivate,
 		s3.ObjectCannedACLPublicRead,
 		s3.ObjectCannedACLPublicReadWrite,
@@ -127,7 +127,7 @@ func init() {
 		s3.ObjectCannedACLBucketOwnerRead,
 		s3.ObjectCannedACLBucketOwnerFullControl,
 	} {
-		validObjectAcls[objectAcl] = struct{}{}
+		validObjectACLs[objectACL] = struct{}{}
 	}
 
 	// Register this as the default s3 driver in addition to s3aws
@@ -153,7 +153,7 @@ type driver struct {
 	MultipartCopyThresholdSize  int64
 	RootDirectory               string
 	StorageClass                string
-	ObjectAcl                   string
+	ObjectACL                   string
 }
 
 type baseEmbed struct {
@@ -313,18 +313,18 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		userAgent = ""
 	}
 
-	objectAcl := s3.ObjectCannedACLPrivate
-	objectAclParam := parameters["objectacl"]
-	if objectAclParam != nil {
-		objectAclString, ok := objectAclParam.(string)
+	objectACL := s3.ObjectCannedACLPrivate
+	objectACLParam := parameters["objectacl"]
+	if objectACLParam != nil {
+		objectACLString, ok := objectACLParam.(string)
 		if !ok {
-			return nil, fmt.Errorf("Invalid value for objectacl parameter: %v", objectAclParam)
+			return nil, fmt.Errorf("Invalid value for objectacl parameter: %v", objectACLParam)
 		}
 
-		if _, ok = validObjectAcls[objectAclString]; !ok {
-			return nil, fmt.Errorf("Invalid value for objectacl parameter: %v", objectAclParam)
+		if _, ok = validObjectACLs[objectACLString]; !ok {
+			return nil, fmt.Errorf("Invalid value for objectacl parameter: %v", objectACLParam)
 		}
-		objectAcl = objectAclString
+		objectACL = objectACLString
 	}
 
 	params := DriverParameters{
@@ -344,7 +344,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		fmt.Sprint(rootDirectory),
 		storageClass,
 		fmt.Sprint(userAgent),
-		objectAcl,
+		objectACL,
 	}
 
 	return New(params)
@@ -459,7 +459,7 @@ func New(params DriverParameters) (*Driver, error) {
 		MultipartCopyThresholdSize:  params.MultipartCopyThresholdSize,
 		RootDirectory:               params.RootDirectory,
 		StorageClass:                params.StorageClass,
-		ObjectAcl:                   params.ObjectAcl,
+		ObjectACL:                   params.ObjectACL,
 	}
 
 	return &Driver{
@@ -912,7 +912,7 @@ func (d *driver) getContentType() *string {
 }
 
 func (d *driver) getACL() *string {
-	return aws.String(d.ObjectAcl)
+	return aws.String(d.ObjectACL)
 }
 
 func (d *driver) getStorageClass() *string {

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -33,7 +33,7 @@ func init() {
 	secure := os.Getenv("S3_SECURE")
 	v4Auth := os.Getenv("S3_V4_AUTH")
 	region := os.Getenv("AWS_REGION")
-	objectAcl := os.Getenv("S3_OBJECT_ACL")
+	objectACL := os.Getenv("S3_OBJECT_ACL")
 	root, err := ioutil.TempDir("", "driver-")
 	regionEndpoint := os.Getenv("REGION_ENDPOINT")
 	if err != nil {
@@ -83,7 +83,7 @@ func init() {
 			rootDirectory,
 			storageClass,
 			driverName + "-test",
-			objectAcl,
+			objectACL,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
Context should use type values instead of strings.
Updated direct calls to WithValue, but still other uses of string keys.
Update Acl to ACL in s3 driver.
