### PR TITLE
Adding utility functions - IsNameOnly and EnsureTagged

### DIFF
--- a/reference/helpers.go
+++ b/reference/helpers.go
@@ -1,0 +1,12 @@
+package reference
+
+// IsNameOnly returns true if reference only contains a repo name.
+func IsNameOnly(ref Named) bool {
+	if _, ok := ref.(NamedTagged); ok {
+		return false
+	}
+	if _, ok := ref.(Canonical); ok {
+		return false
+	}
+	return true
+}

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -1,0 +1,22 @@
+package reference
+
+var (
+	defaultTag = "latest"
+)
+
+// EnsureTagged adds the default tag "latest" to a reference if it only has
+// a repo name.
+func EnsureTagged(ref Named) NamedTagged {
+	namedTagged, ok := ref.(NamedTagged)
+	if !ok {
+		namedTagged, err := WithTag(ref, defaultTag)
+		if err != nil {
+			// Default tag must be valid, to create a NamedTagged
+			// type with non-validated input the WithTag function
+			// should be used instead
+			panic(err)
+		}
+		return namedTagged
+	}
+	return namedTagged
+}


### PR DESCRIPTION
`IsNameOnly` and `WithDefaultTag` aren't present in `docker/docker/reference`, but useful trivial utility functions. This also reduces the gap between the the Docker reference package and the one in this repo.

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>