### PR TITLE
switch to v1 and remove .image

### DIFF
--- a/docs/spec/manifest-v2-2.md
+++ b/docs/spec/manifest-v2-2.md
@@ -30,6 +30,7 @@ the resources they reference:
 - `application/vnd.docker.container.image.v1+json`: Container config JSON
 - `application/vnd.docker.image.rootfs.diff.tar.gzip`: "Layer", as a gzipped tar
 - `application/vnd.docker.image.rootfs.foreign.diff.tar.gzip`: "Layer", as a gzipped tar that should never be pushed
+- `application/vnd.docker.plugin.v1+json`: Plugin config JSON
 
 ## Manifest List
 

--- a/manifest/schema2/manifest.go
+++ b/manifest/schema2/manifest.go
@@ -18,7 +18,7 @@ const (
 	MediaTypeConfig = "application/vnd.docker.container.image.v1+json"
 
 	// MediaTypePluginConfig specifies the mediaType for plugin configuration.
-	MediaTypePluginConfig = "application/vnd.docker.plugin.image.v0+json"
+	MediaTypePluginConfig = "application/vnd.docker.plugin.v1+json"
 
 	// MediaTypeLayer is the mediaType used for layers referenced by the
 	// manifest.


### PR DESCRIPTION
plugins are going out of experimental so let's bump to v1, also @stevvooe suggested we remove `.image`