### PR TITLE
Fix unit test

### DIFF
--- a/notifications/http_test.go
+++ b/notifications/http_test.go
@@ -122,7 +122,7 @@ func TestHTTPSink(t *testing.T) {
 		},
 		{
 			// Case where connection never goes through.
-			url:     "http://shoudlntresolve/",
+			url:     "shoudlntresolve",
 			failure: true,
 		},
 	} {


### PR DESCRIPTION
If running test behide a proxy, we may get the error code
403 Forbidden which will fail line 135 for the last testcase.

Detail:

```
metrics not as expected: notifications.EndpointMetrics{Pending:0,Events:0, Successes:4, Failures:0, Errors:0,Statuses:map[string]int{"307 Temporary Redirect":0, "400 Bad Request":0,"403 Forbidden":0, "200 OK":4}} !=
notifications.EndpointMetrics{Pending:0, Events:0, Successes:4,Failures:0, Errors:0, Statuses:map[string]int{"400 Bad Request":0, "200OK":4, "307 Temporary Redirect":0}}
```

Drop the prefix "http://" would fix that.

Signed-off-by: Hu Keping hukeping@huawei.com
