### PR TITLE
Enforce image is treated as empty class

### DIFF
--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -155,7 +155,9 @@ type RepositoryScope struct {
 // using the scope grammar
 func (rs RepositoryScope) String() string {
 	repoType := "repository"
-	if rs.Class != "" {
+	// Keep existing format for image class to maintain backwards compatibility
+	// with authorization servers which do not support the expanded grammar.
+	if rs.Class != "" && rs.Class != "image" {
 		repoType = fmt.Sprintf("%s(%s)", repoType, rs.Class)
 	}
 	return fmt.Sprintf("%s:%s:%s", repoType, rs.Repository, strings.Join(rs.Actions, ","))


### PR DESCRIPTION
Enforces backwards compatibility with older authorization servers without requiring the client to know about the compatibility requirements.

ping @stevvooe 