### PR TITLE
add alicdn support

### DIFF
--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/docker/distribution/registry/storage/driver/filesystem"
 	_ "github.com/docker/distribution/registry/storage/driver/gcs"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
+	_ "github.com/docker/distribution/registry/storage/driver/middleware/alicdn"
 	_ "github.com/docker/distribution/registry/storage/driver/middleware/cloudfront"
 	_ "github.com/docker/distribution/registry/storage/driver/middleware/redirect"
 	_ "github.com/docker/distribution/registry/storage/driver/oss"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -665,6 +665,14 @@ location of a proxy for the layer stored by the S3 storage driver.
 |-----------|----------|-------------------------------------------------------------------------------------------------------------|
 | `baseurl` | yes      | `SCHEME://HOST` at which layers are served. Can also contain port. For example, `https://example.com:5443`. |
 
+### alicdn
+
+The alicdn middleware can be used together with oss storage. It redirects all blob requests to alicdn with oss-style-signed querystring. 
+
+| Parameter | Required | Description                                                                                                 |
+|:----------|:---------|:------------------------------------------------------------------------------------------------------------|
+| baseurl   | yes      | `SCHEME://your-cdn-domain`. Can also contain port. For example, `https://your-cdn-domain:8080`. |
+
 ## `reporting`
 
 ```

--- a/registry/storage/driver/middleware/alicdn/middleware.go
+++ b/registry/storage/driver/middleware/alicdn/middleware.go
@@ -31,10 +31,10 @@ func newAliCDNStorageMiddleware(storageDriver storagedriver.StorageDriver, optio
 		return nil, fmt.Errorf("unable to parse alicdn baseurl: %s", b)
 	}
 	if u.Scheme == "" {
-		u.Scheme = "http"
+		return nil, fmt.Errorf("no scheme specified for alicdn baseurl")
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("no host specified for alicdn")
+		return nil, fmt.Errorf("no host specified for alicdn baseurl")
 	}
 	return &aliCDNStorageMiddleware{
 		StorageDriver: storageDriver,
@@ -43,16 +43,24 @@ func newAliCDNStorageMiddleware(storageDriver storagedriver.StorageDriver, optio
 	}, nil
 }
 
-func h(data string) int {
+func (cdn *aliCDNStorageMiddleware) h(data string) int {
 	h := fnv.New32a()
 	h.Write([]byte(data))
 	return int(h.Sum32())
 }
 
-func expireOf(path string) time.Time {
-	// map hash(path) to fix point by second on wall clock
-	secondsInWallClock := h(path) % 3600
-	now := time.Now().Truncate(time.Second)
+func (cdn *aliCDNStorageMiddleware) expireOf(now time.Time, path string) time.Time {
+
+	// Every file has it's own expire point based on hash of the path,
+	// such as 19 minutes past the hour, 25 minutes and 12 seconds past the hour, to avoid heavy traffic
+	// back to oss if all file on cdn expire at the same time.
+
+	// If the calculated expire time is too close(less than 5 minutes), return expire point at next hour.
+
+	// To balance the security and cost, one hour as max expire time is considerable.
+
+	secondsInWallClock := cdn.h(path) % 3600
+	now = now.Truncate(time.Second)
 	secondsOfHour := now.Minute()*60 + now.Second()
 	insurance := 5 * 60
 
@@ -64,19 +72,7 @@ func expireOf(path string) time.Time {
 	return expire
 }
 
-func (cdn *aliCDNStorageMiddleware) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
-	if cdn.StorageDriver.Name() != "oss" {
-		context.GetLogger(ctx).Warn("Alicdn middleware does not support this backend storage driver")
-		return cdn.StorageDriver.URLFor(ctx, path, options)
-	}
-
-	options["expiry"] = expireOf(path)
-
-	ossURL, err := cdn.StorageDriver.URLFor(ctx, path, options)
-	if err != nil {
-		return "", err
-	}
-
+func (cdn *aliCDNStorageMiddleware) replaceDomain(ossURL string) (string, error) {
 	u, err := url.Parse(ossURL)
 	if err != nil {
 		return "", err
@@ -84,6 +80,30 @@ func (cdn *aliCDNStorageMiddleware) URLFor(ctx context.Context, path string, opt
 	u.Scheme = cdn.scheme
 	u.Host = cdn.host
 	return u.String(), nil
+}
+
+func (cdn *aliCDNStorageMiddleware) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+	if cdn.StorageDriver.Name() != "oss" {
+		context.GetLogger(ctx).Warn("Alicdn middleware does not support this backend storage driver")
+		return cdn.StorageDriver.URLFor(ctx, path, options)
+	}
+
+	// With private oss bucket, alicdn can not retrive content directly from oss when cache missed.
+	// Unlike cloudfront+S3, we can't grant access privileges of oss to alicdn.
+	// we have to construct an oss sigend url and replace the domain part with alicdn,
+	// the url looks like: http://my-cdn-domain.com/path/to/file?signature=xxxxxx.
+	// if cached missed, alicdn just replace the domain part with oss and get content from oss.
+	// The problem is signature changes every request and cdn's will never be hit.
+	// So I generate oss url with fixed expire (less than one hour) rather fixed time from now.
+	// Before the expire time, all request to the same oss file return the same cdn url, to hit cdn's cache.
+
+	now := time.Now()
+	options["expiry"] = cdn.expireOf(now, path)
+	ossURL, err := cdn.StorageDriver.URLFor(ctx, path, options)
+	if err != nil {
+		return "", err
+	}
+	return cdn.replaceDomain(ossURL)
 }
 func init() {
 	storagemiddleware.Register("alicdn", storagemiddleware.InitFunc(newAliCDNStorageMiddleware))

--- a/registry/storage/driver/middleware/alicdn/middleware.go
+++ b/registry/storage/driver/middleware/alicdn/middleware.go
@@ -1,0 +1,90 @@
+package middleware
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	"github.com/docker/distribution/context"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+	storagemiddleware "github.com/docker/distribution/registry/storage/driver/middleware"
+	"net/url"
+	"time"
+)
+
+type aliCDNStorageMiddleware struct {
+	storagedriver.StorageDriver
+	scheme string
+	host   string
+}
+
+func newAliCDNStorageMiddleware(storageDriver storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error) {
+	o, ok := options["baseurl"]
+	if !ok {
+		return nil, fmt.Errorf("no baseurl provided")
+	}
+	b, ok := o.(string)
+	if !ok {
+		return nil, fmt.Errorf("baseurl must be a string")
+	}
+	u, err := url.Parse(b)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse alicdn baseurl: %s", b)
+	}
+	if u.Scheme == "" {
+		u.Scheme = "http"
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("no host specified for alicdn")
+	}
+	return &aliCDNStorageMiddleware{
+		StorageDriver: storageDriver,
+		scheme:        u.Scheme,
+		host:          u.Host,
+	}, nil
+}
+
+func h(data string) int {
+	h := fnv.New32a()
+	h.Write([]byte(data))
+	return int(h.Sum32())
+}
+
+func expireOf(path string) time.Time {
+	// map hash(path) to fix point by second on wall clock
+	secondsInWallClock := h(path) % 3600
+	now := time.Now().Truncate(time.Second)
+	secondsOfHour := now.Minute()*60 + now.Second()
+	insurance := 5 * 60
+
+	var expire time.Time
+	expire = now.Add(time.Duration(secondsInWallClock-secondsOfHour) * time.Second)
+	if secondsInWallClock-secondsOfHour < insurance {
+		expire = expire.Add(time.Hour)
+	}
+	return expire
+}
+
+func (cdn *aliCDNStorageMiddleware) URLFor(ctx context.Context, path string, options map[string]interface{}) (string, error) {
+	if cdn.StorageDriver.Name() != "oss" {
+		context.GetLogger(ctx).Warn("Alicdn middleware does not support this backend storage driver")
+		return cdn.StorageDriver.URLFor(ctx, path, options)
+	}
+
+	options["expiry"] = expireOf(path)
+
+	ossURL, err := cdn.StorageDriver.URLFor(ctx, path, options)
+	if err != nil {
+		return "", err
+	}
+
+	u, err := url.Parse(ossURL)
+	if err != nil {
+		return "", err
+	}
+	u.Scheme = cdn.scheme
+	u.Host = cdn.host
+	return u.String(), nil
+}
+func init() {
+	storagemiddleware.Register("alicdn", storagemiddleware.InitFunc(newAliCDNStorageMiddleware))
+}

--- a/registry/storage/driver/middleware/alicdn/middleware_test.go
+++ b/registry/storage/driver/middleware/alicdn/middleware_test.go
@@ -7,7 +7,9 @@ import (
 	"time"
 )
 
-func Test(t *testing.T) { check.TestingT(t) }
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
 
 type AliCDNMiddlewareSuite struct{}
 
@@ -72,15 +74,20 @@ func (s *AliCDNMiddlewareSuite) TestExpireOf(c *check.C) {
 
 func (s *aliCDNStorageMiddleware) TestReplaceDomain(c *check.C) {
 	options := make(map[string]interface{})
-	options["baseurl"] = "http://example.com"
-	middleware, err := newAliCDNStorageMiddleware(nil, options)
+	for _, baseurl := range []string{"http://example.com", "https://example.com"} {
+		options["baseurl"] = baseurl
 
-	c.Assert(err, check.IsNil)
-	m, ok := middleware.(*aliCDNStorageMiddleware)
-	c.Assert(ok, check.Equals, true)
+		middleware, err := newAliCDNStorageMiddleware(nil, options)
 
-	ossURL := "https://bucket.oss.aliyuncs.com/path/to/file?signature=xxxxxx"
-	cdnURL, err := m.replaceDomain(ossURL)
-	c.Assert(err, check.IsNil)
-	c.Assert(cdnURL, check.Equals, "http://example.com/path/to/file?signature=xxxxxx")
+		c.Assert(err, check.IsNil)
+		m, ok := middleware.(*aliCDNStorageMiddleware)
+		c.Assert(ok, check.Equals, true)
+
+		for _, ossDomain := range []string{"http://bucket.oss.aliyuncs.com", "https://another.oss.aliyuncs.com"} {
+			ossURL := ossDomain + "/path/to/file?signature=xxxxxx"
+			cdnURL, err := m.replaceDomain(ossURL)
+			c.Assert(err, check.IsNil)
+			c.Assert(cdnURL, check.Equals, baseurl+"/path/to/file?signature=xxxxxx")
+		}
+	}
 }

--- a/registry/storage/driver/middleware/alicdn/middleware_test.go
+++ b/registry/storage/driver/middleware/alicdn/middleware_test.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"testing"
+
+	check "gopkg.in/check.v1"
+	"time"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type AliCDNMiddlewareSuite struct{}
+
+var _ = check.Suite(&AliCDNMiddlewareSuite{})
+
+func (s *AliCDNMiddlewareSuite) TestNoConfig(c *check.C) {
+	options := make(map[string]interface{})
+	_, err := newAliCDNStorageMiddleware(nil, options)
+	c.Assert(err, check.ErrorMatches, "no baseurl provided")
+}
+
+func (s *AliCDNMiddlewareSuite) TestMissScheme(c *check.C) {
+	options := make(map[string]interface{})
+	options["baseurl"] = "example.com"
+	_, err := newAliCDNStorageMiddleware(nil, options)
+	c.Assert(err, check.ErrorMatches, "no scheme specified for alicdn baseurl")
+}
+
+func (s *AliCDNMiddlewareSuite) TestFullConfig(c *check.C) {
+	options := make(map[string]interface{})
+	options["baseurl"] = "http://example.com"
+	middleware, err := newAliCDNStorageMiddleware(nil, options)
+	c.Assert(err, check.IsNil)
+	m, ok := middleware.(*aliCDNStorageMiddleware)
+	c.Assert(ok, check.Equals, true)
+	c.Assert(m.scheme, check.Equals, "http")
+	c.Assert(m.host, check.Equals, "example.com")
+}
+
+func (s *AliCDNMiddlewareSuite) TestExpireOf(c *check.C) {
+	options := make(map[string]interface{})
+	options["baseurl"] = "http://example.com"
+	middleware, err := newAliCDNStorageMiddleware(nil, options)
+
+	c.Assert(err, check.IsNil)
+	m, ok := middleware.(*aliCDNStorageMiddleware)
+	c.Assert(ok, check.Equals, true)
+
+	layout := "2006-01-02T15:04:05.000"
+	path := "/path/to/file" // 12 minutes and 2 seconds past the hour
+
+	t, err := time.Parse(layout, "2017-01-12T16:01:20.123")
+	c.Assert(err, check.IsNil)
+	expire := m.expireOf(t, path)
+	c.Assert(expire.Format(layout), check.Equals, "2017-01-12T16:12:02.000")
+
+	t, err = time.Parse(layout, "2017-01-12T16:05:20.123")
+	c.Assert(err, check.IsNil)
+	expire = m.expireOf(t, path)
+	c.Assert(expire.Format(layout), check.Equals, "2017-01-12T16:12:02.000") // expire not change
+
+	t, err = time.Parse(layout, "2017-01-12T16:10:20.123") // less than 5min to expire
+	c.Assert(err, check.IsNil)
+	expire = m.expireOf(t, path)
+	c.Assert(expire.Format(layout), check.Equals, "2017-01-12T17:12:02.000")
+
+	t, err = time.Parse(layout, "2017-01-12T16:20:20.123") // past expire point in current hour
+	c.Assert(err, check.IsNil)
+	expire = m.expireOf(t, path)
+	c.Assert(expire.Format(layout), check.Equals, "2017-01-12T17:12:02.000")
+}
+
+func (s *aliCDNStorageMiddleware) TestReplaceDomain(c *check.C) {
+	options := make(map[string]interface{})
+	options["baseurl"] = "http://example.com"
+	middleware, err := newAliCDNStorageMiddleware(nil, options)
+
+	c.Assert(err, check.IsNil)
+	m, ok := middleware.(*aliCDNStorageMiddleware)
+	c.Assert(ok, check.Equals, true)
+
+	ossURL := "https://bucket.oss.aliyuncs.com/path/to/file?signature=xxxxxx"
+	cdnURL, err := m.replaceDomain(ossURL)
+	c.Assert(err, check.IsNil)
+	c.Assert(cdnURL, check.Equals, "http://example.com/path/to/file?signature=xxxxxx")
+}


### PR DESCRIPTION

sample config:

```
version: 0.1
log:
  level: info
  formatter: text
  fields:
    service: registry
    environment: staging
storage:
  oss:
    accesskeyid:access-key-id
    accesskeysecret: access-key-secret
    region: region
    bucket: bucket
middleware:
  storage:
    - name: alicdn
      options:
        baseurl: http://my-cdn-domain
http:
  addr: 0.0.0.0:5000
```

Signed-off-by: Jizhong Jiang <jizhong.jiangjz@alibaba-inc.com>