### PR TITLE
Change DELETE action from "*" to "delete"

### DIFF
--- a/registry/auth/token/token_test.go
+++ b/registry/auth/token/token_test.go
@@ -454,6 +454,27 @@ func TestAccessController(t *testing.T) {
 	if userInfo.Name != "foo" {
 		t.Fatalf("expected user name %q, got %q", "foo", userInfo.Name)
 	}
+
+	// 5. Supply a token with full admin rights, which is represented as "*".
+	token, err = makeTestToken(
+		issuer, service,
+		[]*ResourceActions{{
+			Type:    testAccess.Type,
+			Name:    testAccess.Name,
+			Actions: []string{"*"},
+		}},
+		rootKeys[0], 1, time.Now(), time.Now().Add(5*time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.compactRaw()))
+
+	_, err = accessController.Authorized(ctx, testAccess)
+	if err != nil {
+		t.Fatalf("accessController returned unexpected error: %s", err)
+	}
 }
 
 // This tests that newAccessController can handle PEM blocks in the certificate

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -901,12 +901,10 @@ func appendAccessRecords(records []auth.Access, method string, repo string) []au
 				Action:   "push",
 			})
 	case "DELETE":
-		// DELETE access requires full admin rights, which is represented
-		// as "*". This may not be ideal.
 		records = append(records,
 			auth.Access{
 				Resource: resource,
-				Action:   "*",
+				Action:   "delete",
 			})
 	}
 	return records

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -229,9 +229,9 @@ func TestAppendAccessRecords(t *testing.T) {
 		Resource: expectedResource,
 		Action:   "push",
 	}
-	expectedAllRecord := auth.Access{
+	expectedDeleteRecord := auth.Access{
 		Resource: expectedResource,
-		Action:   "*",
+		Action:   "delete",
 	}
 
 	records := []auth.Access{}
@@ -271,7 +271,7 @@ func TestAppendAccessRecords(t *testing.T) {
 
 	records = []auth.Access{}
 	result = appendAccessRecords(records, "DELETE", repo)
-	expectedResult = []auth.Access{expectedAllRecord}
+	expectedResult = []auth.Access{expectedDeleteRecord}
 	if ok := reflect.DeepEqual(result, expectedResult); !ok {
 		t.Fatalf("Actual access record differs from expected")
 	}


### PR DESCRIPTION
With token authentication, requiring the "*" action for DELETE requests
makes it impossible to administratively lock a repository against pushes
and pulls but still allow deletion.  This change adds a new "delete"
action for DELETE requests to make that possible.