### PR TITLE
Add target media type to blob upload

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -202,6 +202,7 @@ type CreateOptions struct {
 		// Blob access check will be skipped if set.
 		Stat *Descriptor
 	}
+	TargetMediaType string
 }
 
 // BlobWriter provides a handle for inserting data into a blob store.

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -3363,6 +3363,7 @@ POST /v2/<name>/blobs/uploads/?digest=<digest>
 Host: <registry host>
 Authorization: <scheme> <token>
 Content-Length: <length of blob>
+Docker-Target-Media-Type: <media-type>
 Content-Type: application/octect-stream
 
 <binary data>
@@ -3378,6 +3379,7 @@ The following parameters should be specified on the request:
 |`Host`|header|Standard HTTP Host Header. Should be set to the registry host.|
 |`Authorization`|header|An RFC7235 compliant authorization header.|
 |`Content-Length`|header||
+|`Docker-Target-Media-Type`|header|The media type of the target configuration of the manifest.|
 |`name`|path|Name of the target repository.|
 |`digest`|query|Digest of uploaded blob. If present, the upload will be completed, in a single request, with contents of the request body as the resulting blob.|
 
@@ -3440,6 +3442,24 @@ The error codes that may be included in the response body are enumerated below:
 |Code|Message|Description|
 |----|-------|-----------|
 | `UNSUPPORTED` | The operation is unsupported. | The operation was unsupported due to a missing implementation or invalid set of parameters. |
+
+
+
+###### On Failure: Mismatched target media type
+
+```
+400 Bad Request
+```
+
+
+
+
+
+The error codes that may be included in the response body are enumerated below:
+
+|Code|Message|Description|
+|----|-------|-----------|
+| `BLOB_UPLOAD_INVALID` | blob upload invalid | The blob upload encountered an error and can no longer proceed. |
 
 
 

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -74,6 +74,13 @@ var (
 		Format:      "0",
 	}
 
+	targetMediaTypeHeader = ParameterDescriptor{
+		Name:        "Docker-Target-Media-Type",
+		Description: "The media type of the target configuration of the manifest.",
+		Type:        "string",
+		Format:      "<media-type>",
+	}
+
 	dockerUploadUUIDHeader = ParameterDescriptor{
 		Name:        "Docker-Upload-UUID",
 		Description: "Identifies the docker upload uuid for the current request.",
@@ -960,6 +967,7 @@ var routeDescriptors = []RouteDescriptor{
 								Type:   "integer",
 								Format: "<length of blob>",
 							},
+							targetMediaTypeHeader,
 						},
 						PathParameters: []ParameterDescriptor{
 							nameParameterDescriptor,
@@ -1007,6 +1015,13 @@ var routeDescriptors = []RouteDescriptor{
 								StatusCode:  http.StatusMethodNotAllowed,
 								ErrorCodes: []errcode.ErrorCode{
 									errcode.ErrorCodeUnsupported,
+								},
+							},
+							{
+								Name:       "Mismatched target media type",
+								StatusCode: http.StatusBadRequest,
+								ErrorCodes: []errcode.ErrorCode{
+									ErrorCodeBlobUploadInvalid,
 								},
 							},
 							unauthorizedResponseDescriptor,


### PR DESCRIPTION
In order to support homogeneous repositories in a user friendly manner, blob uploads must fail fast when attempting to upload content which has a media type which differs from previously uploaded content. This change adds a header to the blob upload which specifies what the media type inside the corresponding manifest will be. Since content uploads start by uploading blobs failing fast requires a change to the blob upload endpoint.

This change does not alter the behavior of blob uploads but is required to add support in the client for registries with this feature enabled. 
