### PR TITLE
Range header is incorrectly specified

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -544,7 +544,7 @@ with the upload URL in the `Location` header:
 ```
 202 Accepted
 Location: /v2/<name>/blobs/uploads/<uuid>
-Range: bytes=0-<offset>
+Range: 0-<offset>
 Content-Length: 0
 Docker-Upload-UUID: <uuid>
 ```


### PR DESCRIPTION
The range header does not need a "bytes=" before the range itself. I have no idea whether this error spreads to other functions that call with "bytes=" or return it as a parameter. I refer you to https://github.com/docker/distribution/blob/b6e0cfbdaa1ddc3a17c95142c7bf6e42c5567370/registry/client/blob_writer.go#L61