### PR TITLE
Remove NormalizedNamed from public interface

### DIFF
--- a/reference/helpers.go
+++ b/reference/helpers.go
@@ -14,7 +14,7 @@ func IsNameOnly(ref Named) bool {
 // FamiliarName returns the familiar name string
 // for the given named, familiarizing if needed.
 func FamiliarName(ref Named) string {
-	if nn, ok := ref.(NormalizedNamed); ok {
+	if nn, ok := ref.(normalizedNamed); ok {
 		return nn.Familiar().Name()
 	}
 	return ref.Name()
@@ -23,7 +23,7 @@ func FamiliarName(ref Named) string {
 // FamiliarString returns the familiar string representation
 // for the given reference, familiarizing if needed.
 func FamiliarString(ref Reference) string {
-	if nn, ok := ref.(NormalizedNamed); ok {
+	if nn, ok := ref.(normalizedNamed); ok {
 		return nn.Familiar().String()
 	}
 	return ref.String()

--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -16,12 +16,12 @@ var (
 	defaultTag          = "latest"
 )
 
-// NormalizedNamed represents a name which has been
+// normalizedNamed represents a name which has been
 // normalized and has a familiar form. A familiar name
 // is what is used in Docker UI. An example normalized
 // name is "docker.io/library/ubuntu" and corresponding
 // familiar name of "ubuntu".
-type NormalizedNamed interface {
+type normalizedNamed interface {
 	Named
 	Familiar() Named
 }
@@ -30,7 +30,7 @@ type NormalizedNamed interface {
 // transforming a familiar name from Docker UI to a fully
 // qualified reference. If the value may be an identifier
 // use ParseAnyReference.
-func ParseNormalizedNamed(s string) (NormalizedNamed, error) {
+func ParseNormalizedNamed(s string) (Named, error) {
 	if ok := anchoredIdentifierRegexp.MatchString(s); ok {
 		return nil, fmt.Errorf("invalid repository name (%s), cannot specify 64-byte hexadecimal strings", s)
 	}
@@ -49,7 +49,7 @@ func ParseNormalizedNamed(s string) (NormalizedNamed, error) {
 	if err != nil {
 		return nil, err
 	}
-	named, isNamed := ref.(NormalizedNamed)
+	named, isNamed := ref.(Named)
 	if !isNamed {
 		return nil, fmt.Errorf("reference %s has no name", ref.String())
 	}

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -216,7 +216,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 			refStrings = append(refStrings, tcase.AmbiguousName)
 		}
 
-		var refs []NormalizedNamed
+		var refs []Named
 		for _, r := range refStrings {
 			named, err := ParseNormalizedNamed(r)
 			if err != nil {
@@ -226,7 +226,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 		}
 
 		for _, r := range refs {
-			if expected, actual := tcase.FamiliarName, r.Familiar().Name(); expected != actual {
+			if expected, actual := tcase.FamiliarName, FamiliarName(r); expected != actual {
 				t.Fatalf("Invalid normalized reference for %q. Expected %q, got %q", r, expected, actual)
 			}
 			if expected, actual := tcase.FullName, r.String(); expected != actual {
@@ -245,22 +245,21 @@ func TestParseRepositoryInfo(t *testing.T) {
 
 func TestParseReferenceWithTagAndDigest(t *testing.T) {
 	shortRef := "busybox:latest@sha256:86e0e091d0da6bde2456dbb48306f3956bbeb2eae1b5b9a43045843f69fe4aaa"
-	nref, err := ParseNormalizedNamed(shortRef)
+	ref, err := ParseNormalizedNamed(shortRef)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expected, actual := "docker.io/library/"+shortRef, nref.String(); actual != expected {
-		t.Fatalf("Invalid parsed reference for %q: expected %q, got %q", nref, expected, actual)
+	if expected, actual := "docker.io/library/"+shortRef, ref.String(); actual != expected {
+		t.Fatalf("Invalid parsed reference for %q: expected %q, got %q", ref, expected, actual)
 	}
 
-	ref := nref.Familiar()
 	if _, isTagged := ref.(NamedTagged); !isTagged {
 		t.Fatalf("Reference from %q should support tag", ref)
 	}
 	if _, isCanonical := ref.(Canonical); !isCanonical {
 		t.Fatalf("Reference from %q should support digest", ref)
 	}
-	if expected, actual := shortRef, ref.String(); actual != expected {
+	if expected, actual := shortRef, FamiliarString(ref); actual != expected {
 		t.Fatalf("Invalid parsed reference for %q: expected %q, got %q", ref, expected, actual)
 	}
 }


### PR DESCRIPTION
The NormalizedNamed interface has shown to not be necessary for integrating the change downstream. The FamiliarName and FamiliarString helpers are the only used interface and allow hiding the normalized completely.