### PR TITLE
Add trim name method helper to create name only references

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -261,6 +261,11 @@ func Match(pattern string, ref Reference) (bool, error) {
 	return matched, err
 }
 
+// TrimNamed removes any tag or digest from the named reference.
+func TrimNamed(ref Named) Named {
+	return repository(ref.Name())
+}
+
 func getBestReferenceType(ref reference) Reference {
 	if ref.name == "" {
 		// Allow digest only references


### PR DESCRIPTION
Add a simple helper to create name only references without having to first get the name as a string and reparse. This method does not fail so ignoring or checking error to simply trim reference is not required.

Ping @tonistiigi @aaronlehmann 