### PR TITLE
docs/spec/json: Trailing commas are forbidden by RFC 7159

### DIFF
--- a/docs/spec/json.md
+++ b/docs/spec/json.md
@@ -31,8 +31,7 @@ Compliant JSON should conform to the following rules:
 3. Unless a canonical key order is defined for a particular schema, object
    keys shall always appear in lexically sorted order.
 4. All whitespace between tokens should be removed.
-5. No "trailing commas" are allowed in object or array definitions.
-6. The angle brackets "<" and ">" are escaped to "\u003c" and "\u003e".
+5. The angle brackets "<" and ">" are escaped to "\u003c" and "\u003e".
    Ampersand "&" is escaped to "\u0026".
 
 ## Examples


### PR DESCRIPTION
RFC 7159 defines [objects as][1]:

    object = begin-object [ member *( value-separator member ) ]
             end-object

and defines [arrays as][2]:

    array = begin-array [ value *( value-separator value ) ] end-array

So neither:

    begin-object ... value-separator end-object

nor:

    begin-array ... value-separator end-array

are valid.  We don't need to repeat that point here.

I checked over #205 and #226 and didn't see anyone explictly arguing for including this rule, so I expect it was just oversight.

[1]: https://tools.ietf.org/html/rfc7159#section-4
[2]: https://tools.ietf.org/html/rfc7159#section-5