### PR TITLE
[#2045] s3-goamz can configure on-prem S3  endpoint

### DIFF
--- a/registry/storage/driver/s3-goamz/s3_test.go
+++ b/registry/storage/driver/s3-goamz/s3_test.go
@@ -29,6 +29,7 @@ func init() {
 	secure := os.Getenv("S3_SECURE")
 	v4auth := os.Getenv("S3_USE_V4_AUTH")
 	region := os.Getenv("AWS_REGION")
+	regionEndpoint := os.Getenv("AWS_REGIONENDPOINT")
 	root, err := ioutil.TempDir("", "driver-")
 	if err != nil {
 		panic(err)
@@ -65,6 +66,7 @@ func init() {
 			secretKey,
 			bucket,
 			aws.GetRegion(region),
+			regionEndpoint,
 			encryptBool,
 			secureBool,
 			v4AuthBool,


### PR DESCRIPTION
The existing driver implementation allows only a well know region.

We try to use the driver internally to our own s3 storage. 