### PR TITLE
notifications: fix expvar for Go 1.7

### DIFF
--- a/notifications/endpoint.go
+++ b/notifications/endpoint.go
@@ -13,7 +13,7 @@ type EndpointConfig struct {
 	Threshold         int
 	Backoff           time.Duration
 	IgnoredMediaTypes []string
-	Transport         *http.Transport
+	Transport         *http.Transport `json:"-"`
 }
 
 // defaults set any zero-valued fields to a reasonable default.

--- a/notifications/metrics_test.go
+++ b/notifications/metrics_test.go
@@ -1,0 +1,28 @@
+package notifications
+
+import (
+	"encoding/json"
+	"expvar"
+	"testing"
+)
+
+func TestMetricsExpvar(t *testing.T) {
+	endpointsVar := expvar.Get("registry").(*expvar.Map).Get("notifications").(*expvar.Map).Get("endpoints")
+
+	var v interface{}
+	if err := json.Unmarshal([]byte(endpointsVar.String()), &v); err != nil {
+		t.Fatalf("unexpected error unmarshaling endpoints: %v", err)
+	}
+	if v != nil {
+		t.Fatalf("expected nil, got %#v", v)
+	}
+
+	NewEndpoint("x", "y", EndpointConfig{})
+
+	if err := json.Unmarshal([]byte(endpointsVar.String()), &v); err != nil {
+		t.Fatalf("unexpected error unmarshaling endpoints: %v", err)
+	}
+	if slice, ok := v.([]interface{}); !ok || len(slice) != 1 {
+		t.Logf("expected one-element []interface{}, got %#v", v)
+	}
+}


### PR DESCRIPTION
Remove EndpointConfig from the registry.notifications.endpoints
expvar.Func's return value.  It results in an empty value for that
expvar variable under Go 1.7 because it contains a non-nil
*http.Transport, which Go 1.7 can no longer encode as JSON.

Removing EndpointConfig has the additional benefit of protecting any secrets in EndpointConfig.Headers.

If keeping EndpointConfig is a goal, an alternative fix is to set epjson.EndpointConfig.Transport to nil.