### PR TITLE
registry/handlers: fix incorrect use of Digest.Verifiers

### DIFF
--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -552,10 +552,7 @@ func testBlobAPI(t *testing.T, env *testEnv, args blobArgs) *testEnv {
 	})
 
 	// Verify the body
-	verifier, err := layerDigest.Verifier()
-	if err != nil {
-		t.Fatalf("unexpected error getting digest verifier: %s", err)
-	}
+	verifier := layerDigest.Verifier()
 	io.Copy(verifier, resp.Body)
 
 	if !verifier.Verified() {


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>