### PR TITLE
v2 signer: correctly sort headers

### DIFF
--- a/registry/storage/driver/s3-aws/s3_v2_signer.go
+++ b/registry/storage/driver/s3-aws/s3_v2_signer.go
@@ -124,6 +124,8 @@ func (v2 *signer) Sign() error {
 		md5, ctype, date, xamz string
 		xamzDate               bool
 		sarray                 []string
+		smap                   map[string]string
+		sharray                []string
 	)
 
 	headers := v2.Request.Header
@@ -136,6 +138,7 @@ func (v2 *signer) Sign() error {
 	v2.Request.Header["Host"] = []string{host}
 	v2.Request.Header["date"] = []string{v2.Time.In(time.UTC).Format(time.RFC1123)}
 
+	smap = make(map[string]string)
 	for k, v := range headers {
 		k = strings.ToLower(k)
 		switch k {
@@ -150,16 +153,20 @@ func (v2 *signer) Sign() error {
 		default:
 			if strings.HasPrefix(k, "x-amz-") {
 				vall := strings.Join(v, ",")
-				sarray = append(sarray, k+":"+vall)
+				smap[k] = k+":"+vall
 				if k == "x-amz-date" {
 					xamzDate = true
 					date = ""
 				}
+				sharray = append(sharray, k)
 			}
 		}
 	}
-	if len(sarray) > 0 {
-		sort.StringSlice(sarray).Sort()
+	if len(sharray) > 0 {
+		sort.StringSlice(sharray).Sort()
+		for _, h := range(sharray) {
+			sarray = append(sarray, smap[h])
+		}
 		xamz = strings.Join(sarray, "\n") + "\n"
 	}
 

--- a/registry/storage/driver/s3-aws/s3_v2_signer.go
+++ b/registry/storage/driver/s3-aws/s3_v2_signer.go
@@ -153,7 +153,7 @@ func (v2 *signer) Sign() error {
 		default:
 			if strings.HasPrefix(k, "x-amz-") {
 				vall := strings.Join(v, ",")
-				smap[k] = k+":"+vall
+				smap[k] = k + ":" + vall
 				if k == "x-amz-date" {
 					xamzDate = true
 					date = ""
@@ -164,7 +164,7 @@ func (v2 *signer) Sign() error {
 	}
 	if len(sharray) > 0 {
 		sort.StringSlice(sharray).Sort()
-		for _, h := range(sharray) {
+		for _, h := range sharray {
 			sarray = append(sarray, smap[h])
 		}
 		xamz = strings.Join(sarray, "\n") + "\n"


### PR DESCRIPTION
The current code determines the header order for the
"string-to-sign" payload by sorting on the concatenation
of headers and values, whereas it should only happen on the
key.

During multipart uploads, since `x-amz-copy-source-range` and
`x-amz-copy-source` headers are present, V2 signatures fail to
validate since header order is swapped.

This patch reverts to the expected behavior.

Signed-off-by: Pierre-Yves Ritschard <pyr@spootnik.org>