### PR TITLE
schema1: Validate descriptors in AppendReference

### DIFF
--- a/manifest/schema1/config_builder.go
+++ b/manifest/schema1/config_builder.go
@@ -240,8 +240,13 @@ func (mb *configManifestBuilder) emptyTar(ctx context.Context) (digest.Digest, e
 
 // AppendReference adds a reference to the current ManifestBuilder
 func (mb *configManifestBuilder) AppendReference(d distribution.Describable) error {
-	// todo: verification here?
-	mb.descriptors = append(mb.descriptors, d.Descriptor())
+	descriptor := d.Descriptor()
+
+	if err := descriptor.Digest.Validate(); err != nil {
+		return err
+	}
+
+	mb.descriptors = append(mb.descriptors, descriptor)
 	return nil
 }
 


### PR DESCRIPTION
If the digest is malformed, it will cause a panic when building the
manifest.

cc @dmcgowan