### PR TITLE
reference: ParseNamed updated to enforce canonical format

### DIFF
--- a/manifest/schema1/config_builder_test.go
+++ b/manifest/schema1/config_builder_test.go
@@ -197,9 +197,13 @@ func TestConfigBuilder(t *testing.T) {
 
 	bs := &mockBlobService{descriptors: make(map[digest.Digest]distribution.Descriptor)}
 
-	ref, err := reference.ParseNamed("testrepo:testtag")
+	ref, err := reference.WithName("testrepo")
 	if err != nil {
 		t.Fatalf("could not parse reference: %v", err)
+	}
+	ref, err = reference.WithTag(ref, "testtag")
+	if err != nil {
+		t.Fatalf("could not add tag: %v", err)
 	}
 
 	builder := NewConfigManifestBuilder(bs, pk, ref, []byte(imgJSON))

--- a/manifest/schema1/reference_builder_test.go
+++ b/manifest/schema1/reference_builder_test.go
@@ -55,7 +55,7 @@ func TestReferenceBuilder(t *testing.T) {
 
 	handCrafted := makeSignedManifest(t, pk, []Reference{r1, r2})
 
-	ref, err := reference.ParseNamed(handCrafted.Manifest.Name)
+	ref, err := reference.WithName(handCrafted.Manifest.Name)
 	if err != nil {
 		t.Fatalf("could not parse reference: %v", err)
 	}

--- a/notifications/bridge_test.go
+++ b/notifications/bridge_test.go
@@ -43,7 +43,7 @@ func TestEventBridgeManifestPulled(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.ParseNamed(repo)
+	repoRef, _ := reference.WithName(repo)
 	if err := l.ManifestPulled(repoRef, sm); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestEventBridgeManifestPushed(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.ParseNamed(repo)
+	repoRef, _ := reference.WithName(repo)
 	if err := l.ManifestPushed(repoRef, sm); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestEventBridgeManifestPushedWithTag(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.ParseNamed(repo)
+	repoRef, _ := reference.WithName(repo)
 	if err := l.ManifestPushed(repoRef, sm, distribution.WithTag(m.Tag)); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestEventBridgeManifestPulledWithTag(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.ParseNamed(repo)
+	repoRef, _ := reference.WithName(repo)
 	if err := l.ManifestPulled(repoRef, sm, distribution.WithTag(m.Tag)); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestEventBridgeManifestDeleted(t *testing.T) {
 		return nil
 	}))
 
-	repoRef, _ := reference.ParseNamed(repo)
+	repoRef, _ := reference.WithName(repo)
 	if err := l.ManifestDeleted(repoRef, dgst); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
 	}
@@ -160,7 +160,7 @@ func checkCommonManifest(t *testing.T, action string, events ...Event) {
 		t.Fatalf("unexpected event action: %q != %q", event.Action, action)
 	}
 
-	repoRef, _ := reference.ParseNamed(repo)
+	repoRef, _ := reference.WithName(repo)
 	ref, _ := reference.WithDigest(repoRef, dgst)
 	u, err := ub.BuildManifestURL(ref)
 	if err != nil {

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -33,7 +33,7 @@ func TestListener(t *testing.T) {
 		ops: make(map[string]int),
 	}
 
-	repoRef, _ := reference.ParseNamed("foo/bar")
+	repoRef, _ := reference.WithName("foo/bar")
 	repository, err := registry.Repository(ctx, repoRef)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)

--- a/reference/normalize_test.go
+++ b/reference/normalize_test.go
@@ -209,6 +209,13 @@ func TestParseRepositoryInfo(t *testing.T) {
 			Domain:        "docker.io",
 		},
 		{
+			RemoteName:    "library/foo",
+			FamiliarName:  "foo",
+			FullName:      "docker.io/library/foo",
+			AmbiguousName: "docker.io/foo",
+			Domain:        "docker.io",
+		},
+		{
 			RemoteName:    "library/foo/bar",
 			FamiliarName:  "library/foo/bar",
 			FullName:      "docker.io/library/foo/bar",

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -55,6 +55,9 @@ var (
 
 	// ErrNameTooLong is returned when a repository name is longer than NameTotalLengthMax.
 	ErrNameTooLong = fmt.Errorf("repository name must not be more than %v characters", NameTotalLengthMax)
+
+	// ErrNameNotCanonical is returned when a name is not canonical.
+	ErrNameNotCanonical = errors.New("repository name must be canonical")
 )
 
 // Reference is an opaque object reference identifier that may include
@@ -231,18 +234,17 @@ func Parse(s string) (Reference, error) {
 }
 
 // ParseNamed parses s and returns a syntactically valid reference implementing
-// the Named interface. The reference must have a name, otherwise an error is
-// returned.
+// the Named interface. The reference must have a name and be in the canonical
+// form, otherwise an error is returned.
 // If an error was encountered it is returned, along with a nil Reference.
 // NOTE: ParseNamed will not handle short digests.
 func ParseNamed(s string) (Named, error) {
-	ref, err := Parse(s)
+	named, err := ParseNormalizedNamed(s)
 	if err != nil {
 		return nil, err
 	}
-	named, isNamed := ref.(Named)
-	if !isNamed {
-		return nil, fmt.Errorf("reference %s has no name", ref.String())
+	if named.String() != s {
+		return nil, ErrNameNotCanonical
 	}
 	return named, nil
 }

--- a/registry/api/v2/urls_test.go
+++ b/registry/api/v2/urls_test.go
@@ -15,7 +15,7 @@ type urlBuilderTestCase struct {
 }
 
 func makeURLBuilderTestCases(urlBuilder *URLBuilder) []urlBuilderTestCase {
-	fooBarRef, _ := reference.ParseNamed("foo/bar")
+	fooBarRef, _ := reference.WithName("foo/bar")
 	return []urlBuilderTestCase{
 		{
 			description:  "test base url",

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -100,7 +100,7 @@ func addTestCatalog(route string, content []byte, link string, m *testutil.Reque
 func TestBlobDelete(t *testing.T) {
 	dgst, _ := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
-	repo, _ := reference.ParseNamed("test.example.com/repo1")
+	repo, _ := reference.WithName("test.example.com/repo1")
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
 			Method: "DELETE",
@@ -139,7 +139,7 @@ func TestBlobFetch(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	repo, _ := reference.ParseNamed("test.example.com/repo1")
+	repo, _ := reference.WithName("test.example.com/repo1")
 	r, err := NewRepository(ctx, repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -160,7 +160,7 @@ func TestBlobFetch(t *testing.T) {
 func TestBlobExistsNoContentLength(t *testing.T) {
 	var m testutil.RequestResponseMap
 
-	repo, _ := reference.ParseNamed("biff")
+	repo, _ := reference.WithName("biff")
 	dgst, content := newRandomBlob(1024)
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
@@ -219,7 +219,7 @@ func TestBlobExists(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	repo, _ := reference.ParseNamed("test.example.com/repo1")
+	repo, _ := reference.WithName("test.example.com/repo1")
 	r, err := NewRepository(ctx, repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -251,7 +251,7 @@ func TestBlobUploadChunked(t *testing.T) {
 		b1[512:513],
 		b1[513:1024],
 	}
-	repo, _ := reference.ParseNamed("test.example.com/uploadrepo")
+	repo, _ := reference.WithName("test.example.com/uploadrepo")
 	uuids := []string{uuid.Generate().String()}
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
@@ -366,7 +366,7 @@ func TestBlobUploadChunked(t *testing.T) {
 func TestBlobUploadMonolithic(t *testing.T) {
 	dgst, b1 := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
-	repo, _ := reference.ParseNamed("test.example.com/uploadrepo")
+	repo, _ := reference.WithName("test.example.com/uploadrepo")
 	uploadID := uuid.Generate().String()
 	m = append(m, testutil.RequestResponseMapping{
 		Request: testutil.Request{
@@ -474,9 +474,9 @@ func TestBlobUploadMonolithic(t *testing.T) {
 func TestBlobMount(t *testing.T) {
 	dgst, content := newRandomBlob(1024)
 	var m testutil.RequestResponseMap
-	repo, _ := reference.ParseNamed("test.example.com/uploadrepo")
+	repo, _ := reference.WithName("test.example.com/uploadrepo")
 
-	sourceRepo, _ := reference.ParseNamed("test.example.com/sourcerepo")
+	sourceRepo, _ := reference.WithName("test.example.com/sourcerepo")
 	canonicalRef, _ := reference.WithDigest(sourceRepo, dgst)
 
 	m = append(m, testutil.RequestResponseMapping{
@@ -678,7 +678,7 @@ func checkEqualManifest(m1, m2 *schema1.SignedManifest) error {
 
 func TestV1ManifestFetch(t *testing.T) {
 	ctx := context.Background()
-	repo, _ := reference.ParseNamed("test.example.com/repo")
+	repo, _ := reference.WithName("test.example.com/repo")
 	m1, dgst, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 	_, pl, err := m1.Payload()
@@ -755,7 +755,7 @@ func TestV1ManifestFetch(t *testing.T) {
 }
 
 func TestManifestFetchWithEtag(t *testing.T) {
-	repo, _ := reference.ParseNamed("test.example.com/repo/by/tag")
+	repo, _ := reference.WithName("test.example.com/repo/by/tag")
 	_, d1, p1 := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 	addTestManifestWithEtag(repo, "latest", p1, &m, d1.String())
@@ -785,7 +785,7 @@ func TestManifestFetchWithEtag(t *testing.T) {
 }
 
 func TestManifestDelete(t *testing.T) {
-	repo, _ := reference.ParseNamed("test.example.com/repo/delete")
+	repo, _ := reference.WithName("test.example.com/repo/delete")
 	_, dgst1, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	_, dgst2, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
@@ -825,7 +825,7 @@ func TestManifestDelete(t *testing.T) {
 }
 
 func TestManifestPut(t *testing.T) {
-	repo, _ := reference.ParseNamed("test.example.com/repo/delete")
+	repo, _ := reference.WithName("test.example.com/repo/delete")
 	m1, dgst, _ := newRandomSchemaV1Manifest(repo, "other", 6)
 
 	_, payload, err := m1.Payload()
@@ -890,7 +890,7 @@ func TestManifestPut(t *testing.T) {
 }
 
 func TestManifestTags(t *testing.T) {
-	repo, _ := reference.ParseNamed("test.example.com/repo/tags/list")
+	repo, _ := reference.WithName("test.example.com/repo/tags/list")
 	tagsList := []byte(strings.TrimSpace(`
 {
 	"name": "test.example.com/repo/tags/list",
@@ -952,7 +952,7 @@ func TestManifestTags(t *testing.T) {
 }
 
 func TestObtainsErrorForMissingTag(t *testing.T) {
-	repo, _ := reference.ParseNamed("test.example.com/repo")
+	repo, _ := reference.WithName("test.example.com/repo")
 
 	var m testutil.RequestResponseMap
 	var errors errcode.Errors
@@ -998,7 +998,7 @@ func TestManifestTagsPaginated(t *testing.T) {
 	s := httptest.NewServer(http.NotFoundHandler())
 	defer s.Close()
 
-	repo, _ := reference.ParseNamed("test.example.com/repo/tags/list")
+	repo, _ := reference.WithName("test.example.com/repo/tags/list")
 	tagsList := []string{"tag1", "tag2", "funtag"}
 	var m testutil.RequestResponseMap
 	for i := 0; i < 3; i++ {
@@ -1067,7 +1067,7 @@ func TestManifestTagsPaginated(t *testing.T) {
 }
 
 func TestManifestUnauthorized(t *testing.T) {
-	repo, _ := reference.ParseNamed("test.example.com/repo")
+	repo, _ := reference.WithName("test.example.com/repo")
 	_, dgst, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
 	var m testutil.RequestResponseMap
 

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -277,7 +277,7 @@ func makeBlobArgs(t *testing.T) blobArgs {
 		layerFile:   layerFile,
 		layerDigest: layerDigest,
 	}
-	args.imageName, _ = reference.ParseNamed("foo/bar")
+	args.imageName, _ = reference.WithName("foo/bar")
 	return args
 }
 
@@ -702,7 +702,7 @@ func TestDeleteDisabled(t *testing.T) {
 	env := newTestEnv(t, false)
 	defer env.Shutdown()
 
-	imageName, _ := reference.ParseNamed("foo/bar")
+	imageName, _ := reference.WithName("foo/bar")
 	// "build" our layer file
 	layerFile, layerDigest, err := testutil.CreateRandomTarFile()
 	if err != nil {
@@ -729,7 +729,7 @@ func TestDeleteReadOnly(t *testing.T) {
 	env := newTestEnv(t, true)
 	defer env.Shutdown()
 
-	imageName, _ := reference.ParseNamed("foo/bar")
+	imageName, _ := reference.WithName("foo/bar")
 	// "build" our layer file
 	layerFile, layerDigest, err := testutil.CreateRandomTarFile()
 	if err != nil {
@@ -759,7 +759,7 @@ func TestStartPushReadOnly(t *testing.T) {
 	defer env.Shutdown()
 	env.app.readOnly = true
 
-	imageName, _ := reference.ParseNamed("foo/bar")
+	imageName, _ := reference.WithName("foo/bar")
 
 	layerUploadURL, err := env.builder.BuildBlobUploadURL(imageName)
 	if err != nil {
@@ -797,8 +797,8 @@ type manifestArgs struct {
 }
 
 func TestManifestAPI(t *testing.T) {
-	schema1Repo, _ := reference.ParseNamed("foo/schema1")
-	schema2Repo, _ := reference.ParseNamed("foo/schema2")
+	schema1Repo, _ := reference.WithName("foo/schema1")
+	schema2Repo, _ := reference.WithName("foo/schema2")
 
 	deleteEnabled := false
 	env1 := newTestEnv(t, deleteEnabled)
@@ -816,8 +816,8 @@ func TestManifestAPI(t *testing.T) {
 }
 
 func TestManifestDelete(t *testing.T) {
-	schema1Repo, _ := reference.ParseNamed("foo/schema1")
-	schema2Repo, _ := reference.ParseNamed("foo/schema2")
+	schema1Repo, _ := reference.WithName("foo/schema1")
+	schema2Repo, _ := reference.WithName("foo/schema2")
 
 	deleteEnabled := true
 	env := newTestEnv(t, deleteEnabled)
@@ -829,7 +829,7 @@ func TestManifestDelete(t *testing.T) {
 }
 
 func TestManifestDeleteDisabled(t *testing.T) {
-	schema1Repo, _ := reference.ParseNamed("foo/schema1")
+	schema1Repo, _ := reference.WithName("foo/schema1")
 	deleteEnabled := false
 	env := newTestEnv(t, deleteEnabled)
 	defer env.Shutdown()
@@ -2293,7 +2293,7 @@ func checkErr(t *testing.T, err error, msg string) {
 }
 
 func createRepository(env *testEnv, t *testing.T, imageName string, tag string) digest.Digest {
-	imageNameRef, err := reference.ParseNamed(imageName)
+	imageNameRef, err := reference.WithName(imageName)
 	if err != nil {
 		t.Fatalf("unable to parse reference: %v", err)
 	}
@@ -2364,7 +2364,7 @@ func TestRegistryAsCacheMutationAPIs(t *testing.T) {
 	env := newTestEnvMirror(t, deleteEnabled)
 	defer env.Shutdown()
 
-	imageName, _ := reference.ParseNamed("foo/bar")
+	imageName, _ := reference.WithName("foo/bar")
 	tag := "latest"
 	tagRef, _ := reference.WithTag(imageName, tag)
 	manifestURL, err := env.builder.BuildManifestURL(tagRef)
@@ -2457,7 +2457,7 @@ func TestProxyManifestGetByTag(t *testing.T) {
 	}
 	truthConfig.HTTP.Headers = headerConfig
 
-	imageName, _ := reference.ParseNamed("foo/bar")
+	imageName, _ := reference.WithName("foo/bar")
 	tag := "latest"
 
 	truthEnv := newTestEnvWithConfig(t, &truthConfig)

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -650,7 +650,7 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 		context.Context = ctxu.WithLogger(context.Context, ctxu.GetLogger(context.Context, auth.UserNameKey))
 
 		if app.nameRequired(r) {
-			nameRef, err := reference.ParseNamed(getName(context))
+			nameRef, err := reference.WithName(getName(context))
 			if err != nil {
 				ctxu.GetLogger(context).Errorf("error parsing reference from context: %v", err)
 				context.Errors = append(context.Errors, distribution.ErrRepositoryNameInvalid{

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -334,7 +334,7 @@ func (buh *blobUploadHandler) createBlobMountOption(fromRepo, mountDigest string
 		return nil, err
 	}
 
-	ref, err := reference.ParseNamed(fromRepo)
+	ref, err := reference.WithName(fromRepo)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/proxy/proxyblobstore_test.go
+++ b/registry/proxy/proxyblobstore_test.go
@@ -115,7 +115,7 @@ func (te *testEnv) RemoteStats() *map[string]int {
 
 // Populate remote store and record the digests
 func makeTestEnv(t *testing.T, name string) *testEnv {
-	nameRef, err := reference.ParseNamed(name)
+	nameRef, err := reference.WithName(name)
 	if err != nil {
 		t.Fatalf("unable to parse reference: %s", err)
 	}

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -83,7 +83,7 @@ func (m *mockChallenger) challengeManager() challenge.Manager {
 }
 
 func newManifestStoreTestEnv(t *testing.T, name, tag string) *manifestStoreTestEnv {
-	nameRef, err := reference.ParseNamed(name)
+	nameRef, err := reference.WithName(name)
 	if err != nil {
 		t.Fatalf("unable to parse reference: %s", err)
 	}

--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -24,7 +24,7 @@ import (
 // obtained using Seek
 func TestWriteSeek(t *testing.T) {
 	ctx := context.Background()
-	imageName, _ := reference.ParseNamed("foo/bar")
+	imageName, _ := reference.WithName("foo/bar")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -60,7 +60,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	imageName, _ := reference.ParseNamed("foo/bar")
+	imageName, _ := reference.WithName("foo/bar")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -255,7 +255,7 @@ func TestSimpleBlobUpload(t *testing.T) {
 // other tests.
 func TestSimpleBlobRead(t *testing.T) {
 	ctx := context.Background()
-	imageName, _ := reference.ParseNamed("foo/bar")
+	imageName, _ := reference.WithName("foo/bar")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -366,8 +366,8 @@ func TestBlobMount(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	imageName, _ := reference.ParseNamed("foo/bar")
-	sourceImageName, _ := reference.ParseNamed("foo/source")
+	imageName, _ := reference.WithName("foo/bar")
+	sourceImageName, _ := reference.WithName("foo/source")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {
@@ -518,7 +518,7 @@ func TestBlobMount(t *testing.T) {
 // TestLayerUploadZeroLength uploads zero-length
 func TestLayerUploadZeroLength(t *testing.T) {
 	ctx := context.Background()
-	imageName, _ := reference.ParseNamed("foo/bar")
+	imageName, _ := reference.WithName("foo/bar")
 	driver := testdriver.New()
 	registry, err := NewRegistry(ctx, driver, BlobDescriptorCacheProvider(memory.NewInMemoryBlobDescriptorCacheProvider()), EnableDelete, EnableRedirect)
 	if err != nil {

--- a/registry/storage/cache/memory/memory.go
+++ b/registry/storage/cache/memory/memory.go
@@ -26,7 +26,7 @@ func NewInMemoryBlobDescriptorCacheProvider() cache.BlobDescriptorCacheProvider 
 }
 
 func (imbdcp *inMemoryBlobDescriptorCacheProvider) RepositoryScoped(repo string) (distribution.BlobDescriptorService, error) {
-	if _, err := reference.ParseNamed(repo); err != nil {
+	if _, err := reference.ParseNormalizedNamed(repo); err != nil {
 		return nil, err
 	}
 

--- a/registry/storage/cache/redis/redis.go
+++ b/registry/storage/cache/redis/redis.go
@@ -41,7 +41,7 @@ func NewRedisBlobDescriptorCacheProvider(pool *redis.Pool) cache.BlobDescriptorC
 
 // RepositoryScoped returns the scoped cache.
 func (rbds *redisBlobDescriptorService) RepositoryScoped(repo string) (distribution.BlobDescriptorService, error) {
-	if _, err := reference.ParseNamed(repo); err != nil {
+	if _, err := reference.ParseNormalizedNamed(repo); err != nil {
 		return nil, err
 	}
 

--- a/registry/storage/catalog_test.go
+++ b/registry/storage/catalog_test.go
@@ -68,7 +68,7 @@ func setupFS(t *testing.T) *setupEnv {
 }
 
 func makeRepo(ctx context.Context, t *testing.T, name string, reg distribution.Namespace) {
-	named, err := reference.ParseNamed(name)
+	named, err := reference.WithName(name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -27,7 +27,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 		emit(repoName)
 
 		var err error
-		named, err := reference.ParseNamed(repoName)
+		named, err := reference.WithName(repoName)
 		if err != nil {
 			return fmt.Errorf("failed to parse repo name %s: %v", repoName, err)
 		}

--- a/registry/storage/garbagecollect_test.go
+++ b/registry/storage/garbagecollect_test.go
@@ -39,7 +39,7 @@ func makeRepository(t *testing.T, registry distribution.Namespace, name string) 
 	ctx := context.Background()
 
 	// Initialize a dummy repository
-	named, err := reference.ParseNamed(name)
+	named, err := reference.WithName(name)
 	if err != nil {
 		t.Fatalf("Failed to parse name %s:  %v", name, err)
 	}

--- a/registry/storage/linkedblobstore_test.go
+++ b/registry/storage/linkedblobstore_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestLinkedBlobStoreCreateWithMountFrom(t *testing.T) {
-	fooRepoName, _ := reference.ParseNamed("nm/foo")
+	fooRepoName, _ := reference.WithName("nm/foo")
 	fooEnv := newManifestStoreTestEnv(t, fooRepoName, "thetag")
 	ctx := context.Background()
 	stats, err := mockRegistry(t, fooEnv.registry)
@@ -54,7 +54,7 @@ func TestLinkedBlobStoreCreateWithMountFrom(t *testing.T) {
 	}
 
 	// create another repository nm/bar
-	barRepoName, _ := reference.ParseNamed("nm/bar")
+	barRepoName, _ := reference.WithName("nm/bar")
 	barRepo, err := fooEnv.registry.Repository(ctx, barRepoName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)
@@ -94,7 +94,7 @@ func TestLinkedBlobStoreCreateWithMountFrom(t *testing.T) {
 	clearStats(stats)
 
 	// create yet another repository nm/baz
-	bazRepoName, _ := reference.ParseNamed("nm/baz")
+	bazRepoName, _ := reference.WithName("nm/baz")
 	bazRepo, err := fooEnv.registry.Repository(ctx, bazRepoName)
 	if err != nil {
 		t.Fatalf("unexpected error getting repo: %v", err)

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -60,7 +60,7 @@ func TestManifestStorage(t *testing.T) {
 }
 
 func testManifestStorage(t *testing.T, options ...RegistryOption) {
-	repoName, _ := reference.ParseNamed("foo/bar")
+	repoName, _ := reference.WithName("foo/bar")
 	env := newManifestStoreTestEnv(t, repoName, "thetag", options...)
 	ctx := context.Background()
 	ms, err := env.repository.Manifests(ctx)

--- a/registry/storage/tagstore_test.go
+++ b/registry/storage/tagstore_test.go
@@ -22,7 +22,7 @@ func testTagStore(t *testing.T) *tagsTestEnv {
 		t.Fatal(err)
 	}
 
-	repoRef, _ := reference.ParseNamed("a/b")
+	repoRef, _ := reference.WithName("a/b")
 	repo, err := reg.Repository(ctx, repoRef)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Updates the `ParseNamed` function to require that the input be in canonical form. Throws an error if the input is not canonical. This protects against using `ParseNamed` to create partial `Named` values. These partial values can still be created explicitly through `WithName` and `Parse`, as used now used by the registry server.

In the future, the registry should start using fully canonical values on the backend and `WithName` should no longer support creating partial values.