### PR TITLE
Update vendored azure-sdk-for-go

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -8,8 +8,8 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/storage",
-			"Comment": "v1.2-334-g95361a2",
-			"Rev": "95361a2573b1fa92a00c5fc2707a80308483c6f9"
+			"Comment": "v5.0.0-beta-6-g0b5fe2a",
+			"Rev": "0b5fe2abe0271ba07049eacaa65922d67c319543"
 		},
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -116,7 +116,7 @@ func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
 
 // PutContent stores the []byte content at a location designated by "path".
 func (d *driver) PutContent(ctx context.Context, path string, contents []byte) error {
-	if _, err := d.client.DeleteBlobIfExists(d.container, path); err != nil {
+	if _, err := d.client.DeleteBlobIfExists(d.container, path, nil); err != nil {
 		return err
 	}
 	writer, err := d.Writer(ctx, path, false)
@@ -151,7 +151,7 @@ func (d *driver) Reader(ctx context.Context, path string, offset int64) (io.Read
 	}
 
 	bytesRange := fmt.Sprintf("%v-", offset)
-	resp, err := d.client.GetBlobRange(d.container, path, bytesRange)
+	resp, err := d.client.GetBlobRange(d.container, path, bytesRange, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (d *driver) Writer(ctx context.Context, path string, append bool) (storaged
 			}
 			size = blobProperties.ContentLength
 		} else {
-			err := d.client.DeleteBlob(d.container, path)
+			err := d.client.DeleteBlob(d.container, path, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -272,12 +272,12 @@ func (d *driver) Move(ctx context.Context, sourcePath string, destPath string) e
 		return err
 	}
 
-	return d.client.DeleteBlob(d.container, sourcePath)
+	return d.client.DeleteBlob(d.container, sourcePath, nil)
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
 func (d *driver) Delete(ctx context.Context, path string) error {
-	ok, err := d.client.DeleteBlobIfExists(d.container, path)
+	ok, err := d.client.DeleteBlobIfExists(d.container, path, nil)
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 	}
 
 	for _, b := range blobs {
-		if err = d.client.DeleteBlob(d.container, b); err != nil {
+		if err = d.client.DeleteBlob(d.container, b, nil); err != nil {
 			return err
 		}
 	}
@@ -442,7 +442,7 @@ func (w *writer) Cancel() error {
 		return fmt.Errorf("already committed")
 	}
 	w.cancelled = true
-	return w.driver.client.DeleteBlob(w.driver.container, w.path)
+	return w.driver.client.DeleteBlob(w.driver.container, w.path, nil)
 }
 
 func (w *writer) Commit() error {
@@ -470,7 +470,7 @@ func (bw *blockWriter) Write(p []byte) (int, error) {
 		if offset+chunkSize > len(p) {
 			chunkSize = len(p) - offset
 		}
-		err := bw.client.AppendBlock(bw.container, bw.path, p[offset:offset+chunkSize])
+		err := bw.client.AppendBlock(bw.container, bw.path, p[offset:offset+chunkSize], nil)
 		if err != nil {
 			return n, err
 		}

--- a/vendor/github.com/Azure/azure-sdk-for-go/LICENSE
+++ b/vendor/github.com/Azure/azure-sdk-for-go/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2016 Microsoft Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/README.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/README.md
@@ -1,0 +1,5 @@
+# Azure Storage SDK for Go
+
+The `github.com/Azure/azure-sdk-for-go/storage` package is used to perform operations in Azure Storage Service. To manage your storage accounts (Azure Resource Manager / ARM), use the [github.com/Azure/azure-sdk-for-go/arm/storage](../arm/storage) package. For your classic storage accounts (Azure Service Management / ASM), use [github.com/Azure/azure-sdk-for-go/management/storageservice](../management/storageservice) package.
+
+This package includes support for [Azure Storage Emulator](https://azure.microsoft.com/documentation/articles/storage-use-emulator/)

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/file.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/file.go
@@ -1,9 +1,11 @@
 package storage
 
 import (
+	"encoding/xml"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // FileServiceClient contains operations for Microsoft Azure File Service.
@@ -11,9 +13,97 @@ type FileServiceClient struct {
 	client Client
 }
 
+// A Share is an entry in ShareListResponse.
+type Share struct {
+	Name       string          `xml:"Name"`
+	Properties ShareProperties `xml:"Properties"`
+}
+
+// ShareProperties contains various properties of a share returned from
+// various endpoints like ListShares.
+type ShareProperties struct {
+	LastModified string `xml:"Last-Modified"`
+	Etag         string `xml:"Etag"`
+	Quota        string `xml:"Quota"`
+}
+
+// ShareListResponse contains the response fields from
+// ListShares call.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn167009.aspx
+type ShareListResponse struct {
+	XMLName    xml.Name `xml:"EnumerationResults"`
+	Xmlns      string   `xml:"xmlns,attr"`
+	Prefix     string   `xml:"Prefix"`
+	Marker     string   `xml:"Marker"`
+	NextMarker string   `xml:"NextMarker"`
+	MaxResults int64    `xml:"MaxResults"`
+	Shares     []Share  `xml:"Shares>Share"`
+}
+
+// ListSharesParameters defines the set of customizable parameters to make a
+// List Shares call.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dn167009.aspx
+type ListSharesParameters struct {
+	Prefix     string
+	Marker     string
+	Include    string
+	MaxResults uint
+	Timeout    uint
+}
+
+// ShareHeaders contains various properties of a file and is an entry
+// in SetShareProperties
+type ShareHeaders struct {
+	Quota string `header:"x-ms-share-quota"`
+}
+
+func (p ListSharesParameters) getParameters() url.Values {
+	out := url.Values{}
+
+	if p.Prefix != "" {
+		out.Set("prefix", p.Prefix)
+	}
+	if p.Marker != "" {
+		out.Set("marker", p.Marker)
+	}
+	if p.Include != "" {
+		out.Set("include", p.Include)
+	}
+	if p.MaxResults != 0 {
+		out.Set("maxresults", fmt.Sprintf("%v", p.MaxResults))
+	}
+	if p.Timeout != 0 {
+		out.Set("timeout", fmt.Sprintf("%v", p.Timeout))
+	}
+
+	return out
+}
+
 // pathForFileShare returns the URL path segment for a File Share resource
 func pathForFileShare(name string) string {
 	return fmt.Sprintf("/%s", name)
+}
+
+// ListShares returns the list of shares in a storage account along with
+// pagination token and other response details.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dd179352.aspx
+func (f FileServiceClient) ListShares(params ListSharesParameters) (ShareListResponse, error) {
+	q := mergeParams(params.getParameters(), url.Values{"comp": {"list"}})
+	uri := f.client.getEndpoint(fileServiceName, "", q)
+	headers := f.client.getStandardHeaders()
+
+	var out ShareListResponse
+	resp, err := f.client.exec("GET", uri, headers, nil)
+	if err != nil {
+		return out, err
+	}
+	defer resp.body.Close()
+
+	err = xmlUnmarshal(resp.body, &out)
+	return out, err
 }
 
 // CreateShare operation creates a new share under the specified account. If the
@@ -27,6 +117,30 @@ func (f FileServiceClient) CreateShare(name string) error {
 	}
 	defer resp.body.Close()
 	return checkRespCode(resp.statusCode, []int{http.StatusCreated})
+}
+
+// ShareExists returns true if a share with given name exists
+// on the storage account, otherwise returns false.
+func (f FileServiceClient) ShareExists(name string) (bool, error) {
+	uri := f.client.getEndpoint(fileServiceName, pathForFileShare(name), url.Values{"restype": {"share"}})
+	headers := f.client.getStandardHeaders()
+
+	resp, err := f.client.exec("HEAD", uri, headers, nil)
+	if resp != nil {
+		defer resp.body.Close()
+		if resp.statusCode == http.StatusOK || resp.statusCode == http.StatusNotFound {
+			return resp.statusCode == http.StatusOK, nil
+		}
+	}
+	return false, err
+}
+
+// GetShareURL gets the canonical URL to the share with the specified name in the
+// specified container. This method does not create a publicly accessible URL if
+// the file is private and this method does not check if the file
+// exists.
+func (f FileServiceClient) GetShareURL(name string) string {
+	return f.client.getEndpoint(fileServiceName, pathForFileShare(name), url.Values{})
 }
 
 // CreateShareIfNotExists creates a new share under the specified account if
@@ -47,9 +161,66 @@ func (f FileServiceClient) CreateShareIfNotExists(name string) (bool, error) {
 
 // CreateShare creates a Azure File Share and returns its response
 func (f FileServiceClient) createShare(name string) (*storageResponse, error) {
+	if err := f.checkForStorageEmulator(); err != nil {
+		return nil, err
+	}
 	uri := f.client.getEndpoint(fileServiceName, pathForFileShare(name), url.Values{"restype": {"share"}})
 	headers := f.client.getStandardHeaders()
 	return f.client.exec("PUT", uri, headers, nil)
+}
+
+// GetShareProperties provides various information about the specified
+// file. See https://msdn.microsoft.com/en-us/library/azure/dn689099.aspx
+func (f FileServiceClient) GetShareProperties(name string) (*ShareProperties, error) {
+	uri := f.client.getEndpoint(fileServiceName, pathForFileShare(name), url.Values{"restype": {"share"}})
+
+	headers := f.client.getStandardHeaders()
+	resp, err := f.client.exec("HEAD", uri, headers, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		return nil, err
+	}
+
+	return &ShareProperties{
+		LastModified: resp.headers.Get("Last-Modified"),
+		Etag:         resp.headers.Get("Etag"),
+		Quota:        resp.headers.Get("x-ms-share-quota"),
+	}, nil
+}
+
+// SetShareProperties replaces the ShareHeaders for the specified file.
+//
+// Some keys may be converted to Camel-Case before sending. All keys
+// are returned in lower case by SetShareProperties. HTTP header names
+// are case-insensitive so case munging should not matter to other
+// applications either.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/mt427368.aspx
+func (f FileServiceClient) SetShareProperties(name string, shareHeaders ShareHeaders) error {
+	params := url.Values{}
+	params.Set("restype", "share")
+	params.Set("comp", "properties")
+
+	uri := f.client.getEndpoint(fileServiceName, pathForFileShare(name), params)
+	headers := f.client.getStandardHeaders()
+
+	extraHeaders := headersFromStruct(shareHeaders)
+
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
+
+	resp, err := f.client.exec("PUT", uri, headers, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+
+	return checkRespCode(resp.statusCode, []int{http.StatusOK})
 }
 
 // DeleteShare operation marks the specified share for deletion. The share
@@ -86,6 +257,96 @@ func (f FileServiceClient) DeleteShareIfExists(name string) (bool, error) {
 // deleteShare makes the call to Delete Share operation endpoint and returns
 // the response
 func (f FileServiceClient) deleteShare(name string) (*storageResponse, error) {
+	if err := f.checkForStorageEmulator(); err != nil {
+		return nil, err
+	}
 	uri := f.client.getEndpoint(fileServiceName, pathForFileShare(name), url.Values{"restype": {"share"}})
 	return f.client.exec("DELETE", uri, f.client.getStandardHeaders(), nil)
+}
+
+// SetShareMetadata replaces the metadata for the specified Share.
+//
+// Some keys may be converted to Camel-Case before sending. All keys
+// are returned in lower case by GetShareMetadata. HTTP header names
+// are case-insensitive so case munging should not matter to other
+// applications either.
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dd179414.aspx
+func (f FileServiceClient) SetShareMetadata(name string, metadata map[string]string, extraHeaders map[string]string) error {
+	params := url.Values{}
+	params.Set("restype", "share")
+	params.Set("comp", "metadata")
+
+	uri := f.client.getEndpoint(fileServiceName, pathForFileShare(name), params)
+	headers := f.client.getStandardHeaders()
+	for k, v := range metadata {
+		headers[userDefinedMetadataHeaderPrefix+k] = v
+	}
+
+	for k, v := range extraHeaders {
+		headers[k] = v
+	}
+
+	resp, err := f.client.exec("PUT", uri, headers, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+
+	return checkRespCode(resp.statusCode, []int{http.StatusOK})
+}
+
+// GetShareMetadata returns all user-defined metadata for the specified share.
+//
+// All metadata keys will be returned in lower case. (HTTP header
+// names are case-insensitive.)
+//
+// See https://msdn.microsoft.com/en-us/library/azure/dd179414.aspx
+func (f FileServiceClient) GetShareMetadata(name string) (map[string]string, error) {
+	params := url.Values{}
+	params.Set("restype", "share")
+	params.Set("comp", "metadata")
+
+	uri := f.client.getEndpoint(fileServiceName, pathForFileShare(name), params)
+	headers := f.client.getStandardHeaders()
+
+	resp, err := f.client.exec("GET", uri, headers, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		return nil, err
+	}
+
+	metadata := make(map[string]string)
+	for k, v := range resp.headers {
+		// Can't trust CanonicalHeaderKey() to munge case
+		// reliably. "_" is allowed in identifiers:
+		// https://msdn.microsoft.com/en-us/library/azure/dd179414.aspx
+		// https://msdn.microsoft.com/library/aa664670(VS.71).aspx
+		// http://tools.ietf.org/html/rfc7230#section-3.2
+		// ...but "_" is considered invalid by
+		// CanonicalMIMEHeaderKey in
+		// https://golang.org/src/net/textproto/reader.go?s=14615:14659#L542
+		// so k can be "X-Ms-Meta-Foo" or "x-ms-meta-foo_bar".
+		k = strings.ToLower(k)
+		if len(v) == 0 || !strings.HasPrefix(k, strings.ToLower(userDefinedMetadataHeaderPrefix)) {
+			continue
+		}
+		// metadata["foo"] = content of the last X-Ms-Meta-Foo header
+		k = k[len(userDefinedMetadataHeaderPrefix):]
+		metadata[k] = v[len(v)-1]
+	}
+	return metadata, nil
+}
+
+//checkForStorageEmulator determines if the client is setup for use with
+//Azure Storage Emulator, and returns a relevant error
+func (f FileServiceClient) checkForStorageEmulator() error {
+	if f.client.accountName == StorageEmulatorAccountName {
+		return fmt.Errorf("Error: File service is not currently supported by Azure Storage Emulator")
+	}
+	return nil
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/table.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/table.go
@@ -1,0 +1,129 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// TableServiceClient contains operations for Microsoft Azure Table Storage
+// Service.
+type TableServiceClient struct {
+	client Client
+}
+
+// AzureTable is the typedef of the Azure Table name
+type AzureTable string
+
+const (
+	tablesURIPath = "/Tables"
+)
+
+type createTableRequest struct {
+	TableName string `json:"TableName"`
+}
+
+func pathForTable(table AzureTable) string { return fmt.Sprintf("%s", table) }
+
+func (c *TableServiceClient) getStandardHeaders() map[string]string {
+	return map[string]string{
+		"x-ms-version":   "2015-02-21",
+		"x-ms-date":      currentTimeRfc1123Formatted(),
+		"Accept":         "application/json;odata=nometadata",
+		"Accept-Charset": "UTF-8",
+		"Content-Type":   "application/json",
+	}
+}
+
+// QueryTables returns the tables created in the
+// *TableServiceClient storage account.
+func (c *TableServiceClient) QueryTables() ([]AzureTable, error) {
+	uri := c.client.getEndpoint(tableServiceName, tablesURIPath, url.Values{})
+
+	headers := c.getStandardHeaders()
+	headers["Content-Length"] = "0"
+
+	resp, err := c.client.execTable("GET", uri, headers, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.body)
+
+	var respArray queryTablesResponse
+	if err := json.Unmarshal(buf.Bytes(), &respArray); err != nil {
+		return nil, err
+	}
+
+	s := make([]AzureTable, len(respArray.TableName))
+	for i, elem := range respArray.TableName {
+		s[i] = AzureTable(elem.TableName)
+	}
+
+	return s, nil
+}
+
+// CreateTable creates the table given the specific
+// name. This function fails if the name is not compliant
+// with the specification or the tables already exists.
+func (c *TableServiceClient) CreateTable(table AzureTable) error {
+	uri := c.client.getEndpoint(tableServiceName, tablesURIPath, url.Values{})
+
+	headers := c.getStandardHeaders()
+
+	req := createTableRequest{TableName: string(table)}
+	buf := new(bytes.Buffer)
+
+	if err := json.NewEncoder(buf).Encode(req); err != nil {
+		return err
+	}
+
+	headers["Content-Length"] = fmt.Sprintf("%d", buf.Len())
+
+	resp, err := c.client.execTable("POST", uri, headers, buf)
+
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusCreated}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteTable deletes the table given the specific
+// name. This function fails if the table is not present.
+// Be advised: DeleteTable deletes all the entries
+// that may be present.
+func (c *TableServiceClient) DeleteTable(table AzureTable) error {
+	uri := c.client.getEndpoint(tableServiceName, tablesURIPath, url.Values{})
+	uri += fmt.Sprintf("('%s')", string(table))
+
+	headers := c.getStandardHeaders()
+
+	headers["Content-Length"] = "0"
+
+	resp, err := c.client.execTable("DELETE", uri, headers, nil)
+
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusNoContent}); err != nil {
+		return err
+
+	}
+	return nil
+}

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/table_entities.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/table_entities.go
@@ -1,0 +1,355 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+)
+
+const (
+	partitionKeyNode                    = "PartitionKey"
+	rowKeyNode                          = "RowKey"
+	tag                                 = "table"
+	tagIgnore                           = "-"
+	continuationTokenPartitionKeyHeader = "X-Ms-Continuation-Nextpartitionkey"
+	continuationTokenRowHeader          = "X-Ms-Continuation-Nextrowkey"
+	maxTopParameter                     = 1000
+)
+
+type queryTablesResponse struct {
+	TableName []struct {
+		TableName string `json:"TableName"`
+	} `json:"value"`
+}
+
+const (
+	tableOperationTypeInsert          = iota
+	tableOperationTypeUpdate          = iota
+	tableOperationTypeMerge           = iota
+	tableOperationTypeInsertOrReplace = iota
+	tableOperationTypeInsertOrMerge   = iota
+)
+
+type tableOperation int
+
+// TableEntity interface specifies
+// the functions needed to support
+// marshaling and unmarshaling into
+// Azure Tables. The struct must only contain
+// simple types because Azure Tables do not
+// support hierarchy.
+type TableEntity interface {
+	PartitionKey() string
+	RowKey() string
+	SetPartitionKey(string) error
+	SetRowKey(string) error
+}
+
+// ContinuationToken is an opaque (ie not useful to inspect)
+// struct that Get... methods can return if there are more
+// entries to be returned than the ones already
+// returned. Just pass it to the same function to continue
+// receiving the remaining entries.
+type ContinuationToken struct {
+	NextPartitionKey string
+	NextRowKey       string
+}
+
+type getTableEntriesResponse struct {
+	Elements []map[string]interface{} `json:"value"`
+}
+
+// QueryTableEntities queries the specified table and returns the unmarshaled
+// entities of type retType.
+// top parameter limits the returned entries up to top. Maximum top
+// allowed by Azure API is 1000. In case there are more than top entries to be
+// returned the function will return a non nil *ContinuationToken. You can call the
+// same function again passing the received ContinuationToken as previousContToken
+// parameter in order to get the following entries. The query parameter
+// is the odata query. To retrieve all the entries pass the empty string.
+// The function returns a pointer to a TableEntity slice, the *ContinuationToken
+// if there are more entries to be returned and an error in case something went
+// wrong.
+//
+// Example:
+// 		entities, cToken, err = tSvc.QueryTableEntities("table", cToken, reflect.TypeOf(entity), 20, "")
+func (c *TableServiceClient) QueryTableEntities(tableName AzureTable, previousContToken *ContinuationToken, retType reflect.Type, top int, query string) ([]TableEntity, *ContinuationToken, error) {
+	if top > maxTopParameter {
+		return nil, nil, fmt.Errorf("top accepts at maximum %d elements. Requested %d instead", maxTopParameter, top)
+	}
+
+	uri := c.client.getEndpoint(tableServiceName, pathForTable(tableName), url.Values{})
+	uri += fmt.Sprintf("?$top=%d", top)
+	if query != "" {
+		uri += fmt.Sprintf("&$filter=%s", url.QueryEscape(query))
+	}
+
+	if previousContToken != nil {
+		uri += fmt.Sprintf("&NextPartitionKey=%s&NextRowKey=%s", previousContToken.NextPartitionKey, previousContToken.NextRowKey)
+	}
+
+	headers := c.getStandardHeaders()
+
+	headers["Content-Length"] = "0"
+
+	resp, err := c.client.execTable("GET", uri, headers, nil)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	contToken := extractContinuationTokenFromHeaders(resp.headers)
+
+	if err != nil {
+		return nil, contToken, err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusOK}); err != nil {
+		return nil, contToken, err
+	}
+
+	retEntries, err := deserializeEntity(retType, resp.body)
+	if err != nil {
+		return nil, contToken, err
+	}
+
+	return retEntries, contToken, nil
+}
+
+// InsertEntity inserts an entity in the specified table.
+// The function fails if there is an entity with the same
+// PartitionKey and RowKey in the table.
+func (c *TableServiceClient) InsertEntity(table AzureTable, entity TableEntity) error {
+	var err error
+
+	if sc, err := c.execTable(table, entity, false, "POST"); err != nil {
+		return checkRespCode(sc, []int{http.StatusCreated})
+	}
+
+	return err
+}
+
+func (c *TableServiceClient) execTable(table AzureTable, entity TableEntity, specifyKeysInURL bool, method string) (int, error) {
+	uri := c.client.getEndpoint(tableServiceName, pathForTable(table), url.Values{})
+	if specifyKeysInURL {
+		uri += fmt.Sprintf("(PartitionKey='%s',RowKey='%s')", url.QueryEscape(entity.PartitionKey()), url.QueryEscape(entity.RowKey()))
+	}
+
+	headers := c.getStandardHeaders()
+
+	var buf bytes.Buffer
+
+	if err := injectPartitionAndRowKeys(entity, &buf); err != nil {
+		return 0, err
+	}
+
+	headers["Content-Length"] = fmt.Sprintf("%d", buf.Len())
+
+	var err error
+	var resp *odataResponse
+
+	resp, err = c.client.execTable(method, uri, headers, &buf)
+
+	if err != nil {
+		return 0, err
+	}
+
+	defer resp.body.Close()
+
+	return resp.statusCode, nil
+}
+
+// UpdateEntity updates the contents of an entity with the
+// one passed as parameter. The function fails if there is no entity
+// with the same PartitionKey and RowKey in the table.
+func (c *TableServiceClient) UpdateEntity(table AzureTable, entity TableEntity) error {
+	var err error
+
+	if sc, err := c.execTable(table, entity, true, "PUT"); err != nil {
+		return checkRespCode(sc, []int{http.StatusNoContent})
+	}
+	return err
+}
+
+// MergeEntity merges the contents of an entity with the
+// one passed as parameter.
+// The function fails if there is no entity
+// with the same PartitionKey and RowKey in the table.
+func (c *TableServiceClient) MergeEntity(table AzureTable, entity TableEntity) error {
+	var err error
+
+	if sc, err := c.execTable(table, entity, true, "MERGE"); err != nil {
+		return checkRespCode(sc, []int{http.StatusNoContent})
+	}
+	return err
+}
+
+// DeleteEntityWithoutCheck deletes the entity matching by
+// PartitionKey and RowKey. There is no check on IfMatch
+// parameter so the entity is always deleted.
+// The function fails if there is no entity
+// with the same PartitionKey and RowKey in the table.
+func (c *TableServiceClient) DeleteEntityWithoutCheck(table AzureTable, entity TableEntity) error {
+	return c.DeleteEntity(table, entity, "*")
+}
+
+// DeleteEntity deletes the entity matching by
+// PartitionKey, RowKey and ifMatch field.
+// The function fails if there is no entity
+// with the same PartitionKey and RowKey in the table or
+// the ifMatch is different.
+func (c *TableServiceClient) DeleteEntity(table AzureTable, entity TableEntity, ifMatch string) error {
+	uri := c.client.getEndpoint(tableServiceName, pathForTable(table), url.Values{})
+	uri += fmt.Sprintf("(PartitionKey='%s',RowKey='%s')", url.QueryEscape(entity.PartitionKey()), url.QueryEscape(entity.RowKey()))
+
+	headers := c.getStandardHeaders()
+
+	headers["Content-Length"] = "0"
+	headers["If-Match"] = ifMatch
+
+	resp, err := c.client.execTable("DELETE", uri, headers, nil)
+
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+
+	if err := checkRespCode(resp.statusCode, []int{http.StatusNoContent}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InsertOrReplaceEntity inserts an entity in the specified table
+// or replaced the existing one.
+func (c *TableServiceClient) InsertOrReplaceEntity(table AzureTable, entity TableEntity) error {
+	var err error
+
+	if sc, err := c.execTable(table, entity, true, "PUT"); err != nil {
+		return checkRespCode(sc, []int{http.StatusNoContent})
+	}
+	return err
+}
+
+// InsertOrMergeEntity inserts an entity in the specified table
+// or merges the existing one.
+func (c *TableServiceClient) InsertOrMergeEntity(table AzureTable, entity TableEntity) error {
+	var err error
+
+	if sc, err := c.execTable(table, entity, true, "MERGE"); err != nil {
+		return checkRespCode(sc, []int{http.StatusNoContent})
+	}
+	return err
+}
+
+func injectPartitionAndRowKeys(entity TableEntity, buf *bytes.Buffer) error {
+	if err := json.NewEncoder(buf).Encode(entity); err != nil {
+		return err
+	}
+
+	dec := make(map[string]interface{})
+	if err := json.NewDecoder(buf).Decode(&dec); err != nil {
+		return err
+	}
+
+	// Inject PartitionKey and RowKey
+	dec[partitionKeyNode] = entity.PartitionKey()
+	dec[rowKeyNode] = entity.RowKey()
+
+	// Remove tagged fields
+	// The tag is defined in the const section
+	// This is useful to avoid storing the PartitionKey and RowKey twice.
+	numFields := reflect.ValueOf(entity).Elem().NumField()
+	for i := 0; i < numFields; i++ {
+		f := reflect.ValueOf(entity).Elem().Type().Field(i)
+
+		if f.Tag.Get(tag) == tagIgnore {
+			// we must look for its JSON name in the dictionary
+			// as the user can rename it using a tag
+			jsonName := f.Name
+			if f.Tag.Get("json") != "" {
+				jsonName = f.Tag.Get("json")
+			}
+			delete(dec, jsonName)
+		}
+	}
+
+	buf.Reset()
+
+	if err := json.NewEncoder(buf).Encode(&dec); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deserializeEntity(retType reflect.Type, reader io.Reader) ([]TableEntity, error) {
+	buf := new(bytes.Buffer)
+
+	var ret getTableEntriesResponse
+	if err := json.NewDecoder(reader).Decode(&ret); err != nil {
+		return nil, err
+	}
+
+	tEntries := make([]TableEntity, len(ret.Elements))
+
+	for i, entry := range ret.Elements {
+
+		buf.Reset()
+		if err := json.NewEncoder(buf).Encode(entry); err != nil {
+			return nil, err
+		}
+
+		dec := make(map[string]interface{})
+		if err := json.NewDecoder(buf).Decode(&dec); err != nil {
+			return nil, err
+		}
+
+		var pKey, rKey string
+		// strip pk and rk
+		for key, val := range dec {
+			switch key {
+			case partitionKeyNode:
+				pKey = val.(string)
+			case rowKeyNode:
+				rKey = val.(string)
+			}
+		}
+
+		delete(dec, partitionKeyNode)
+		delete(dec, rowKeyNode)
+
+		buf.Reset()
+		if err := json.NewEncoder(buf).Encode(dec); err != nil {
+			return nil, err
+		}
+
+		// Create a empty retType instance
+		tEntries[i] = reflect.New(retType.Elem()).Interface().(TableEntity)
+		// Popolate it with the values
+		if err := json.NewDecoder(buf).Decode(&tEntries[i]); err != nil {
+			return nil, err
+		}
+
+		// Reset PartitionKey and RowKey
+		tEntries[i].SetPartitionKey(pKey)
+		tEntries[i].SetRowKey(rKey)
+	}
+
+	return tEntries, nil
+}
+
+func extractContinuationTokenFromHeaders(h http.Header) *ContinuationToken {
+	ct := ContinuationToken{h.Get(continuationTokenPartitionKeyHeader), h.Get(continuationTokenRowHeader)}
+
+	if ct.NextPartitionKey != "" && ct.NextRowKey != "" {
+		return &ct
+	}
+	return nil
+}

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/util.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/util.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"time"
 )
 
@@ -68,4 +69,17 @@ func xmlMarshal(v interface{}) (io.Reader, int, error) {
 		return nil, 0, err
 	}
 	return bytes.NewReader(b), len(b), nil
+}
+
+func headersFromStruct(v interface{}) map[string]string {
+	headers := make(map[string]string)
+	value := reflect.ValueOf(v)
+	for i := 0; i < value.NumField(); i++ {
+		key := value.Type().Field(i).Tag.Get("header")
+		val := value.Field(i).String()
+		if val != "" {
+			headers[key] = val
+		}
+	}
+	return headers
 }


### PR DESCRIPTION
Updating to a recent version of Azure Storage SDK to be
able to **patch some memory leaks** through configurable HTTP client
change added to the registry recently.
