### PR TITLE
Fix broken doc links

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,7 +11,7 @@ Most people should use the [official Registry docker image](https://hub.docker.c
 
 People looking for advanced operational use cases might consider rolling their own image with a custom Dockerfile inheriting `FROM registry:2`.
 
-OS X users who want to run natively can do so following [the instructions here](osx-setup-guide.md).
+OS X users who want to run natively can do so following [the instructions here](https://github.com/docker/docker.github.io/blob/master/registry/recipes/osx-setup-guide.md).
 
 ### Gotchas
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains the following components:
 | **registry**       | An implementation of the [Docker Registry HTTP API V2](docs/spec/api.md) for use with docker 1.6+.                                                                                                  |
 | **libraries**      | A rich set of libraries for interacting with distribution components. Please see [godoc](https://godoc.org/github.com/docker/distribution) for details. **Note**: These libraries are **unstable**. |
 | **specifications** | _Distribution_ related specifications are available in [docs/spec](docs/spec)                                                                                                                        |
-| **documentation**  | Docker's full documentation set is available at [docs.docker.com](https://docs.docker.com). This repository [contains the subset](docs/index.md) related just to the registry.                                                                                                                                          |
+| **documentation**  | Docker's full documentation set is available at [docs.docker.com](https://docs.docker.com). This repository [contains the subset](docs/) related just to the registry.                                                                                                                                          |
 
 ### How does this integrate with Docker engine?
 
@@ -68,7 +68,7 @@ others, it is not.
 For example, users with their own software products may want to maintain a
 registry for private, company images. Also, you may wish to deploy your own
 image repository for images used to test or in continuous integration. For these
-use cases and others, [deploying your own registry instance](docs/deploying.md)
+use cases and others, [deploying your own registry instance](https://github.com/docker/docker.github.io/blob/master/registry/deploying.md)
 may be the better choice.
 
 ### Migration to Registry 2.0


### PR DESCRIPTION
Signed-off-by: Jihoon Chung <jihoon@gmail.com>

This fixes broken doc links. (Replaces with [general doc repo's](https://github.com/docker/docker.github.io) links)