### PR TITLE
fix panic when using storage redirect middleware

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/docker/distribution/registry/storage/driver/gcs"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 	_ "github.com/docker/distribution/registry/storage/driver/middleware/cloudfront"
+	_ "github.com/docker/distribution/registry/storage/driver/middleware/redirect"
 	_ "github.com/docker/distribution/registry/storage/driver/oss"
 	_ "github.com/docker/distribution/registry/storage/driver/s3-aws"
 	_ "github.com/docker/distribution/registry/storage/driver/s3-goamz"


### PR DESCRIPTION
fix panic when using storage redirect middleware in registry version 2.5.1
When we start registry with storage redirect middleware in config file, it will panic. The error message can be show as follows:

```
unable to configure storage middleware (redirect): no storage middleware registered with name: redirect
```

this PR fix this problem by importing storage redirect middleware in main.go