### PR TITLE
refactor doc comment

### DIFF
--- a/health/doc.go
+++ b/health/doc.go
@@ -122,9 +122,10 @@
 //  # curl localhost:5001/debug/health
 //  {"fileChecker":"file exists"}
 //
-// FileChecker only accepts absolute or relative file path. It does not work properly with tilde(~).
-// You should make sure that the application has proper permission(read and execute permission
-// for directory along with the specified file path). Otherwise, the FileChecker will report error
+// FileChecker only accepts absolute or relative file path. It does not work
+// properly with tilde(~). You should make sure that the application has
+// proper permission(read and execute permission for directory along with
+// the specified file path). Otherwise, the FileChecker will report error
 // and file health check is not ok.
 //
 // You could also test the connectivity to a downstream service by using a


### PR DESCRIPTION
make all comment lines less than 79 chars. 

[For more info](https://github.com/docker/distribution/pull/2072/files/658cda621fef91cff547cc06664c49b1a185865b#r92716666)