### PR TITLE
Fix reference package

### DIFF
--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -81,7 +81,7 @@ func splitDockerDomain(name string) (domain, remainder string) {
 // For example, "docker.io/library/redis" will have the familiar
 // name "redis" and "docker.io/dmcgowan/myapp" will be "dmcgowan/myapp".
 // Returns a familiarized named only reference.
-func familiarizeName(named NamedRepository) repository {
+func familiarizeName(named namedRepository) repository {
 	repo := repository{
 		domain: named.Domain(),
 		path:   named.Path(),
@@ -96,7 +96,7 @@ func familiarizeName(named NamedRepository) repository {
 
 func (r reference) Familiar() Named {
 	return reference{
-		NamedRepository: familiarizeName(r.NamedRepository),
+		namedRepository: familiarizeName(r.namedRepository),
 		tag:             r.tag,
 		digest:          r.digest,
 	}
@@ -108,14 +108,14 @@ func (r repository) Familiar() Named {
 
 func (t taggedReference) Familiar() Named {
 	return taggedReference{
-		NamedRepository: familiarizeName(t.NamedRepository),
+		namedRepository: familiarizeName(t.namedRepository),
 		tag:             t.tag,
 	}
 }
 
 func (c canonicalReference) Familiar() Named {
 	return canonicalReference{
-		NamedRepository: familiarizeName(c.NamedRepository),
+		namedRepository: familiarizeName(c.namedRepository),
 		digest:          c.digest,
 	}
 }

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/digestset"
+	"github.com/opencontainers/go-digest"
 )
 
 var (
@@ -142,7 +143,7 @@ func ParseAnyReference(ref string) (Reference, error) {
 	if ok := anchoredIdentifierRegexp.MatchString(ref); ok {
 		return digestReference("sha256:" + ref), nil
 	}
-	if dgst, err := digest.ParseDigest(ref); err == nil {
+	if dgst, err := digest.Parse(ref); err == nil {
 		return digestReference(dgst), nil
 	}
 
@@ -151,14 +152,14 @@ func ParseAnyReference(ref string) (Reference, error) {
 
 // ParseAnyReferenceWithSet parses a reference string as a possible short
 // identifier to be matched in a digest set, a full digest, or familiar name.
-func ParseAnyReferenceWithSet(ref string, ds *digest.Set) (Reference, error) {
+func ParseAnyReferenceWithSet(ref string, ds *digestset.Set) (Reference, error) {
 	if ok := anchoredShortIdentifierRegexp.MatchString(ref); ok {
 		dgst, err := ds.Lookup(ref)
 		if err == nil {
 			return digestReference(dgst), nil
 		}
 	} else {
-		if dgst, err := digest.ParseDigest(ref); err == nil {
+		if dgst, err := digest.Parse(ref); err == nil {
 			return digestReference(dgst), nil
 		}
 	}

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -3,7 +3,8 @@ package reference
 import (
 	"testing"
 
-	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/digestset"
+	"github.com/opencontainers/go-digest"
 )
 
 func TestValidateReferenceName(t *testing.T) {
@@ -410,7 +411,7 @@ func TestParseAnyReference(t *testing.T) {
 		if len(tcase.Digests) == 0 {
 			ref, err = ParseAnyReference(tcase.Reference)
 		} else {
-			ds := digest.NewSet()
+			ds := digestset.NewSet()
 			for _, dgst := range tcase.Digests {
 				if err := ds.Add(dgst); err != nil {
 					t.Fatalf("Error adding digest %s: %v", dgst.String(), err)

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -135,9 +135,9 @@ type Canonical interface {
 	Digest() digest.Digest
 }
 
-// NamedRepository is a reference to a repository with a name.
-// A NamedRepository has both domain and path components.
-type NamedRepository interface {
+// namedRepository is a reference to a repository with a name.
+// A namedRepository has both domain and path components.
+type namedRepository interface {
 	Named
 	Domain() string
 	Path() string
@@ -145,7 +145,7 @@ type NamedRepository interface {
 
 // Domain returns the domain part of the Named reference
 func Domain(named Named) string {
-	if r, ok := named.(NamedRepository); ok {
+	if r, ok := named.(namedRepository); ok {
 		return r.Domain()
 	}
 	domain, _ := splitDomain(named.Name())
@@ -154,7 +154,7 @@ func Domain(named Named) string {
 
 // Path returns the name without the domain part of the Named reference
 func Path(named Named) (name string) {
-	if r, ok := named.(NamedRepository); ok {
+	if r, ok := named.(namedRepository); ok {
 		return r.Path()
 	}
 	_, path := splitDomain(named.Name())
@@ -175,7 +175,7 @@ func splitDomain(name string) (string, string) {
 // is returned as name
 // DEPRECATED: Use Domain or Path
 func SplitHostname(named Named) (string, string) {
-	if r, ok := named.(NamedRepository); ok {
+	if r, ok := named.(namedRepository); ok {
 		return r.Domain(), r.Path()
 	}
 	return splitDomain(named.Name())
@@ -212,7 +212,7 @@ func Parse(s string) (Reference, error) {
 	}
 
 	ref := reference{
-		NamedRepository: repo,
+		namedRepository: repo,
 		tag:             matches[2],
 	}
 	if matches[3] != "" {
@@ -272,7 +272,7 @@ func WithTag(name Named, tag string) (NamedTagged, error) {
 		return nil, ErrTagInvalidFormat
 	}
 	var repo repository
-	if r, ok := name.(NamedRepository); ok {
+	if r, ok := name.(namedRepository); ok {
 		repo.domain = r.Domain()
 		repo.path = r.Path()
 	} else {
@@ -280,13 +280,13 @@ func WithTag(name Named, tag string) (NamedTagged, error) {
 	}
 	if canonical, ok := name.(Canonical); ok {
 		return reference{
-			NamedRepository: repo,
+			namedRepository: repo,
 			tag:             tag,
 			digest:          canonical.Digest(),
 		}, nil
 	}
 	return taggedReference{
-		NamedRepository: repo,
+		namedRepository: repo,
 		tag:             tag,
 	}, nil
 }
@@ -298,7 +298,7 @@ func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
 		return nil, ErrDigestInvalidFormat
 	}
 	var repo repository
-	if r, ok := name.(NamedRepository); ok {
+	if r, ok := name.(namedRepository); ok {
 		repo.domain = r.Domain()
 		repo.path = r.Path()
 	} else {
@@ -306,13 +306,13 @@ func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
 	}
 	if tagged, ok := name.(Tagged); ok {
 		return reference{
-			NamedRepository: repo,
+			namedRepository: repo,
 			tag:             tagged.Tag(),
 			digest:          digest,
 		}, nil
 	}
 	return canonicalReference{
-		NamedRepository: repo,
+		namedRepository: repo,
 		digest:          digest,
 	}, nil
 }
@@ -347,15 +347,15 @@ func getBestReferenceType(ref reference) Reference {
 	if ref.tag == "" {
 		if ref.digest != "" {
 			return canonicalReference{
-				NamedRepository: ref.NamedRepository,
+				namedRepository: ref.namedRepository,
 				digest:          ref.digest,
 			}
 		}
-		return ref.NamedRepository
+		return ref.namedRepository
 	}
 	if ref.digest == "" {
 		return taggedReference{
-			NamedRepository: ref.NamedRepository,
+			namedRepository: ref.namedRepository,
 			tag:             ref.tag,
 		}
 	}
@@ -364,7 +364,7 @@ func getBestReferenceType(ref reference) Reference {
 }
 
 type reference struct {
-	NamedRepository
+	namedRepository
 	tag    string
 	digest digest.Digest
 }
@@ -416,7 +416,7 @@ func (d digestReference) Digest() digest.Digest {
 }
 
 type taggedReference struct {
-	NamedRepository
+	namedRepository
 	tag string
 }
 
@@ -429,7 +429,7 @@ func (t taggedReference) Tag() string {
 }
 
 type canonicalReference struct {
-	NamedRepository
+	namedRepository
 	digest digest.Digest
 }
 


### PR DESCRIPTION
Needed another rebase which was not caught before merge. Now using go-digest package.
Additionally unexported the `NamedRepository` interface. This is not currently needed outside the package and we might want to merge it into `Named`. In the latter case, we don't want to be in a position where we need to keep around unneeded interfaces because they were previously exported.