### PR TITLE
Remove Jenkinsfile used for docs CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,0 @@
-// Only run on Linux atm
-wrappedNode(label: 'docker') {
-  deleteDir()
-  stage "checkout"
-  checkout scm
-
-  documentationChecker("docs")
-}


### PR DESCRIPTION
The documentation has been migrated to docker/docker.github.io, so I'm removing this Jenkins file that was running docs-related CI and can start breaking the builds.

Signed-off-by: Joao Fernandes <joao.fernandes@docker.com>