### PR TITLE
convert ALL the fmt.Errorf to errors.New if there is no need to format the string

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -627,7 +628,7 @@ func Parse(rd io.Reader) (*Configuration, error) {
 						v0_1.Loglevel = Loglevel("info")
 					}
 					if v0_1.Storage.Type() == "" {
-						return nil, fmt.Errorf("No storage configuration provided")
+						return nil, errors.New("no storage configuration provided")
 					}
 					return (*Configuration)(v0_1), nil
 				}

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -2,7 +2,6 @@ package health
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -98,7 +97,7 @@ func TestHealthHandler(t *testing.T) {
 	checkUp(t, "initial health check")
 
 	// now, we fail the health check
-	updater.Update(fmt.Errorf("the server is now out of commission"))
+	updater.Update(errors.New("the server is now out of commission"))
 	checkDown(t, "server should be down") // should be down
 
 	// bring server back up

--- a/manifest/schema1/reference_builder.go
+++ b/manifest/schema1/reference_builder.go
@@ -1,9 +1,8 @@
 package schema1
 
 import (
-	"fmt"
-
 	"errors"
+
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/manifest"
@@ -58,7 +57,7 @@ func (mb *referenceManifestBuilder) Build(ctx context.Context) (distribution.Man
 func (mb *referenceManifestBuilder) AppendReference(d distribution.Describable) error {
 	r, ok := d.(Reference)
 	if !ok {
-		return fmt.Errorf("Unable to add non-reference type to v1 builder")
+		return errors.New("unable to add non-reference type to v1 builder")
 	}
 
 	// Entries need to be prepended

--- a/notifications/event.go
+++ b/notifications/event.go
@@ -1,8 +1,9 @@
 package notifications
 
 import (
-	"fmt"
 	"time"
+
+	"errors"
 
 	"github.com/docker/distribution"
 )
@@ -143,7 +144,7 @@ var (
 	// ErrSinkClosed is returned if a write is issued to a sink that has been
 	// closed. If encountered, the error should be considered terminal and
 	// retries will not be successful.
-	ErrSinkClosed = fmt.Errorf("sink: closed")
+	ErrSinkClosed = errors.New("sink: closed")
 )
 
 // Sink accepts and sends events.

--- a/notifications/http.go
+++ b/notifications/http.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -116,7 +117,7 @@ func (hs *httpSink) Close() error {
 	defer hs.mu.Unlock()
 
 	if hs.closed {
-		return fmt.Errorf("httpsink: already closed")
+		return errors.New("httpsink: already closed")
 	}
 
 	hs.closed = true

--- a/notifications/sinks.go
+++ b/notifications/sinks.go
@@ -2,7 +2,7 @@ package notifications
 
 import (
 	"container/list"
-	"fmt"
+	"errors"
 	"sync"
 	"time"
 
@@ -61,7 +61,7 @@ func (b *Broadcaster) Close() error {
 	select {
 	case <-b.closed:
 		// already closed
-		return fmt.Errorf("broadcaster: already closed")
+		return errors.New("broadcaster: already closed")
 	default:
 		// do a little chan handoff dance to synchronize closing
 		closed := make(chan struct{})
@@ -157,7 +157,7 @@ func (eq *eventQueue) Close() error {
 	defer eq.mu.Unlock()
 
 	if eq.closed {
-		return fmt.Errorf("eventqueue: already closed")
+		return errors.New("eventqueue: already closed")
 	}
 
 	// set closed flag
@@ -326,7 +326,7 @@ func (rs *retryingSink) Close() error {
 	defer rs.mu.Unlock()
 
 	if rs.closed {
-		return fmt.Errorf("retryingsink: already closed")
+		return errors.New("retryingsink: already closed")
 	}
 
 	rs.closed = true

--- a/registry/api/v2/headerparser.go
+++ b/registry/api/v2/headerparser.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -62,7 +63,7 @@ Loop:
 
 		if len(parse) == 0 {
 			if state != stateElement && state != statePairEnd && state != stateParameter {
-				return nil, parse, fmt.Errorf("unexpected end of input")
+				return nil, parse, errors.New("unexpected end of input")
 			}
 			// terminating
 			break
@@ -121,7 +122,7 @@ Loop:
 			parse = parse[len(match):]
 			switch {
 			case len(parse) == 0:
-				return nil, parse, fmt.Errorf("unterminated quoted string")
+				return nil, parse, errors.New("unterminated quoted string")
 			case parse[0] == '"':
 				res[parameter] = value
 				value = ""

--- a/registry/client/auth/challenge/authchallenge.go
+++ b/registry/client/auth/challenge/authchallenge.go
@@ -1,7 +1,7 @@
 package challenge
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -71,7 +71,7 @@ func (m *simpleManager) GetChallenges(endpoint url.URL) ([]Challenge, error) {
 func (m *simpleManager) AddResponse(resp *http.Response) error {
 	challenges := ResponseChallenges(resp)
 	if resp.Request == nil {
-		return fmt.Errorf("missing request reference")
+		return errors.New("missing request reference")
 	}
 	urlCopy := url.URL{
 		Path:   resp.Request.URL.Path,

--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -320,7 +320,7 @@ func (th *tokenHandler) fetchTokenWithOAuth(realm *url.URL, refreshToken, servic
 		form.Set("access_type", "offline")
 	} else {
 		// refuse to do oauth without a grant type
-		return "", time.Time{}, fmt.Errorf("no supported grant type")
+		return "", time.Time{}, errors.New("no supported grant type")
 	}
 
 	resp, err := th.client().PostForm(realm.String(), form)

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -398,7 +398,7 @@ func (o etagOption) Apply(ms distribution.ManifestService) error {
 		ms.etags[o.tag] = fmt.Sprintf(`"%s"`, o.etag)
 		return nil
 	}
-	return fmt.Errorf("etag options is a client-only option")
+	return errors.New("etag options is a client-only option")
 }
 
 // ReturnContentDigest allows a client to set a the content digest on

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	cryptorand "crypto/rand"
+	"errors"
 	"expvar"
 	"fmt"
 	"math/rand"
@@ -813,7 +814,7 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 			if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthorized); err != nil {
 				ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
 			}
-			return fmt.Errorf("forbidden: no repository name")
+			return errors.New("forbidden: no repository name")
 		}
 		accessRecords = appendCatalogAccessRecord(accessRecords, r)
 	}

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -172,7 +173,7 @@ func (buh *blobUploadHandler) PatchBlobData(w http.ResponseWriter, r *http.Reque
 
 	ct := r.Header.Get("Content-Type")
 	if ct != "" && ct != "application/octet-stream" {
-		buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(fmt.Errorf("Bad Content-Type")))
+		buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(errors.New("Bad Content-Type")))
 		// TODO(dmcgowan): encode error
 		return
 	}

--- a/registry/handlers/context.go
+++ b/registry/handlers/context.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"sync"
 
@@ -52,7 +52,7 @@ func getReference(ctx context.Context) (reference string) {
 	return ctxu.GetStringValue(ctx, "vars.reference")
 }
 
-var errDigestNotAvailable = fmt.Errorf("digest not available in context")
+var errDigestNotAvailable = errors.New("digest not available in context")
 
 func getDigest(ctx context.Context) (dgst digest.Digest, err error) {
 	dgstStr := ctxu.GetStringValue(ctx, "vars.digest")

--- a/registry/handlers/hmac.go
+++ b/registry/handlers/hmac.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -26,7 +26,7 @@ type blobUploadState struct {
 
 type hmacKey string
 
-var errInvalidSecret = fmt.Errorf("invalid secret")
+var errInvalidSecret = errors.New("invalid secret")
 
 // unpackUploadState unpacks and validates the blob upload state from the
 // token, using the hmacKey secret.

--- a/registry/proxy/scheduler/scheduler.go
+++ b/registry/proxy/scheduler/scheduler.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"sync"
 	"time"
 
@@ -86,7 +86,7 @@ func (ttles *TTLExpirationScheduler) AddBlob(blobRef reference.Canonical, ttl ti
 	defer ttles.Unlock()
 
 	if ttles.stopped {
-		return fmt.Errorf("scheduler not started")
+		return errors.New("scheduler not started")
 	}
 
 	ttles.add(blobRef, ttl, entryTypeBlob)
@@ -99,7 +99,7 @@ func (ttles *TTLExpirationScheduler) AddManifest(manifestRef reference.Canonical
 	defer ttles.Unlock()
 
 	if ttles.stopped {
-		return fmt.Errorf("scheduler not started")
+		return errors.New("scheduler not started")
 	}
 
 	ttles.add(manifestRef, ttl, entryTypeManifest)
@@ -117,7 +117,7 @@ func (ttles *TTLExpirationScheduler) Start() error {
 	}
 
 	if !ttles.stopped {
-		return fmt.Errorf("Scheduler already started")
+		return errors.New("Scheduler already started")
 	}
 
 	context.GetLogger(ttles.ctx).Infof("Starting cached object TTL expiration scheduler...")
@@ -186,7 +186,7 @@ func (ttles *TTLExpirationScheduler) startTimer(entry *schedulerEntry, ttl time.
 			f = ttles.onManifestExpire
 		default:
 			f = func(reference.Reference) error {
-				return fmt.Errorf("scheduler entry type")
+				return errors.New("scheduler entry type")
 			}
 		}
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -135,7 +136,7 @@ func (registry *Registry) ListenAndServe() error {
 
 		if config.HTTP.TLS.LetsEncrypt.CacheFile != "" {
 			if config.HTTP.TLS.Certificate != "" {
-				return fmt.Errorf("cannot specify both certificate and Let's Encrypt")
+				return errors.New("cannot specify both certificate and Let's Encrypt")
 			}
 			var m letsencrypt.Manager
 			if err := m.CacheFile(config.HTTP.TLS.LetsEncrypt.CacheFile); err != nil {
@@ -165,7 +166,7 @@ func (registry *Registry) ListenAndServe() error {
 				}
 
 				if ok := pool.AppendCertsFromPEM(caPem); !ok {
-					return fmt.Errorf("Could not add CA to pool")
+					return errors.New("Could not add CA to pool")
 				}
 			}
 
@@ -328,7 +329,7 @@ func resolveConfiguration(args []string) (*configuration.Configuration, error) {
 	}
 
 	if configurationPath == "" {
-		return nil, fmt.Errorf("configuration path unspecified")
+		return nil, errors.New("configuration path unspecified")
 	}
 
 	fp, err := os.Open(configurationPath)

--- a/registry/storage/blob_test.go
+++ b/registry/storage/blob_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -589,7 +590,7 @@ func seekerSize(seeker io.ReadSeeker) (int64, error) {
 	}
 
 	if resumed != current {
-		return 0, fmt.Errorf("error returning seeker to original state, could not seek back to original location")
+		return 0, errors.New("error returning seeker to original state, could not seek back to original location")
 	}
 
 	return end, nil

--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -166,7 +166,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 		// if no descriptors are provided, we have nothing to validate
 		// against. We don't really want to support this for the registry.
 		return distribution.Descriptor{}, distribution.ErrBlobInvalidDigest{
-			Reason: fmt.Errorf("cannot validate against empty digest"),
+			Reason: errors.New("cannot validate against empty digest"),
 		}
 	}
 
@@ -269,7 +269,7 @@ func (bw *blobWriter) validateBlob(ctx context.Context, desc distribution.Descri
 			Errorf("canonical digest does match provided digest")
 		return distribution.Descriptor{}, distribution.ErrBlobInvalidDigest{
 			Digest: desc.Digest,
-			Reason: fmt.Errorf("content does not match digest"),
+			Reason: errors.New("content does not match digest"),
 		}
 	}
 

--- a/registry/storage/catalog_test.go
+++ b/registry/storage/catalog_test.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"fmt"
+	"errors"
 	"io"
 	"math/rand"
 	"testing"
@@ -230,7 +230,7 @@ func newBadListDriver() *badListDriver {
 }
 
 func (d *badListDriver) List(ctx context.Context, path string) ([]string, error) {
-	return nil, fmt.Errorf("List error")
+	return nil, errors.New("List error")
 }
 
 func TestCatalogWalkError(t *testing.T) {

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -5,6 +5,7 @@ package azure
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -426,11 +427,11 @@ func (d *driver) newWriter(path string, size int64) storagedriver.FileWriter {
 
 func (w *writer) Write(p []byte) (int, error) {
 	if w.closed {
-		return 0, fmt.Errorf("already closed")
+		return 0, errors.New("already closed")
 	} else if w.committed {
-		return 0, fmt.Errorf("already committed")
+		return 0, errors.New("already committed")
 	} else if w.cancelled {
-		return 0, fmt.Errorf("already cancelled")
+		return 0, errors.New("already cancelled")
 	}
 
 	n, err := w.bw.Write(p)
@@ -444,7 +445,7 @@ func (w *writer) Size() int64 {
 
 func (w *writer) Close() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	}
 	w.closed = true
 	return w.bw.Flush()
@@ -452,9 +453,9 @@ func (w *writer) Close() error {
 
 func (w *writer) Cancel() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	} else if w.committed {
-		return fmt.Errorf("already committed")
+		return errors.New("already committed")
 	}
 	w.cancelled = true
 	return w.driver.client.DeleteBlob(w.driver.container, w.path, nil)
@@ -462,11 +463,11 @@ func (w *writer) Cancel() error {
 
 func (w *writer) Commit() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	} else if w.committed {
-		return fmt.Errorf("already committed")
+		return errors.New("already committed")
 	} else if w.cancelled {
-		return fmt.Errorf("already cancelled")
+		return errors.New("already cancelled")
 	}
 	w.committed = true
 	return w.bw.Flush()

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -373,11 +374,11 @@ func newFileWriter(file *os.File, size int64) *fileWriter {
 
 func (fw *fileWriter) Write(p []byte) (int, error) {
 	if fw.closed {
-		return 0, fmt.Errorf("already closed")
+		return 0, errors.New("already closed")
 	} else if fw.committed {
-		return 0, fmt.Errorf("already committed")
+		return 0, errors.New("already committed")
 	} else if fw.cancelled {
-		return 0, fmt.Errorf("already cancelled")
+		return 0, errors.New("already cancelled")
 	}
 	n, err := fw.bw.Write(p)
 	fw.size += int64(n)
@@ -390,7 +391,7 @@ func (fw *fileWriter) Size() int64 {
 
 func (fw *fileWriter) Close() error {
 	if fw.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	}
 
 	if err := fw.bw.Flush(); err != nil {
@@ -410,7 +411,7 @@ func (fw *fileWriter) Close() error {
 
 func (fw *fileWriter) Cancel() error {
 	if fw.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	}
 
 	fw.cancelled = true
@@ -420,11 +421,11 @@ func (fw *fileWriter) Cancel() error {
 
 func (fw *fileWriter) Commit() error {
 	if fw.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	} else if fw.committed {
-		return fmt.Errorf("already committed")
+		return errors.New("already committed")
 	} else if fw.cancelled {
-		return fmt.Errorf("already cancelled")
+		return errors.New("already cancelled")
 	}
 
 	if err := fw.bw.Flush(); err != nil {

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -16,6 +16,7 @@ package gcs
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -98,7 +99,7 @@ type driver struct {
 func FromParameters(parameters map[string]interface{}) (storagedriver.StorageDriver, error) {
 	bucket, ok := parameters["bucket"]
 	if !ok || fmt.Sprint(bucket) == "" {
-		return nil, fmt.Errorf("No bucket parameter provided")
+		return nil, errors.New("No bucket parameter provided")
 	}
 
 	rootDirectory, ok := parameters["rootdirectory"]
@@ -435,7 +436,7 @@ func (w *writer) Commit() error {
 
 func (w *writer) checkClosed() error {
 	if w.closed {
-		return fmt.Errorf("Writer already closed")
+		return errors.New("Writer already closed")
 	}
 	return nil
 }

--- a/registry/storage/driver/gcs/gcs_test.go
+++ b/registry/storage/driver/gcs/gcs_test.go
@@ -3,11 +3,13 @@
 package gcs
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"fmt"
+
 	ctx "github.com/docker/distribution/context"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/testsuites"
@@ -214,7 +216,7 @@ func TestRetry(t *testing.T) {
 	assertError("googleapi: Error 404: google api error", err)
 
 	err = retry(func() error {
-		return fmt.Errorf("error")
+		return errors.New("error")
 	})
 	assertError("error", err)
 }

--- a/registry/storage/driver/inmemory/mfs.go
+++ b/registry/storage/driver/inmemory/mfs.go
@@ -1,6 +1,7 @@
 package inmemory
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -10,10 +11,10 @@ import (
 )
 
 var (
-	errExists    = fmt.Errorf("exists")
-	errNotExists = fmt.Errorf("notexists")
-	errIsNotDir  = fmt.Errorf("notdir")
-	errIsDir     = fmt.Errorf("isdir")
+	errExists    = errors.New("exists")
+	errNotExists = errors.New("notexists")
+	errIsNotDir  = errors.New("notdir")
+	errIsDir     = errors.New("isdir")
 )
 
 type node interface {
@@ -177,7 +178,7 @@ func (d *dir) mkdirs(p string) (*dir, error) {
 // mkdir creates a child directory under d with the given name.
 func (d *dir) mkdir(name string) (*dir, error) {
 	if name == "" {
-		return nil, fmt.Errorf("invalid dirname")
+		return nil, errors.New("invalid dirname")
 	}
 
 	_, ok := d.children[name]

--- a/registry/storage/driver/middleware/cloudfront/middleware.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware.go
@@ -6,6 +6,7 @@ package middleware
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -36,11 +37,11 @@ var _ storagedriver.StorageDriver = &cloudFrontStorageMiddleware{}
 func newCloudFrontStorageMiddleware(storageDriver storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error) {
 	base, ok := options["baseurl"]
 	if !ok {
-		return nil, fmt.Errorf("no baseurl provided")
+		return nil, errors.New("no baseurl provided")
 	}
 	baseURL, ok := base.(string)
 	if !ok {
-		return nil, fmt.Errorf("baseurl must be a string")
+		return nil, errors.New("baseurl must be a string")
 	}
 	if !strings.Contains(baseURL, "://") {
 		baseURL = "https://" + baseURL
@@ -53,19 +54,19 @@ func newCloudFrontStorageMiddleware(storageDriver storagedriver.StorageDriver, o
 	}
 	pk, ok := options["privatekey"]
 	if !ok {
-		return nil, fmt.Errorf("no privatekey provided")
+		return nil, errors.New("no privatekey provided")
 	}
 	pkPath, ok := pk.(string)
 	if !ok {
-		return nil, fmt.Errorf("privatekey must be a string")
+		return nil, errors.New("privatekey must be a string")
 	}
 	kpid, ok := options["keypairid"]
 	if !ok {
-		return nil, fmt.Errorf("no keypairid provided")
+		return nil, errors.New("no keypairid provided")
 	}
 	keypairID, ok := kpid.(string)
 	if !ok {
-		return nil, fmt.Errorf("keypairid must be a string")
+		return nil, errors.New("keypairid must be a string")
 	}
 
 	pkBytes, err := ioutil.ReadFile(pkPath)
@@ -75,7 +76,7 @@ func newCloudFrontStorageMiddleware(storageDriver storagedriver.StorageDriver, o
 
 	block, _ := pem.Decode([]byte(pkBytes))
 	if block == nil {
-		return nil, fmt.Errorf("failed to decode private key as an rsa private key")
+		return nil, errors.New("failed to decode private key as an rsa private key")
 	}
 	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {

--- a/registry/storage/driver/middleware/redirect/middleware.go
+++ b/registry/storage/driver/middleware/redirect/middleware.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -20,21 +21,21 @@ var _ storagedriver.StorageDriver = &redirectStorageMiddleware{}
 func newRedirectStorageMiddleware(sd storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error) {
 	o, ok := options["baseurl"]
 	if !ok {
-		return nil, fmt.Errorf("no baseurl provided")
+		return nil, errors.New("no baseurl provided")
 	}
 	b, ok := o.(string)
 	if !ok {
-		return nil, fmt.Errorf("baseurl must be a string")
+		return nil, errors.New("baseurl must be a string")
 	}
 	u, err := url.Parse(b)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse redirect baseurl: %s", b)
 	}
 	if u.Scheme == "" {
-		return nil, fmt.Errorf("no scheme specified for redirect baseurl")
+		return nil, errors.New("no scheme specified for redirect baseurl")
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("no host specified for redirect baseurl")
+		return nil, errors.New("no host specified for redirect baseurl")
 	}
 
 	return &redirectStorageMiddleware{StorageDriver: sd, scheme: u.Scheme, host: u.Host}, nil

--- a/registry/storage/driver/oss/oss.go
+++ b/registry/storage/driver/oss/oss.go
@@ -13,6 +13,7 @@ package oss
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -98,21 +99,21 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 
 	accessKey, ok := parameters["accesskeyid"]
 	if !ok {
-		return nil, fmt.Errorf("No accesskeyid parameter provided")
+		return nil, errors.New("No accesskeyid parameter provided")
 	}
 	secretKey, ok := parameters["accesskeysecret"]
 	if !ok {
-		return nil, fmt.Errorf("No accesskeysecret parameter provided")
+		return nil, errors.New("No accesskeysecret parameter provided")
 	}
 
 	regionName, ok := parameters["region"]
 	if !ok || fmt.Sprint(regionName) == "" {
-		return nil, fmt.Errorf("No region parameter provided")
+		return nil, errors.New("No region parameter provided")
 	}
 
 	bucket, ok := parameters["bucket"]
 	if !ok || fmt.Sprint(bucket) == "" {
-		return nil, fmt.Errorf("No bucket parameter provided")
+		return nil, errors.New("No bucket parameter provided")
 	}
 
 	internalBool := false
@@ -120,7 +121,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	if ok {
 		internalBool, ok = internal.(bool)
 		if !ok {
-			return nil, fmt.Errorf("The internal parameter should be a boolean")
+			return nil, errors.New("The internal parameter should be a boolean")
 		}
 	}
 
@@ -129,7 +130,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	if ok {
 		encryptBool, ok = encrypt.(bool)
 		if !ok {
-			return nil, fmt.Errorf("The encrypt parameter should be a boolean")
+			return nil, errors.New("The encrypt parameter should be a boolean")
 		}
 	}
 
@@ -138,7 +139,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	if ok {
 		secureBool, ok = secure.(bool)
 		if !ok {
-			return nil, fmt.Errorf("The secure parameter should be a boolean")
+			return nil, errors.New("The secure parameter should be a boolean")
 		}
 	}
 
@@ -542,11 +543,11 @@ func (d *driver) newWriter(key string, multi *oss.Multi, parts []oss.Part) stora
 
 func (w *writer) Write(p []byte) (int, error) {
 	if w.closed {
-		return 0, fmt.Errorf("already closed")
+		return 0, errors.New("already closed")
 	} else if w.committed {
-		return 0, fmt.Errorf("already committed")
+		return 0, errors.New("already committed")
 	} else if w.cancelled {
-		return 0, fmt.Errorf("already cancelled")
+		return 0, errors.New("already cancelled")
 	}
 
 	// If the last written part is smaller than minChunkSize, we need to make a
@@ -626,7 +627,7 @@ func (w *writer) Size() int64 {
 
 func (w *writer) Close() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	}
 	w.closed = true
 	return w.flushPart()
@@ -634,9 +635,9 @@ func (w *writer) Close() error {
 
 func (w *writer) Cancel() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	} else if w.committed {
-		return fmt.Errorf("already committed")
+		return errors.New("already committed")
 	}
 	w.cancelled = true
 	err := w.multi.Abort()
@@ -645,11 +646,11 @@ func (w *writer) Cancel() error {
 
 func (w *writer) Commit() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	} else if w.committed {
-		return fmt.Errorf("already committed")
+		return errors.New("already committed")
 	} else if w.cancelled {
-		return fmt.Errorf("already cancelled")
+		return errors.New("already cancelled")
 	}
 	err := w.flushPart()
 	if err != nil {

--- a/registry/storage/driver/s3-goamz/s3.go
+++ b/registry/storage/driver/s3-goamz/s3.go
@@ -14,6 +14,7 @@ package s3
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -112,7 +113,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 
 	regionName := parameters["region"]
 	if regionName == nil || fmt.Sprint(regionName) == "" {
-		return nil, fmt.Errorf("No region parameter provided")
+		return nil, errors.New("No region parameter provided")
 	}
 	region := aws.GetRegion(fmt.Sprint(regionName))
 	if region.Name == "" {
@@ -121,7 +122,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 
 	bucket := parameters["bucket"]
 	if bucket == nil || fmt.Sprint(bucket) == "" {
-		return nil, fmt.Errorf("No bucket parameter provided")
+		return nil, errors.New("No bucket parameter provided")
 	}
 
 	encryptBool := false
@@ -130,7 +131,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	case string:
 		b, err := strconv.ParseBool(encrypt)
 		if err != nil {
-			return nil, fmt.Errorf("The encrypt parameter should be a boolean")
+			return nil, errors.New("The encrypt parameter should be a boolean")
 		}
 		encryptBool = b
 	case bool:
@@ -138,7 +139,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	case nil:
 		// do nothing
 	default:
-		return nil, fmt.Errorf("The encrypt parameter should be a boolean")
+		return nil, errors.New("The encrypt parameter should be a boolean")
 	}
 
 	secureBool := true
@@ -147,7 +148,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	case string:
 		b, err := strconv.ParseBool(secure)
 		if err != nil {
-			return nil, fmt.Errorf("The secure parameter should be a boolean")
+			return nil, errors.New("The secure parameter should be a boolean")
 		}
 		secureBool = b
 	case bool:
@@ -155,7 +156,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	case nil:
 		// do nothing
 	default:
-		return nil, fmt.Errorf("The secure parameter should be a boolean")
+		return nil, errors.New("The secure parameter should be a boolean")
 	}
 
 	v4AuthBool := false
@@ -164,7 +165,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	case string:
 		b, err := strconv.ParseBool(v4Auth)
 		if err != nil {
-			return nil, fmt.Errorf("The v4auth parameter should be a boolean")
+			return nil, errors.New("The v4auth parameter should be a boolean")
 		}
 		v4AuthBool = b
 	case bool:
@@ -172,7 +173,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	case nil:
 		// do nothing
 	default:
-		return nil, fmt.Errorf("The v4auth parameter should be a boolean")
+		return nil, errors.New("The v4auth parameter should be a boolean")
 	}
 
 	chunkSize := int64(defaultChunkSize)
@@ -619,11 +620,11 @@ func (d *driver) newWriter(key string, multi *s3.Multi, parts []s3.Part) storage
 
 func (w *writer) Write(p []byte) (int, error) {
 	if w.closed {
-		return 0, fmt.Errorf("already closed")
+		return 0, errors.New("already closed")
 	} else if w.committed {
-		return 0, fmt.Errorf("already committed")
+		return 0, errors.New("already committed")
 	} else if w.cancelled {
-		return 0, fmt.Errorf("already cancelled")
+		return 0, errors.New("already cancelled")
 	}
 
 	// If the last written part is smaller than minChunkSize, we need to make a
@@ -703,7 +704,7 @@ func (w *writer) Size() int64 {
 
 func (w *writer) Close() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	}
 	w.closed = true
 	return w.flushPart()
@@ -711,9 +712,9 @@ func (w *writer) Close() error {
 
 func (w *writer) Cancel() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	} else if w.committed {
-		return fmt.Errorf("already committed")
+		return errors.New("already committed")
 	}
 	w.cancelled = true
 	err := w.multi.Abort()
@@ -722,11 +723,11 @@ func (w *writer) Cancel() error {
 
 func (w *writer) Commit() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	} else if w.committed {
-		return fmt.Errorf("already committed")
+		return errors.New("already committed")
 	} else if w.cancelled {
-		return fmt.Errorf("already cancelled")
+		return errors.New("already cancelled")
 	}
 	err := w.flushPart()
 	if err != nil {

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha1"
 	"crypto/tls"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -147,19 +148,19 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	}
 
 	if params.Username == "" {
-		return nil, fmt.Errorf("No username parameter provided")
+		return nil, errors.New("No username parameter provided")
 	}
 
 	if params.Password == "" {
-		return nil, fmt.Errorf("No password parameter provided")
+		return nil, errors.New("No password parameter provided")
 	}
 
 	if params.AuthURL == "" {
-		return nil, fmt.Errorf("No authurl parameter provided")
+		return nil, errors.New("No authurl parameter provided")
 	}
 
 	if params.Container == "" {
-		return nil, fmt.Errorf("No container parameter provided")
+		return nil, errors.New("No container parameter provided")
 	}
 
 	if params.ChunkSize < minChunkSize {
@@ -736,7 +737,7 @@ func chunkFilenames(slice []string, maxSize int) (chunks [][]string, err error) 
 			chunks = append(chunks, slice[offset:offset+chunkSize])
 		}
 	} else {
-		return nil, fmt.Errorf("Max chunk size must be > 0")
+		return nil, errors.New("Max chunk size must be > 0")
 	}
 	return
 }
@@ -795,11 +796,11 @@ func (d *driver) newWriter(path, segmentsPath string, segments []swift.Object) s
 
 func (w *writer) Write(p []byte) (int, error) {
 	if w.closed {
-		return 0, fmt.Errorf("already closed")
+		return 0, errors.New("already closed")
 	} else if w.committed {
-		return 0, fmt.Errorf("already committed")
+		return 0, errors.New("already committed")
 	} else if w.cancelled {
-		return 0, fmt.Errorf("already cancelled")
+		return 0, errors.New("already cancelled")
 	}
 
 	n, err := w.bw.Write(p)
@@ -813,7 +814,7 @@ func (w *writer) Size() int64 {
 
 func (w *writer) Close() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	}
 
 	if err := w.bw.Flush(); err != nil {
@@ -835,9 +836,9 @@ func (w *writer) Close() error {
 
 func (w *writer) Cancel() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	} else if w.committed {
-		return fmt.Errorf("already committed")
+		return errors.New("already committed")
 	}
 	w.cancelled = true
 	return w.driver.Delete(context.Background(), w.path)
@@ -845,11 +846,11 @@ func (w *writer) Cancel() error {
 
 func (w *writer) Commit() error {
 	if w.closed {
-		return fmt.Errorf("already closed")
+		return errors.New("already closed")
 	} else if w.committed {
-		return fmt.Errorf("already committed")
+		return errors.New("already committed")
 	} else if w.cancelled {
-		return fmt.Errorf("already cancelled")
+		return errors.New("already cancelled")
 	}
 
 	if err := w.bw.Flush(); err != nil {

--- a/registry/storage/filereader.go
+++ b/registry/storage/filereader.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"bufio"
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -90,7 +90,7 @@ func (fr *fileReader) Seek(offset int64, whence int) (int64, error) {
 	}
 
 	if newOffset < 0 {
-		err = fmt.Errorf("cannot seek to negative position")
+		err = errors.New("cannot seek to negative position")
 	} else {
 		if fr.offset != newOffset {
 			fr.reset()
@@ -104,7 +104,7 @@ func (fr *fileReader) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (fr *fileReader) Close() error {
-	return fr.closeWithErr(fmt.Errorf("fileReader: closed"))
+	return fr.closeWithErr(errors.New("fileReader: closed"))
 }
 
 // reader prepares the current reader at the lrs offset, ensuring its buffered

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/docker/distribution"
@@ -18,7 +19,7 @@ func emit(format string, a ...interface{}) {
 func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, registry distribution.Namespace, dryRun bool) error {
 	repositoryEnumerator, ok := registry.(distribution.RepositoryEnumerator)
 	if !ok {
-		return fmt.Errorf("unable to convert Namespace to RepositoryEnumerator")
+		return errors.New("unable to convert Namespace to RepositoryEnumerator")
 	}
 
 	// mark
@@ -43,7 +44,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 
 		manifestEnumerator, ok := manifestService.(distribution.ManifestEnumerator)
 		if !ok {
-			return fmt.Errorf("unable to convert ManifestService into ManifestEnumerator")
+			return errors.New("unable to convert ManifestService into ManifestEnumerator")
 		}
 
 		err = manifestEnumerator.Enumerate(ctx, func(dgst digest.Digest) error {

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -1,9 +1,11 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 
 	"encoding/json"
+
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/manifest"
@@ -35,7 +37,7 @@ func (o skipLayerOption) Apply(m distribution.ManifestService) error {
 		ms.skipDependencyVerification = true
 		return nil
 	}
-	return fmt.Errorf("skip layer verification only valid for manifestStore")
+	return errors.New("skip layer verification only valid for manifestStore")
 }
 
 type manifestStore struct {

--- a/registry/storage/signedmanifesthandler.go
+++ b/registry/storage/signedmanifesthandler.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/docker/distribution"
@@ -98,7 +99,7 @@ func (ms *signedManifestHandler) verifyManifest(ctx context.Context, mnfst schem
 		errs = append(errs,
 			distribution.ErrManifestNameInvalid{
 				Name:   mnfst.Name,
-				Reason: fmt.Errorf("invalid manifest name format"),
+				Reason: errors.New("invalid manifest name format"),
 			})
 	}
 

--- a/registry/storage/walk_test.go
+++ b/registry/storage/walk_test.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"fmt"
+	"errors"
 	"sort"
 	"testing"
 
@@ -51,7 +51,7 @@ func TestWalkErrors(t *testing.T) {
 		t.Error("Expected invalid root err")
 	}
 
-	errEarlyExpected := fmt.Errorf("Early termination")
+	errEarlyExpected := errors.New("Early termination")
 
 	err = Walk(ctx, d, "/", func(fileInfo driver.FileInfo) error {
 		// error on the 2nd file

--- a/testutil/tarfile.go
+++ b/testutil/tarfile.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"archive/tar"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	mrand "math/rand"
@@ -57,7 +58,7 @@ func CreateRandomTarFile() (rs io.ReadSeeker, dgst digest.Digest, err error) {
 
 		nn, err := io.Copy(wr, bytes.NewReader(randomData))
 		if nn != fileSize {
-			return nil, "", fmt.Errorf("short copy writing random file to tar")
+			return nil, "", errors.New("short copy writing random file to tar")
 		}
 
 		if err != nil {

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -6,6 +6,7 @@ package uuid
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -25,7 +26,7 @@ const (
 
 var (
 	// ErrUUIDInvalid indicates a parsed string is not a valid uuid.
-	ErrUUIDInvalid = fmt.Errorf("invalid uuid")
+	ErrUUIDInvalid = errors.New("invalid uuid")
 
 	// Loggerf can be used to override the default logging destination. Such
 	// log messages in this library should be logged at warning or higher.


### PR DESCRIPTION
as the Go source said , `fmt.Errorf` is just the combination of `fmt.Sprintf` and `errors.New`:
```go
// Errorf formats according to a format specifier and returns the string
// as a value that satisfies error.
func Errorf(format string, a ...interface{}) error {
	return errors.New(Sprintf(format, a...))
}
```
Signed-off-by: kaiwentan <kaiwentan@harmonycloud.cn>

