### PR TITLE
Pick up the losing error

### DIFF
--- a/registry/auth/token/token.go
+++ b/registry/auth/token/token.go
@@ -170,7 +170,7 @@ func (t *Token) Verify(verifyOpts VerifyOptions) error {
 	signingKey, err := t.VerifySigningKey(verifyOpts)
 	if err != nil {
 		log.Info(err)
-		return ErrInvalidToken
+		return err
 	}
 
 	// Finally, verify the signature of the token using the key which signed it.

--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -390,9 +390,8 @@ func TestAccessController(t *testing.T) {
 	if !ok {
 		t.Fatal("accessController did not return a challenge")
 	}
-
-	if challenge.Error() != ErrInvalidToken.Error() {
-		t.Fatalf("accessControler did not get expected error - got %s - expected %s", challenge, ErrTokenRequired)
+	if !strings.Contains(challenge.Error(), "could not verify JWK certificate chain") {
+		t.Fatalf("accessControler did not get expected error - got %s - expected %s", challenge.Error(), "could not verify JWK certificate chain")
 	}
 
 	if authCtx != nil {


### PR DESCRIPTION
The `ErrInvalidToken` for "invalid token" is a general error message
which would be not enough for people to find the problem.

For example, the original error was "token signed by untrusted key
with ID:xxx", only return the `ErrInvalidToken` will lose those
useful information.

Signed-off-by: Hu Keping hukeping@huawei.com
