### PR TITLE
reference: Correct EnsureTagged documentation

### DIFF
--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -123,8 +123,8 @@ func (c canonicalReference) Familiar() Named {
 	}
 }
 
-// EnsureTagged adds the default tag "latest" to a reference if it only has
-// a repo name.
+// EnsureTagged adds the default tag "latest" to a reference if it does not
+// already have a tag.
 func EnsureTagged(ref Named) NamedTagged {
 	namedTagged, ok := ref.(NamedTagged)
 	if !ok {


### PR DESCRIPTION
The current documentation says "EnsureTagged adds the default tag
"latest" to a reference if it only has a repo name.". This is misleading
because it will also add the tag in cases where the reference has a
digest.

cc @dmcgowan