### PR TITLE
Plugin integration test

### DIFF
--- a/contrib/docker-integration/docker-compose.yml
+++ b/contrib/docker-integration/docker-compose.yml
@@ -64,7 +64,7 @@ registryv2tokenoauthnotls:
     - ./tokenserver-oauth/certs/signing.cert:/etc/docker/registry/tokenbundle.pem
 tokenserveroauth:
   build: "tokenserver-oauth"
-  command: "--debug -addr 0.0.0.0:5559 -issuer registry-test -passwd .htpasswd -tlscert tls.cert -tlskey tls.key -key sign.key -realm http://auth.localregistry:5559"
+  command: "--debug -addr 0.0.0.0:5559 -issuer registry-test -passwd .htpasswd -tlscert tls.cert -tlskey tls.key -key sign.key -realm http://auth.localregistry:5559 -enforce-class"
   ports:
     - "5559"
 malevolent:

--- a/contrib/docker-integration/golem.conf
+++ b/contrib/docker-integration/golem.conf
@@ -1,6 +1,6 @@
 [[suite]]
   dind=true
-  images=[ "nginx:1.9", "dmcgowan/token-server:simple", "dmcgowan/token-server:oauth", "dmcgowan/malevolent:0.1.0" ]
+  images=[ "nginx:1.9", "dmcgowan/token-server:simple", "dmcgowan/token-server:oauth", "dmcgowan/malevolent:0.1.0", "dmcgowan/ncat:latest" ]
 
   [[suite.pretest]]
     command="sh ./install_certs.sh /etc/generated_certs.d"

--- a/contrib/docker-integration/helpers.bash
+++ b/contrib/docker-integration/helpers.bash
@@ -32,34 +32,43 @@ function basic_auth_version_check() {
 	fi
 }
 
+email="a@nowhere.com"
+
+# docker_t_login calls login with email depending on version
+function docker_t_login() {
+	# Only pass email field pre 1.11, no deprecation warning
+	parse_version "$GOLEM_DIND_VERSION"
+	v=$version
+	parse_version "1.11.0"
+	if [ "$v" -lt "$version" ]; then
+		run docker_t login -e $email $@
+	else
+		run docker_t login $@
+	fi
+}
+
 # login issues a login to docker to the provided server
 # uses user, password, and email variables set outside of function
 # requies bats
 function login() {
 	rm -f /root/.docker/config.json
 
-	# Only pass email field pre 1.11, no deprecation warning
+	docker_t_login -u $user -p $password $1
+	if [ "$status" -ne 0 ]; then
+		echo $output
+	fi
+	[ "$status" -eq 0 ]
+
+	# Handle different deprecation warnings
 	parse_version "$GOLEM_DIND_VERSION"
 	v=$version
 	parse_version "1.11.0"
 	if [ "$v" -lt "$version" ]; then
-		run docker_t login -u $user -p $password -e $email $1
-		if [ "$status" -ne 0 ]; then
-			echo $output
-		fi
-		[ "$status" -eq 0 ]
 		# First line is WARNING about credential save or email deprecation (maybe both)
 		[ "${lines[2]}" = "Login Succeeded" -o "${lines[1]}" = "Login Succeeded" ]
 	else
-		run docker_t login -u $user -p $password $1
-		if [ "$status" -ne 0 ]; then
-			echo $output
-		fi
-		echo $output
-		[ "$status" -eq 0 ]
 		[ "${lines[0]}" = "Login Succeeded" ]
 	fi
-
 
 }
 
@@ -109,7 +118,7 @@ function docker_t() {
 	docker exec dockerdaemon docker $@
 }
 
-# build reates a new docker image id from another image
+# build creates a new docker image id from another image
 function build() {
 	docker exec -i dockerdaemon docker build --no-cache -t $1 - <<DOCKERFILE
 FROM $2

--- a/contrib/docker-integration/plugins.bats
+++ b/contrib/docker-integration/plugins.bats
@@ -30,6 +30,8 @@ CONFIGJSON
 
 	docker export $cid | tar -x -C $plugindir/rootfs
 
+	docker rm $cid
+
 	daemontmp=$(docker exec dockerdaemon mktemp -d)
 
 	tar -c -C $plugindir . | docker exec -i dockerdaemon tar -x -C $daemontmp

--- a/contrib/docker-integration/plugins.bats
+++ b/contrib/docker-integration/plugins.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+
+# This tests pushing and pulling plugins
+
+load helpers
+
+user="testuser"
+password="testpassword"
+base="hello-world"
+
+#TODO: Create plugin image
+function create_plugin() {
+	plugindir=$(mktemp -d)
+
+	cat - > $plugindir/config.json <<CONFIGJSON
+{
+	"manifestVersion": "v0",
+	"description": "A test plugin for integration tests",
+	"entrypoint": ["/usr/bin/ncat", "-l", "-U", "//run/docker/plugins/plugin.sock"],
+	"interface" : {
+		"types": ["docker.volumedriver/1.0"],
+		"socket": "plugin.sock"
+	}
+}
+CONFIGJSON
+
+	cid=$(docker create dmcgowan/ncat:latest /bin/sh)
+
+	mkdir $plugindir/rootfs
+
+	docker export $cid | tar -x -C $plugindir/rootfs
+
+	daemontmp=$(docker exec dockerdaemon mktemp -d)
+
+	tar -c -C $plugindir . | docker exec -i dockerdaemon tar -x -C $daemontmp
+
+	docker exec dockerdaemon docker plugin create $1 $daemontmp
+
+	docker exec dockerdaemon rm -rf $daemontmp
+
+	rm -rf $plugindir
+}
+
+@test "Test plugin push and pull" {
+	version_check docker "$GOLEM_DIND_VERSION" "1.13.0-rc3"
+	version_check docker "$GOLEM_DISTRIBUTION_VERSION" "2.6.0"
+
+	login_oauth localregistry:5558
+	image="localregistry:5558/testuser/plugin1"
+
+	create_plugin $image
+
+	run docker_t plugin push $image
+	echo $output
+	[ "$status" -eq 0 ]
+
+	docker_t plugin rm $image
+
+	docker_t plugin install --grant-all-permissions $image
+}
+
+@test "Test plugin push and failed image pull" {
+	version_check docker "$GOLEM_DIND_VERSION" "1.13.0-rc3"
+	version_check docker "$GOLEM_DISTRIBUTION_VERSION" "2.6.0"
+
+
+	login_oauth localregistry:5558
+	image="localregistry:5558/testuser/plugin-not-image"
+
+	create_plugin $image
+
+	run docker_t plugin push $image
+	echo $output
+	[ "$status" -eq 0 ]
+
+	docker_t plugin rm $image
+
+	run docker_t pull $image
+
+	[ "$status" -ne 0 ]
+}
+
+@test "Test image push and failed plugin pull" {
+	version_check docker "$GOLEM_DIND_VERSION" "1.13.0-rc3"
+	version_check docker "$GOLEM_DISTRIBUTION_VERSION" "2.6.0"
+
+	login_oauth localregistry:5558
+	image="localregistry:5558/testuser/image-not-plugin"
+
+	build $image "$base:latest"
+
+	run docker_t push $image
+	echo $output
+	[ "$status" -eq 0 ]
+
+	docker_t rmi $image
+
+	run docker_t plugin install --grant-all-permissions $image
+
+	[ "$status" -ne 0 ]
+}

--- a/contrib/docker-integration/run_multiversion.sh
+++ b/contrib/docker-integration/run_multiversion.sh
@@ -54,12 +54,14 @@ time docker pull docker:1.9.1-dind
 time docker pull docker:1.10.3-dind
 time docker pull docker:1.11.1-dind
 time docker pull docker:1.12.3-dind
+time docker pull docker:1.13.0-rc5-dind
 
 golem -cache $cachedir \
 	-i "golem-distribution:latest,$distimage,$distversion" \
 	-i "golem-dind:latest,docker:1.9.1-dind,1.9.1" \
 	-i "golem-dind:latest,docker:1.10.3-dind,1.10.3" \
 	-i "golem-dind:latest,docker:1.11.1-dind,1.11.1" \
-	-i "golem-dind:latest,docker:1.12.3-dind,1.12.0" \
+	-i "golem-dind:latest,docker:1.12.3-dind,1.12.3" \
+	-i "golem-dind:latest,docker:1.13.0-rc5-dind,1.13.0" \
 	$DIR
 

--- a/contrib/docker-integration/tls.bats
+++ b/contrib/docker-integration/tls.bats
@@ -12,7 +12,6 @@ image="${base}:latest"
 # Login information, should match values in nginx/test.passwd
 user=${TEST_USER:-"testuser"}
 password=${TEST_PASSWORD:-"passpassword"}
-email="distribution@docker.com"
 
 function setup() {
 	tempImage $image

--- a/contrib/docker-integration/token.bats
+++ b/contrib/docker-integration/token.bats
@@ -6,23 +6,17 @@ load helpers
 
 user="testuser"
 password="testpassword"
-email="a@nowhere.com"
 base="hello-world"
 
 @test "Test token server login" {
-	run docker_t login -u $user -p $password -e $email localregistry:5554
-	echo $output
-	[ "$status" -eq 0 ]
-
-	# First line is WARNING about credential save or email deprecation
-	[ "${lines[2]}" = "Login Succeeded" -o "${lines[1]}" = "Login Succeeded" ]
+	login localregistry:5554
 }
 
 @test "Test token server bad login" {
-	run docker_t login -u "testuser" -p "badpassword" -e $email localregistry:5554
+	docker_t_login -u "testuser" -p "badpassword" localregistry:5554
 	[ "$status" -ne 0 ]
 
-	run docker_t login -u "baduser" -p "testpassword" -e $email localregistry:5554
+	docker_t_login -u "baduser" -p "testpassword" localregistry:5554
 	[ "$status" -ne 0 ]
 }
 
@@ -58,10 +52,10 @@ base="hello-world"
 @test "Test oauth token server bad login" {
 	version_check docker "$GOLEM_DIND_VERSION" "1.11.0"
 
-	run docker_t login -u "testuser" -p "badpassword" -e $email localregistry:5557
+	docker_t_login -u "testuser" -p "badpassword" -e $email localregistry:5557
 	[ "$status" -ne 0 ]
 
-	run docker_t login -u "baduser" -p "testpassword" -e $email localregistry:5557
+	docker_t_login -u "baduser" -p "testpassword" -e $email localregistry:5557
 	[ "$status" -ne 0 ]
 }
 

--- a/contrib/docker-integration/tokenserver-oauth/Dockerfile
+++ b/contrib/docker-integration/tokenserver-oauth/Dockerfile
@@ -1,4 +1,4 @@
-FROM dmcgowan/token-server:oauth
+FROM dmcgowan/token-server@sha256:5a6f76d3086cdf63249c77b521108387b49d85a30c5e1c4fe82fdf5ae3b76ba7
 
 WORKDIR /
 

--- a/contrib/docker-integration/tokenserver/Dockerfile
+++ b/contrib/docker-integration/tokenserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM dmcgowan/token-server:simple
+FROM dmcgowan/token-server@sha256:0eab50ebdff5b6b95b3addf4edbd8bd2f5b940f27b41b43c94afdf05863a81af
 
 WORKDIR /
 


### PR DESCRIPTION
- Add plugin push and pull tests. Tests that images pushed as plugins cannot be pulled as images and vice versa.
- Additional base image used for creating plugin rootfs
- Updates login to allow supply the email flag in less than docker 1.11. Needed to support 1.13 which removes the email flag.