### PR TITLE
registry/handles/app: always append default urls regexps

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -188,8 +188,11 @@ type Configuration struct {
 
 	// Validation configures validation options for the registry.
 	Validation struct {
-		// Enabled enables the other options in this section.
+		// Enabled enables the other options in this section. This field is
+		// deprecated in favor of Disabled.
 		Enabled bool `yaml:"enabled,omitempty"`
+		// Disabled disables the other options in this section.
+		Disabled bool `yaml:"disabled,omitempty"`
 		// Manifests configures manifest validation.
 		Manifests struct {
 			// URLs configures validation for URLs in pushed manifests.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,7 +251,6 @@ information about each option that appears later in this page.
       schema1:
         signingkeyfile: /etc/registry/key.json
     validation:
-      enabled: true
       manifests:
         urls:
           allow:
@@ -1871,7 +1870,6 @@ defines such a feature with configurable behavior.
 ## Validation
 
     validation:
-      enabled: true
       manifests:
         urls:
           allow:
@@ -1879,16 +1877,18 @@ defines such a feature with configurable behavior.
           deny:
             - ^https?://www\.example\.com/
 
-### Enabled
+### disabled
 
-Use the `enabled` flag to enable the other options in the `validation`
-section. They are disabled by default.
+Use the `disabled` flag to disable the other options in the `validation`
+section. They are enabled by default.
+This option deprecates the `enabled` flag.
 
-### Manifests
+### manifests
 
-Use the `manifest` subsection to configure manifest validation.
+Use the `manifests` subsection to configure manifests validation. If `disabled` is
+`false` the validation allows nothing.
 
-#### URLs
+#### urls
 
 The `allow` and `deny` options are both lists of
 [regular expressions](https://godoc.org/regexp/syntax) that restrict the URLs in

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -213,6 +213,10 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		options = append(options, storage.EnableRedirect)
 	}
 
+	if !config.Validation.Enabled {
+		config.Validation.Enabled = !config.Validation.Disabled
+	}
+
 	// configure validation
 	if config.Validation.Enabled {
 		if len(config.Validation.Manifests.URLs.Allow) == 0 && len(config.Validation.Manifests.URLs.Deny) == 0 {


### PR DESCRIPTION
Even when validation is off, we don't want to allow manifests with foreign layers urls.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>