### PR TITLE
storagedriver/azure: close leaking response body

### DIFF
--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -111,6 +111,7 @@ func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
 		return nil, err
 	}
 
+	defer blob.Close()
 	return ioutil.ReadAll(blob)
 }
 


### PR DESCRIPTION
In GetContent() we read the bytes from a blob but do not close
the underlying response body.

Apparently this is not a big deal (it's been there since 4054cd3e, which is Nov 2014).

I found other memory leaks caused by not reusing http client and not specifying http.Client.Timeout. I'll address that in another PR by re-vendoring the Azure storage SDK.

