### PR TITLE
optimize oss copy action when push upload finished.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -167,15 +167,15 @@
 		},
 		{
 			"ImportPath": "github.com/denverdino/aliyungo/common",
-			"Rev": "6ffb587da9da6d029d0ce517b85fecc82172d502"
+			"Rev": "ce70ed03a598bb3ba258ff9c90a83a257959067c"
 		},
 		{
 			"ImportPath": "github.com/denverdino/aliyungo/oss",
-			"Rev": "6ffb587da9da6d029d0ce517b85fecc82172d502"
+			"Rev": "ce70ed03a598bb3ba258ff9c90a83a257959067c"
 		},
 		{
 			"ImportPath": "github.com/denverdino/aliyungo/util",
-			"Rev": "6ffb587da9da6d029d0ce517b85fecc82172d502"
+			"Rev": "ce70ed03a598bb3ba258ff9c90a83a257959067c"
 		},
 		{
 			"ImportPath": "github.com/docker/goamz/aws",

--- a/vendor/github.com/denverdino/aliyungo/common/regions.go
+++ b/vendor/github.com/denverdino/aliyungo/common/regions.go
@@ -11,8 +11,9 @@ const (
 	Hongkong     = Region("cn-hongkong")
 	Shenzhen     = Region("cn-shenzhen")
 	USWest1      = Region("us-west-1")
+	USEast1      = Region("us-east-1")
 	APSouthEast1 = Region("ap-southeast-1")
 	Shanghai     = Region("cn-shanghai")
 )
 
-var ValidRegions = []Region{Hangzhou, Qingdao, Beijing, Shenzhen, Hongkong, Shanghai, USWest1, APSouthEast1}
+var ValidRegions = []Region{Hangzhou, Qingdao, Beijing, Shenzhen, Hongkong, Shanghai, USWest1, USEast1, APSouthEast1}

--- a/vendor/github.com/denverdino/aliyungo/common/types.go
+++ b/vendor/github.com/denverdino/aliyungo/common/types.go
@@ -6,3 +6,10 @@ const (
 	PayByBandwidth = InternetChargeType("PayByBandwidth")
 	PayByTraffic   = InternetChargeType("PayByTraffic")
 )
+
+type InstanceChargeType string
+
+const (
+	PrePaid  = InstanceChargeType("PrePaid")
+	PostPaid = InstanceChargeType("PostPaid")
+)

--- a/vendor/github.com/denverdino/aliyungo/oss/multi.go
+++ b/vendor/github.com/denverdino/aliyungo/oss/multi.go
@@ -141,9 +141,13 @@ func (b *Bucket) InitMulti(key string, contType string, perm ACL, options Option
 	return &Multi{Bucket: b, Key: key, UploadId: resp.UploadId}, nil
 }
 
+func (m *Multi) PutPartCopy(n int, options CopyOptions, source string) (*CopyObjectResult, Part, error) {
+	return m.PutPartCopyWithContentLength(n, options, source, -1)
+}
+
 //
 // You can read doc at http://docs.aliyun.com/#/pub/oss/api-reference/multipart-upload&UploadPartCopy
-func (m *Multi) PutPartCopy(n int, options CopyOptions, source string) (*CopyObjectResult, Part, error) {
+func (m *Multi) PutPartCopyWithContentLength(n int, options CopyOptions, source string, contentLength int64) (*CopyObjectResult, Part, error) {
 	// TODO source format a /BUCKET/PATH/TO/OBJECT
 	// TODO not a good design. API could be changed to PutPartCopyWithinBucket(..., path) and PutPartCopyFromBucket(bucket, path)
 
@@ -155,14 +159,17 @@ func (m *Multi) PutPartCopy(n int, options CopyOptions, source string) (*CopyObj
 	params.Set("uploadId", m.UploadId)
 	params.Set("partNumber", strconv.FormatInt(int64(n), 10))
 
-	sourceBucket := m.Bucket.Client.Bucket(strings.TrimRight(strings.Split(source, "/")[1], "/"))
-	//log.Println("source: ", source)
-	//log.Println("sourceBucket: ", sourceBucket.Name)
-	//log.Println("HEAD: ", strings.strings.SplitAfterN(source, "/", 3)[2])
-	// TODO SplitAfterN can be use in bucket name
-	sourceMeta, err := sourceBucket.Head(strings.SplitAfterN(source, "/", 3)[2], nil)
-	if err != nil {
-		return nil, Part{}, err
+	if contentLength < 0 {
+		sourceBucket := m.Bucket.Client.Bucket(strings.TrimRight(strings.Split(source, "/")[1], "/"))
+		//log.Println("source: ", source)
+		//log.Println("sourceBucket: ", sourceBucket.Name)
+		//log.Println("HEAD: ", strings.strings.SplitAfterN(source, "/", 3)[2])
+		// TODO SplitAfterN can be use in bucket name
+		sourceMeta, err := sourceBucket.Head(strings.SplitAfterN(source, "/", 3)[2], nil)
+		if err != nil {
+			return nil, Part{}, err
+		}
+		contentLength = sourceMeta.ContentLength
 	}
 
 	for attempt := attempts.Start(); attempt.Next(); {
@@ -174,7 +181,7 @@ func (m *Multi) PutPartCopy(n int, options CopyOptions, source string) (*CopyObj
 			params:  params,
 		}
 		resp := &CopyObjectResult{}
-		err = m.Bucket.Client.query(req, resp)
+		err := m.Bucket.Client.query(req, resp)
 		if shouldRetry(err) && attempt.HasNext() {
 			continue
 		}
@@ -184,7 +191,7 @@ func (m *Multi) PutPartCopy(n int, options CopyOptions, source string) (*CopyObj
 		if resp.ETag == "" {
 			return nil, Part{}, errors.New("part upload succeeded with no ETag")
 		}
-		return resp, Part{n, resp.ETag, sourceMeta.ContentLength}, nil
+		return resp, Part{n, resp.ETag, contentLength}, nil
 	}
 	panic("unreachable")
 }

--- a/vendor/github.com/denverdino/aliyungo/oss/regions.go
+++ b/vendor/github.com/denverdino/aliyungo/oss/regions.go
@@ -15,6 +15,7 @@ const (
 	Hongkong     = Region("oss-cn-hongkong")
 	Shenzhen     = Region("oss-cn-shenzhen")
 	USWest1      = Region("oss-us-west-1")
+	USEast1      = Region("oss-us-east-1")
 	APSouthEast1 = Region("oss-ap-southeast-1")
 	Shanghai     = Region("oss-cn-shanghai")
 
@@ -53,4 +54,17 @@ func (r Region) GetInternalEndpoint(bucket string, secure bool) string {
 		return fmt.Sprintf("%s://oss-internal.aliyuncs.com", protocol)
 	}
 	return fmt.Sprintf("%s://%s.%s-internal.aliyuncs.com", protocol, bucket, string(r))
+}
+
+// GetInternalEndpoint returns internal endpoint of region
+func (r Region) GetVPCInternalEndpoint(bucket string, secure bool) string {
+	protocol := getProtocol(secure)
+	if bucket == "" {
+		return fmt.Sprintf("%s://vpc100-oss-cn-hangzhou.aliyuncs.com", protocol)
+	}
+	if r == USEast1 {
+		return r.GetInternalEndpoint(bucket, secure)
+	} else {
+		return fmt.Sprintf("%s://%s.vpc100-%s.aliyuncs.com", protocol, bucket, string(r))
+	}
 }

--- a/vendor/github.com/denverdino/aliyungo/oss/signature.go
+++ b/vendor/github.com/denverdino/aliyungo/oss/signature.go
@@ -32,6 +32,7 @@ var ossParamsToSign = map[string]bool{
 	"response-cache-control":       true,
 	"response-content-disposition": true,
 	"response-content-encoding":    true,
+	"bucketInfo":                   true,
 }
 
 func (client *Client) signRequest(request *request) {
@@ -101,5 +102,6 @@ func canonicalizeHeader(headers http.Header) (newHeaders http.Header, result str
 	for _, k := range canonicalizedHeaders {
 		canonicalizedHeader += k + ":" + headers.Get(k) + "\n"
 	}
+
 	return newHeaders, canonicalizedHeader
 }

--- a/vendor/github.com/denverdino/aliyungo/util/encoding.go
+++ b/vendor/github.com/denverdino/aliyungo/util/encoding.go
@@ -37,8 +37,8 @@ func setQueryValues(i interface{}, values *url.Values, prefix string) {
 		elem = elem.Elem()
 	}
 	elemType := elem.Type()
-
 	for i := 0; i < elem.NumField(); i++ {
+
 		fieldName := elemType.Field(i).Name
 		anonymous := elemType.Field(i).Anonymous
 		field := elem.Field(i)


### PR DESCRIPTION

# Describe
when push a large layer to the repo, previous oss driver copy the uploaded blob to store sequentially, we optimize the current oss driver to CopyLargeFileInParallel. which can reduce the copy time to 3/4.

# Fix
CopyLargeFileInParallel

Change-Id: I8744deb826dd9f5481d2c67c257face87771909f
Signed-off-by: yaoyao.xyy <yaoyao.xyy@alibaba-inc.com>