### PR TITLE
Convert Markdown frontmatter to YAML

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Configuring a registry"
-description = "Explains how to configure a registry"
-keywords = ["registry, on-prem, images, tags, repository, distribution, configuration"]
-[menu.main]
-parent="smn_registry"
-weight=4
-+++
-<![end-metadata]-->
+---
+title: "Configuring a registry"
+description: "Explains how to configure a registry"
+keywords: ["registry, on-prem, images, tags, repository, distribution, configuration"]
+---
 
 # Registry Configuration Reference
 

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "HTTP API V2"
-description = "Specification for the Registry API."
-keywords = ["registry, on-prem, images, tags, repository, distribution, api, advanced"]
-[menu.main]
-parent="smn_registry_ref"
-+++
-<![end-metadata]-->
+---
+title: "HTTP API V2"
+description: "Specification for the Registry API."
+keywords: ["registry, on-prem, images, tags, repository, distribution, api, advanced"]
+---
 
 # Docker Registry HTTP API V2
 

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "HTTP API V2"
-description = "Specification for the Registry API."
-keywords = ["registry, on-prem, images, tags, repository, distribution, api, advanced"]
-[menu.main]
-parent="smn_registry_ref"
-+++
-<![end-metadata]-->
+---
+title: "HTTP API V2"
+description: "Specification for the Registry API."
+keywords: ["registry, on-prem, images, tags, repository, distribution, api, advanced"]
+---
 
 # Docker Registry HTTP API V2
 

--- a/docs/spec/auth/index.md
+++ b/docs/spec/auth/index.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Docker Registry Token Authentication"
-description = "Docker Registry v2 authentication schema"
-keywords = ["registry, on-prem, images, tags, repository, distribution, authentication, advanced"]
-[menu.main]
-parent="smn_registry_ref"
-weight=100
-+++
-<![end-metadata]-->
+---
+title: "Docker Registry Token Authentication"
+description: "Docker Registry v2 authentication schema"
+keywords: ["registry, on-prem, images, tags, repository, distribution, authentication, advanced"]
+---
 
 # Docker Registry v2 authentication
 

--- a/docs/spec/auth/jwt.md
+++ b/docs/spec/auth/jwt.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Token Authentication Implementation"
-description = "Describe the reference implementation of the Docker Registry v2 authentication schema"
-keywords = ["registry, on-prem, images, tags, repository, distribution, JWT authentication, advanced"]
-[menu.main]
-parent="smn_registry_ref"
-weight=101
-+++
-<![end-metadata]-->
+---
+title: "Token Authentication Implementation"
+description: "Describe the reference implementation of the Docker Registry v2 authentication schema"
+keywords: ["registry, on-prem, images, tags, repository, distribution, JWT authentication, advanced"]
+---
 
 # Docker Registry v2 Bearer token specification
 

--- a/docs/spec/auth/oauth.md
+++ b/docs/spec/auth/oauth.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Oauth2 Token Authentication"
-description = "Specifies the Docker Registry v2 authentication"
-keywords = ["registry, on-prem, images, tags, repository, distribution, oauth2, advanced"]
-[menu.main]
-parent="smn_registry_ref"
-weight=102
-+++
-<![end-metadata]-->
+---
+title: "Oauth2 Token Authentication"
+description: "Specifies the Docker Registry v2 authentication"
+keywords: ["registry, on-prem, images, tags, repository, distribution, oauth2, advanced"]
+---
 
 # Docker Registry v2 authentication using OAuth2
 
@@ -193,4 +188,3 @@ Content-Type: application/json
 
 {"refresh_token":"kas9Da81Dfa8","access_token":"eyJhbGciOiJFUzI1NiIsInR5":"expires_in":900,"scope":"repository:samalba/my-app:pull,repository:samalba/my-app:push"}
 ```
-

--- a/docs/spec/auth/scope.md
+++ b/docs/spec/auth/scope.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Token Scope Documentation"
-description = "Describes the scope and access fields used for registry authorization tokens"
-keywords = ["registry, on-prem, images, tags, repository, distribution, advanced, access, scope"]
-[menu.main]
-parent="smn_registry_ref"
-weight=103
-+++
-<![end-metadata]-->
+---
+title: "Token Scope Documentation"
+description: "Describes the scope and access fields used for registry authorization tokens"
+keywords: ["registry, on-prem, images, tags, repository, distribution, advanced, access, scope"]
+---
 
 # Docker Registry Token Scope and Access
 
@@ -140,4 +135,3 @@ done by fetching an access token using the refresh token. Since the refresh
 token is not scoped to specific resources for an audience, extra care should
 be taken to only use the refresh token to negotiate new access tokens directly
 with the authorization server, and never with a resource provider.
-

--- a/docs/spec/auth/token.md
+++ b/docs/spec/auth/token.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Token Authentication Specification"
-description = "Specifies the Docker Registry v2 authentication"
-keywords = ["registry, on-prem, images, tags, repository, distribution, Bearer authentication, advanced"]
-[menu.main]
-parent="smn_registry_ref"
-weight=104
-+++
-<![end-metadata]-->
+---
+title: "Token Authentication Specification"
+description: "Specifies the Docker Registry v2 authentication"
+keywords: ["registry, on-prem, images, tags, repository, distribution, Bearer authentication, advanced"]
+---
 
 # Docker Registry v2 authentication via central service
 
@@ -25,7 +20,7 @@ This document outlines the v2 Docker registry authentication scheme:
 5. The client retries the original request with the Bearer token embedded in
    the request's Authorization header.
 6. The Registry authorizes the client by validating the Bearer token and the
-   claim set embedded within it and begins the push/pull session as usual. 
+   claim set embedded within it and begins the push/pull session as usual.
 
 ## Requirements
 
@@ -161,7 +156,7 @@ Defines getting a bearer and refresh token using the token endpoint.
         <code>expires_in</code>
     </dt>
     <dd>
-        (Optional) The duration in seconds since the token was issued that it 
+        (Optional) The duration in seconds since the token was issued that it
         will remain valid.  When omitted, this defaults to 60 seconds.  For
         compatibility with older clients, a token should never be returned with
         less than 60 seconds to live.

--- a/docs/spec/implementations.md
+++ b/docs/spec/implementations.md
@@ -1,8 +1,6 @@
-<!--[metadata]>
-+++
-draft = true
-+++
-<![end-metadata]-->
+---
+published: false
+---
 
 # Distribution API Implementations
 

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,13 +1,8 @@
-<!--[metadata]>
-+++
-title = "Reference Overview"
-description = "Explains registry JSON objects"
-keywords = ["registry, service, images, repository,  json"]
-[menu.main]
-parent="smn_registry_ref"
-weight=-1
-+++
-<![end-metadata]-->
+---
+title: "Reference Overview"
+description: "Explains registry JSON objects"
+keywords: ["registry, service, images, repository,  json"]
+---
 
 # Docker Registry Reference
 

--- a/docs/spec/json.md
+++ b/docs/spec/json.md
@@ -1,13 +1,9 @@
-<!--[metadata]>
-+++
-draft=true
-title = "Docker Distribution JSON Canonicalization"
-description = "Explains registry JSON objects"
-keywords = ["registry, service, images, repository,  json"]
-[menu.main]
-parent="smn_registry_ref"
-+++
-<![end-metadata]-->
+---
+published: false
+title: "Docker Distribution JSON Canonicalization"
+description: "Explains registry JSON objects"
+keywords: ["registry, service, images, repository,  json"]
+---
 
 
 

--- a/docs/spec/manifest-v2-1.md
+++ b/docs/spec/manifest-v2-1.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "Image Manifest V 2, Schema 1 "
-description = "image manifest for the Registry."
-keywords = ["registry, on-prem, images, tags, repository, distribution, api, advanced, manifest"]
-[menu.main]
-parent="smn_registry_ref"
-+++
-<![end-metadata]-->
+---
+title: "Image Manifest V 2, Schema 1 "
+description: "image manifest for the Registry."
+keywords: ["registry, on-prem, images, tags, repository, distribution, api, advanced, manifest"]
+---
 
 # Image Manifest Version 2, Schema 1
 

--- a/docs/spec/manifest-v2-2.md
+++ b/docs/spec/manifest-v2-2.md
@@ -1,12 +1,8 @@
-<!--[metadata]>
-+++
-title = "Image Manifest V 2, Schema 2 "
-description = "image manifest for the Registry."
-keywords = ["registry, on-prem, images, tags, repository, distribution, api, advanced, manifest"]
-[menu.main]
-parent="smn_registry_ref"
-+++
-<![end-metadata]-->
+---
+title: "Image Manifest V 2, Schema 2 "
+description: "image manifest for the Registry."
+keywords: ["registry, on-prem, images, tags, repository, distribution, api, advanced, manifest"]
+---
 
 # Image Manifest Version 2, Schema 2
 

--- a/docs/spec/menu.md
+++ b/docs/spec/menu.md
@@ -1,13 +1,7 @@
-<!--[metadata]>
-+++
-title = "Reference"
-description = "Explains registry JSON objects"
-keywords = ["registry, service, images, repository,  json"]
-type = "menu"
-[menu.main]
-identifier="smn_registry_ref"
-parent="smn_registry"
-weight=7
-+++
-<![end-metadata]-->
-
+---
+title: "Reference"
+description: "Explains registry JSON objects"
+keywords: ["registry, service, images, repository,  json"]
+type: "menu"
+identifier: "smn_registry_ref"
+---


### PR DESCRIPTION
Some frontmatter such as the weights, menu stuff, etc is no longer used
'draft=true' becomes 'published: false'

Signed-off-by: Misty Stanley-Jones <misty@docker.com>