### PR TITLE
Use app.driver.Stat for registry health check

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -345,7 +345,7 @@ func (app *App) RegisterHealthChecks(healthRegistries ...*health.Registry) {
 		}
 
 		storageDriverCheck := func() error {
-			_, err := app.driver.List(app, "/") // "/" should always exist
+			_, err := app.driver.Stat(app, "/") // "/" should always exist
 			return err                          // any error will be treated as failure
 		}
 

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -137,7 +137,7 @@ func (base *Base) Stat(ctx context.Context, path string) (storagedriver.FileInfo
 	ctx, done := context.WithTrace(ctx)
 	defer done("%s.Stat(%q)", base.Name(), path)
 
-	if !storagedriver.PathRegexp.MatchString(path) {
+	if !storagedriver.PathRegexp.MatchString(path) && path != "/" {
 		return nil, storagedriver.InvalidPathError{Path: path, DriverName: base.StorageDriver.Name()}
 	}
 


### PR DESCRIPTION
`driver.List` on `"/"` is very expensive if registry contains significant amount of images. And the result isn't used anyways.  In most (if not all) storage drivers, `Stat` has a cheaper implementation, so use it instead to achieve the same goal.

Test plan:
`docker build -t registry:latest .` 
Run the registry with `cmd/registry/config-example.yml` and try push a image to the local registry at several different time point: immediately when registry boot up; 10s after registry boot up; 30s after registry boot up. And all pushes finished without problem.