### PR TITLE
Distinguish ErrorCodeManifestBlobUnknown message

### DIFF
--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -97,7 +97,7 @@ var (
 	// unknown to the registry.
 	ErrorCodeManifestBlobUnknown = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:   "MANIFEST_BLOB_UNKNOWN",
-		Message: "blob unknown to registry",
+		Message: "manifest blob unknown to registry",
 		Description: `This error may be returned when a manifest blob is 
 		unknown to the registry.`,
 		HTTPStatusCode: http.StatusBadRequest,


### PR DESCRIPTION
Both "ErrorCodeManifestBlobUnknown" and "ErrorCodeBlobUnknown" have the same `message` (which gets logged as `error.code` field), making it hard to distinguish.

We're seeing error.code="blob unknown" in the logs and can't distinguish which one is which.