### PR TITLE
reference: Replace EnsureTagged with TagNameOnly

### DIFF
--- a/reference/normalize.go
+++ b/reference/normalize.go
@@ -123,11 +123,10 @@ func (c canonicalReference) Familiar() Named {
 	}
 }
 
-// EnsureTagged adds the default tag "latest" to a reference if it only has
+// TagNameOnly adds the default tag "latest" to a reference if it only has
 // a repo name.
-func EnsureTagged(ref Named) NamedTagged {
-	namedTagged, ok := ref.(NamedTagged)
-	if !ok {
+func TagNameOnly(ref Named) Named {
+	if IsNameOnly(ref) {
 		namedTagged, err := WithTag(ref, defaultTag)
 		if err != nil {
 			// Default tag must be valid, to create a NamedTagged
@@ -137,7 +136,7 @@ func EnsureTagged(ref Named) NamedTagged {
 		}
 		return namedTagged
 	}
-	return namedTagged
+	return ref
 }
 
 // ParseAnyReference parses a reference string as a possible identifier,


### PR DESCRIPTION
The common use case for this function is to add a default tag if the
reference only has a name. The current behavior only adds the default
tag if there is no *tag*, which requires most callers to check for a
digest. Change the behavior to only add default tags to name-only
references, and change the name to reflect this. The documentation
already described the new behavior, so it does not need to be changed.

cc @dmcgowan