### PR TITLE
registry/storage: clean up zero-length blob comments

### DIFF
--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -530,7 +530,7 @@ func TestLayerUploadZeroLength(t *testing.T) {
 	}
 	bs := repository.Blobs(ctx)
 
-	simpleUpload(t, bs, []byte{}, digestSha256EmptyTar)
+	simpleUpload(t, bs, []byte{}, digestSha256Empty)
 }
 
 func simpleUpload(t *testing.T, bs distribution.BlobIngester, blob []byte, expectedDigest digest.Digest) {

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -19,8 +19,8 @@ var (
 )
 
 const (
-	// DigestSha256EmptyTar is the canonical sha256 digest of empty data
-	digestSha256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	// digestSha256Empty is the canonical sha256 digest of empty data
+	digestSha256Empty = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 )
 
 // blobWriter is used to control the various aspects of resumable
@@ -314,7 +314,7 @@ func (bw *blobWriter) moveBlob(ctx context.Context, desc distribution.Descriptor
 	// If no data was received, we may not actually have a file on disk. Check
 	// the size here and write a zero-length file to blobPath if this is the
 	// case. For the most part, this should only ever happen with zero-length
-	// tars.
+	// blobs.
 	if _, err := bw.blobStore.driver.Stat(ctx, bw.path); err != nil {
 		switch err := err.(type) {
 		case storagedriver.PathNotFoundError:
@@ -322,8 +322,8 @@ func (bw *blobWriter) moveBlob(ctx context.Context, desc distribution.Descriptor
 			// get a hash, then the underlying file is deleted, we risk moving
 			// a zero-length blob into a nonzero-length blob location. To
 			// prevent this horrid thing, we employ the hack of only allowing
-			// to this happen for the digest of an empty tar.
-			if desc.Digest == digestSha256EmptyTar {
+			// to this happen for the digest of an empty blob.
+			if desc.Digest == digestSha256Empty {
 				return bw.blobStore.driver.PutContent(ctx, blobPath, []byte{})
 			}
 


### PR DESCRIPTION
A previous inspection of the code surrounding zero-length blobs led to
some interesting question. After inspection, it was found that the hash
was indeed for the empty string (""), and not an empty tar, so the code
was correct. The variable naming and comments have been updated
accordingly.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #2129

cc @aaronlehmann 