### PR TITLE
Remove newlines from end of error strings

### DIFF
--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -80,7 +80,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to mark: %v\n", err)
+		return fmt.Errorf("failed to mark: %v", err)
 	}
 
 	// sweep
@@ -106,7 +106,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 		}
 		err = vacuum.RemoveBlob(string(dgst))
 		if err != nil {
-			return fmt.Errorf("failed to delete blob %s: %v\n", dgst, err)
+			return fmt.Errorf("failed to delete blob %s: %v", dgst, err)
 		}
 	}
 


### PR DESCRIPTION
Golint now checks for new lines at the end of go error strings, remove these unneeded new lines.