### PR TITLE
Honor X-Forwarded-Port header

### DIFF
--- a/registry/api/v2/headerparser.go
+++ b/registry/api/v2/headerparser.go
@@ -1,0 +1,161 @@
+package v2
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var (
+	// according to rfc7230
+	reToken            = regexp.MustCompile(`^[^"(),/:;<=>?@[\]{}[:space:][:cntrl:]]+`)
+	reQuotedValue      = regexp.MustCompile(`^[^\\"]+`)
+	reEscapedCharacter = regexp.MustCompile(`^[[:blank:][:graph:]]`)
+)
+
+// parseForwardedHeader is a benevolent parser of Forwarded header defined in rfc7239. The header contains
+// a comma-separated list of forwarding key-value pairs. Each list element is set by single proxy. The
+// function parses only the first element of the list, which is set by the very first proxy. It returns a map
+// of corresponding key-value pairs and an unparsed slice of the input string.
+//
+// Examples of Forwarded header values:
+//
+//  1. Forwarded: For=192.0.2.43; Proto=https,For="[2001:db8:cafe::17]",For=unknown
+//  2. Forwarded: for="192.0.2.43:443"; host="registry.example.org", for="10.10.05.40:80"
+//
+// The first will be parsed into {"for": "192.0.2.43", "proto": "https"} while the second into
+// {"for": "192.0.2.43:443", "host": "registry.example.org"}.
+func parseForwardedHeader(forwarded string) (map[string]string, string, error) {
+	// Following are states of forwarded header parser. Any state could transition to a failure.
+	const (
+		// terminating state; can transition to Parameter
+		stateElement = iota
+		// terminating state; can transition to KeyValueDelimiter
+		stateParameter
+		// can transition to Value
+		stateKeyValueDelimiter
+		// can transition to one of { QuotedValue, PairEnd }
+		stateValue
+		// can transition to one of { EscapedCharacter, PairEnd }
+		stateQuotedValue
+		// can transition to one of { QuotedValue }
+		stateEscapedCharacter
+		// terminating state; can transition to one of { Parameter, Element }
+		statePairEnd
+	)
+
+	var (
+		parameter string
+		value     string
+		parse     = forwarded[:]
+		res       = map[string]string{}
+		state     = stateElement
+	)
+
+Loop:
+	for {
+		// skip spaces unless in quoted value
+		if state != stateQuotedValue && state != stateEscapedCharacter {
+			parse = strings.TrimLeftFunc(parse, unicode.IsSpace)
+		}
+
+		if len(parse) == 0 {
+			if state != stateElement && state != statePairEnd && state != stateParameter {
+				return nil, parse, fmt.Errorf("unexpected end of input")
+			}
+			// terminating
+			break
+		}
+
+		switch state {
+		// terminate at list element delimiter
+		case stateElement:
+			if parse[0] == ',' {
+				parse = parse[1:]
+				break Loop
+			}
+			state = stateParameter
+
+		// parse parameter (the key of key-value pair)
+		case stateParameter:
+			match := reToken.FindString(parse)
+			if len(match) == 0 {
+				return nil, parse, fmt.Errorf("failed to parse token at position %d", len(forwarded)-len(parse))
+			}
+			parameter = strings.ToLower(match)
+			parse = parse[len(match):]
+			state = stateKeyValueDelimiter
+
+		// parse '='
+		case stateKeyValueDelimiter:
+			if parse[0] != '=' {
+				return nil, parse, fmt.Errorf("expected '=', not '%c' at position %d", parse[0], len(forwarded)-len(parse))
+			}
+			parse = parse[1:]
+			state = stateValue
+
+		// parse value or quoted value
+		case stateValue:
+			if parse[0] == '"' {
+				parse = parse[1:]
+				state = stateQuotedValue
+			} else {
+				value = reToken.FindString(parse)
+				if len(value) == 0 {
+					return nil, parse, fmt.Errorf("failed to parse value at position %d", len(forwarded)-len(parse))
+				}
+				if _, exists := res[parameter]; exists {
+					return nil, parse, fmt.Errorf("duplicate parameter %q at position %d", parameter, len(forwarded)-len(parse))
+				}
+				res[parameter] = value
+				parse = parse[len(value):]
+				value = ""
+				state = statePairEnd
+			}
+
+		// parse a part of quoted value until the first backslash
+		case stateQuotedValue:
+			match := reQuotedValue.FindString(parse)
+			value += match
+			parse = parse[len(match):]
+			switch {
+			case len(parse) == 0:
+				return nil, parse, fmt.Errorf("unterminated quoted string")
+			case parse[0] == '"':
+				res[parameter] = value
+				value = ""
+				parse = parse[1:]
+				state = statePairEnd
+			case parse[0] == '\\':
+				parse = parse[1:]
+				state = stateEscapedCharacter
+			}
+
+		// parse escaped character in a quoted string, ignore the backslash
+		// transition back to QuotedValue state
+		case stateEscapedCharacter:
+			c := reEscapedCharacter.FindString(parse)
+			if len(c) == 0 {
+				return nil, parse, fmt.Errorf("invalid escape sequence at position %d", len(forwarded)-len(parse)-1)
+			}
+			value += c
+			parse = parse[1:]
+			state = stateQuotedValue
+
+		// expect either a new key-value pair, new list or end of input
+		case statePairEnd:
+			switch parse[0] {
+			case ';':
+				parse = parse[1:]
+				state = stateParameter
+			case ',':
+				state = stateElement
+			default:
+				return nil, parse, fmt.Errorf("expected ',' or ';', not %c at position %d", parse[0], len(forwarded)-len(parse))
+			}
+		}
+	}
+
+	return res, parse, nil
+}

--- a/registry/api/v2/headerparser_test.go
+++ b/registry/api/v2/headerparser_test.go
@@ -1,0 +1,161 @@
+package v2
+
+import (
+	"testing"
+)
+
+func TestParseForwardedHeader(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		raw           string
+		expected      map[string]string
+		expectedRest  string
+		expectedError bool
+	}{
+		{
+			name: "empty",
+			raw:  "",
+		},
+		{
+			name:     "one pair",
+			raw:      " key = value ",
+			expected: map[string]string{"key": "value"},
+		},
+		{
+			name:     "two pairs",
+			raw:      " key1 = value1; key2=value2",
+			expected: map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:     "uppercase parameter",
+			raw:      "KeY=VaL",
+			expected: map[string]string{"key": "VaL"},
+		},
+		{
+			name:     "missing key=value pair - be tolerant",
+			raw:      "key=val;",
+			expected: map[string]string{"key": "val"},
+		},
+		{
+			name:     "quoted values",
+			raw:      `key="val";param = "[[ $((1 + 1)) == 3 ]] && echo panic!;" ; p=" abcd "`,
+			expected: map[string]string{"key": "val", "param": "[[ $((1 + 1)) == 3 ]] && echo panic!;", "p": " abcd "},
+		},
+		{
+			name:     "empty quoted value",
+			raw:      `key=""`,
+			expected: map[string]string{"key": ""},
+		},
+		{
+			name:     "quoted double quotes",
+			raw:      `key="\"value\""`,
+			expected: map[string]string{"key": `"value"`},
+		},
+		{
+			name:     "quoted backslash",
+			raw:      `key="\"\\\""`,
+			expected: map[string]string{"key": `"\"`},
+		},
+		{
+			name:         "ignore subsequent elements",
+			raw:          "key=a, param= b",
+			expected:     map[string]string{"key": "a"},
+			expectedRest: " param= b",
+		},
+		{
+			name:         "empty element - be tolerant",
+			raw:          " , key=val",
+			expectedRest: " key=val",
+		},
+		{
+			name:     "obscure key",
+			raw:      `ob₷C&r€ = value`,
+			expected: map[string]string{`ob₷c&r€`: "value"},
+		},
+		{
+			name:          "duplicate parameter",
+			raw:           "key=a; p=b; key=c",
+			expectedError: true,
+		},
+		{
+			name:          "empty parameter",
+			raw:           "=value",
+			expectedError: true,
+		},
+		{
+			name:          "empty value",
+			raw:           "key= ",
+			expectedError: true,
+		},
+		{
+			name:          "empty value before a new element ",
+			raw:           "key=,",
+			expectedError: true,
+		},
+		{
+			name:          "empty value before a new pair",
+			raw:           "key=;",
+			expectedError: true,
+		},
+		{
+			name:          "just parameter",
+			raw:           "key",
+			expectedError: true,
+		},
+		{
+			name:          "missing key-value",
+			raw:           "a=b;;",
+			expectedError: true,
+		},
+		{
+			name:          "unclosed quoted value",
+			raw:           `key="value`,
+			expectedError: true,
+		},
+		{
+			name:          "escaped terminating dquote",
+			raw:           `key="value\"`,
+			expectedError: true,
+		},
+		{
+			name:          "just a quoted value",
+			raw:           `"key=val"`,
+			expectedError: true,
+		},
+		{
+			name:          "quoted key",
+			raw:           `"key"=val`,
+			expectedError: true,
+		},
+	} {
+		parsed, rest, err := parseForwardedHeader(tc.raw)
+		if err != nil && !tc.expectedError {
+			t.Errorf("[%s] got unexpected error: %v", tc.name, err)
+		}
+		if err == nil && tc.expectedError {
+			t.Errorf("[%s] got unexpected non-error", tc.name)
+		}
+		if err != nil || tc.expectedError {
+			continue
+		}
+		for key, value := range tc.expected {
+			v, exists := parsed[key]
+			if !exists {
+				t.Errorf("[%s] missing expected parameter %q", tc.name, key)
+				continue
+			}
+			if v != value {
+				t.Errorf("[%s] got unexpected value for parameter %q: %q != %q", tc.name, key, v, value)
+			}
+		}
+		for key, value := range parsed {
+			if _, exists := tc.expected[key]; !exists {
+				t.Errorf("[%s] got unexpected key/value pair: %q=%q", tc.name, key, value)
+			}
+		}
+
+		if rest != tc.expectedRest {
+			t.Errorf("[%s] got unexpected unparsed string: %q != %q", tc.name, rest, tc.expectedRest)
+		}
+	}
+}

--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -1,8 +1,10 @@
 package v2
 
 import (
+	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/docker/distribution/reference"
@@ -49,10 +51,14 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 	var scheme string
 
 	forwardedProto := r.Header.Get("X-Forwarded-Proto")
+	// TODO: log the error
+	forwardedHeader, _, _ := parseForwardedHeader(r.Header.Get("Forwarded"))
 
 	switch {
 	case len(forwardedProto) > 0:
 		scheme = forwardedProto
+	case len(forwardedHeader["proto"]) > 0:
+		scheme = forwardedHeader["proto"]
 	case r.TLS != nil:
 		scheme = "https"
 	case len(r.URL.Scheme) > 0:
@@ -62,14 +68,46 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 	}
 
 	host := r.Host
-	forwardedHost := r.Header.Get("X-Forwarded-Host")
-	if len(forwardedHost) > 0 {
+
+	if forwardedHost := r.Header.Get("X-Forwarded-Host"); len(forwardedHost) > 0 {
 		// According to the Apache mod_proxy docs, X-Forwarded-Host can be a
 		// comma-separated list of hosts, to which each proxy appends the
 		// requested host. We want to grab the first from this comma-separated
 		// list.
 		hosts := strings.SplitN(forwardedHost, ",", 2)
 		host = strings.TrimSpace(hosts[0])
+	} else if addr, exists := forwardedHeader["for"]; exists {
+		host = addr
+	} else if h, exists := forwardedHeader["host"]; exists {
+		host = h
+	}
+
+	portLessHost, port := host, ""
+	if !isIPv6Address(portLessHost) {
+		// with go 1.6, this would treat the last part of IPv6 address as a port
+		portLessHost, port, _ = net.SplitHostPort(host)
+	}
+	if forwardedPort := r.Header.Get("X-Forwarded-Port"); len(port) == 0 && len(forwardedPort) > 0 {
+		ports := strings.SplitN(forwardedPort, ",", 2)
+		forwardedPort = strings.TrimSpace(ports[0])
+		if _, err := strconv.ParseInt(forwardedPort, 10, 32); err == nil {
+			port = forwardedPort
+		}
+	}
+
+	if len(portLessHost) > 0 {
+		host = portLessHost
+	}
+	if len(port) > 0 {
+		// remove enclosing brackets of ipv6 address otherwise they will be duplicated
+		if len(host) > 1 && host[0] == '[' && host[len(host)-1] == ']' {
+			host = host[1 : len(host)-1]
+		}
+		// JoinHostPort properly encloses ipv6 addresses in square brackets
+		host = net.JoinHostPort(host, port)
+	} else if isIPv6Address(host) && host[0] != '[' {
+		// ipv6 needs to be enclosed in square brackets in urls
+		host = "[" + host + "]"
 	}
 
 	basePath := routeDescriptorsMap[RouteNameBase].Path
@@ -248,4 +286,29 @@ func appendValues(u string, values ...url.Values) string {
 	}
 
 	return appendValuesURL(up, values...).String()
+}
+
+// isIPv6Address returns true if given string is a valid IPv6 address. No port is allowed. The address may be
+// enclosed in square brackets.
+func isIPv6Address(host string) bool {
+	if len(host) > 1 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
+	}
+	// The IPv6 scoped addressing zone identifier starts after the last percent sign.
+	if i := strings.LastIndexByte(host, '%'); i > 0 {
+		host = host[:i]
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	if ip.To16() == nil {
+		return false
+	}
+	if ip.To4() == nil {
+		return true
+	}
+	// dot can be present in ipv4-mapped address, it needs to come after a colon though
+	i := strings.IndexAny(host, ":.")
+	return i >= 0 && host[i] == ':'
 }


### PR DESCRIPTION
If the explicit port is specified using this header, use it as a base for redirect urls.

As documented in article "HTTP Headers and Elastic Load Balancing" of AWS ELB docs:

> The X-Forwarded-Port request header helps you identify the port that an HTTP or HTTPS load balancer uses to connect to the client.

This makes registry behave correctly when proxy strips port from the requests e.g.:

```
GET /openshift/token?account=unused&scope=repository%3Apjoe%2Fhello-world%3Apush%2Cpull HTTP/1.1
Host: registry.f24-ose.vm
User-Agent: docker/1.12.1 go/go1.7 git-commit/23cf638 kernel/4.7.6-1-ARCH os/linux arch/amd64 UpstreamClient(Docker-Client/1.12.1 \(linux\))
Authorization: Basic dW51c2VkOlV1WGoyTGdTWkk4TGc0azY1bXFwc3ZlT1VKdXg1NnFDMTJXMThRdUdYOG8=
Accept-Encoding: gzip
Connection: close
X-Forwarded-Host: registry.f24-ose.vm
X-Forwarded-Port: 5000
X-Forwarded-Proto: http
Forwarded: for=192.168.100.80;host=registry.f24-ose.vm;proto=http
X-Forwarded-For: 192.168.100.80
```

Where original request (docker daemon -> registry's proxy) looks like this:

```
GET /openshift/token?account=unused&scope=repository%3Apjoe%2Fhello-world%3Apush%2Cpull HTTP/1.1
Host: registry.f24-ose.vm:5000
User-Agent: docker/1.12.1 go/go1.7 git-commit/23cf638 kernel/4.7.6-1-ARCH os/linux arch/amd64 UpstreamClient(Docker-Client/1.12.1 \(linux\))
Authorization: Basic dW51c2VkOlV1WGoyTGdTWkk4TGc0azY1bXFwc3ZlT1VKdXg1NnFDMTJXMThRdUdYOG8=
Accept-Encoding: gzip
Connection: close
```

Without this patch, during a `POST /v2/pjoe/hello-world/blobs/uploads/ HTTP/1.1` request, registry would redirect to port-less url `registry.f24-ose.vm` which would make docker daemon attempt to upload on port 80 and fail.

With this patch, registry will reply with correct location:

```
HTTP/1.1 202 Accepted
Content-Length: 0
Docker-Distribution-Api-Version: registry/2.0
Docker-Upload-Uuid: 24f37d8f-312d-45d4-b507-5a45923daf14
Location: http://registry.f24-ose.vm:5000/v2/pjoe/hello-world/blobs/uploads/24f37d8f-312d-45d4-b507-5a45923daf14?_state=g0583DtjmtCDcE3a8fSJbTwoM70F5BL15Omx058lFLx7Ik5hbWUiOiJwam9lL2hlbGxvLXdvcmxkIiwiVVVJRCI6IjI0ZjM3ZDhmLTMxMmQtNDVkNC1iNTA3LTVhNDU5MjNkYWYxNCIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAxNi0xMC0xN1QxMjoxNzowMC42MTYwNDU2NzhaIn0%3D
...
```
