### PR TITLE
Cleanup makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,22 +27,25 @@ version/version.go:
 # Required for go 1.5 to build
 GO15VENDOREXPERIMENT := 1
 
+# Go files
+GOFILES=$(shell find . -type f -name '*.go')
+
 # Package list
-PKGS := $(shell go list -tags "${DOCKER_BUILDTAGS}" ./... | grep -v ^github.com/docker/distribution/vendor/)
+PKGS=$(shell go list -tags "${DOCKER_BUILDTAGS}" ./... | grep -v ^github.com/docker/distribution/vendor/)
 
 # Resolving binary dependencies for specific targets
-GOLINT := $(shell which golint || echo '')
-GODEP := $(shell which godep || echo '')
+GOLINT=$(shell which golint || echo '')
+GODEP=$(shell which godep || echo '')
 
-${PREFIX}/bin/registry: $(wildcard **/*.go)
+${PREFIX}/bin/registry: $(GOFILES)
 	@echo "+ $@"
 	@go build -tags "${DOCKER_BUILDTAGS}" -o $@ ${GO_LDFLAGS}  ${GO_GCFLAGS} ./cmd/registry
 
-${PREFIX}/bin/digest:  $(wildcard **/*.go)
+${PREFIX}/bin/digest:  $(GOFILES)
 	@echo "+ $@"
 	@go build -tags "${DOCKER_BUILDTAGS}" -o $@ ${GO_LDFLAGS}  ${GO_GCFLAGS} ./cmd/digest
 
-${PREFIX}/bin/registry-api-descriptor-template: $(wildcard **/*.go)
+${PREFIX}/bin/registry-api-descriptor-template: $(GOFILES)
 	@echo "+ $@"
 	@go build -o $@ ${GO_LDFLAGS} ${GO_GCFLAGS} ./cmd/registry-api-descriptor-template
 


### PR DESCRIPTION
Use find instead of wildcard to get go files since wildcard does not do recursive lookups via `**`, missing most go files. Do lazy evaluations of variables which are not needed immediately.
