### PR TITLE
fix filechecker in health with precondition check

### DIFF
--- a/health/checks/checks.go
+++ b/health/checks/checks.go
@@ -2,9 +2,11 @@ package checks
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -15,10 +17,19 @@ import (
 // if the file exists.
 func FileChecker(f string) health.Checker {
 	return health.CheckFunc(func() error {
-		if _, err := os.Stat(f); err == nil {
-			return errors.New("file exists")
+		absoluteFilePath, err := filepath.Abs(f)
+		if err != nil {
+			return fmt.Errorf("failed to get absolute path for %q: %v", f, err)
 		}
-		return nil
+
+		_, err = os.Stat(absoluteFilePath)
+		if err == nil {
+			return errors.New("file exists")
+		} else if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
 	})
 }
 

--- a/health/doc.go
+++ b/health/doc.go
@@ -122,6 +122,11 @@
 //  # curl localhost:5001/debug/health
 //  {"fileChecker":"file exists"}
 //
+// FileChecker only accepts absolute or relative file path. It does not work properly with tilde(~).
+// You should make sure that the application has proper permission(read and execute permission
+// for directory along with the specified file path). Otherwise, the FileChecker will report error
+// and file health check is not ok.
+//
 // You could also test the connectivity to a downstream service by using a
 // "HTTPChecker", but ensure that you only mark the test unhealthy if there
 // are a minimum of two failures in a row:


### PR DESCRIPTION
This PR is a migration of #2049 

FileChecker can not work properly when the specified file can not be Stat because the app has no proper permission (read and execute permission for directory along with the specified file path). This should be make clear to end users and under such circumstance, FileChecker should return error instead nil to make the precondition ready. Otherwise, we can not actually disable the app by touch the disable file.

We should also add more document about the usage of FileChecker.

FileChecker only accepts absolute or relative file path. It does not work properly with tilde(~). You should make sure that the application has proper permission(read and execute permission for directory along with the specified file path). Otherwise, the FileChecker will report error and file health check is not ok.
Also, this PR will add support for relative path. And, if it can not be expanded to the corresponding absolute path, an error will be returned by FileChecker. This is also one precondition that can make FileChecker work when we want to disable one app by touching a disable file. :)