### PR TITLE
Remove ambiguity for unsupported official repository input

### DIFF
--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -12,7 +12,7 @@ import (
 var (
 	legacyDefaultDomain = "index.docker.io"
 	defaultDomain       = "docker.io"
-	defaultRepoPrefix   = "library/"
+	officialRepoName    = "library"
 	defaultTag          = "latest"
 )
 
@@ -70,7 +70,7 @@ func splitDockerDomain(name string) (domain, remainder string) {
 		domain = defaultDomain
 	}
 	if domain == defaultDomain && !strings.ContainsRune(remainder, '/') {
-		remainder = defaultRepoPrefix + remainder
+		remainder = officialRepoName + "/" + remainder
 	}
 	return
 }
@@ -89,7 +89,10 @@ func familiarizeName(named namedRepository) repository {
 
 	if repo.domain == defaultDomain {
 		repo.domain = ""
-		repo.path = strings.TrimPrefix(repo.path, defaultRepoPrefix)
+		// Handle official repositories which have the pattern "library/<official repo name>"
+		if split := strings.Split(repo.path, "/"); len(split) == 2 && split[0] == officialRepoName {
+			repo.path = split[1]
+		}
 	}
 	return repo
 }

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -208,6 +208,20 @@ func TestParseRepositoryInfo(t *testing.T) {
 			AmbiguousName: "index.docker.io/library/ubuntu-12.04-base",
 			Domain:        "docker.io",
 		},
+		{
+			RemoteName:    "library/foo/bar",
+			FamiliarName:  "library/foo/bar",
+			FullName:      "docker.io/library/foo/bar",
+			AmbiguousName: "",
+			Domain:        "docker.io",
+		},
+		{
+			RemoteName:    "store/foo/bar",
+			FamiliarName:  "store/foo/bar",
+			FullName:      "docker.io/store/foo/bar",
+			AmbiguousName: "",
+			Domain:        "docker.io",
+		},
 	}
 
 	for _, tcase := range tcases {
@@ -482,6 +496,21 @@ func TestNormalizedSplitHostname(t *testing.T) {
 			input:  "xn--n3h.com:18080/foo",
 			domain: "xn--n3h.com:18080",
 			name:   "foo",
+		},
+		{
+			input:  "docker.io/foo",
+			domain: "docker.io",
+			name:   "library/foo",
+		},
+		{
+			input:  "docker.io/library/foo",
+			domain: "docker.io",
+			name:   "library/foo",
+		},
+		{
+			input:  "docker.io/library/foo/bar",
+			domain: "docker.io",
+			name:   "library/foo/bar",
 		},
 	}
 	for _, testcase := range testcases {


### PR DESCRIPTION
Officials repositories always have 2 part names with the first part being library and second part being the offical repository name. Names with more than 2 parts should not hit the special case for official repositories since they are not valid official repositories. Add tests for this ambiguity and to ensure that 3 part names are supports for the default repository, as used by the docker store.