### PR TITLE
refactor the code style in distribution/registry/storage/driver/s3-goamz/s3.go

### DIFF
--- a/registry/storage/driver/s3-goamz/s3.go
+++ b/registry/storage/driver/s3-goamz/s3.go
@@ -443,13 +443,13 @@ func (d *driver) List(ctx context.Context, opath string) ([]string, error) {
 			directories = append(directories, strings.Replace(commonPrefix[0:len(commonPrefix)-1], d.s3Path(""), prefix, 1))
 		}
 
-		if listResponse.IsTruncated {
-			listResponse, err = d.Bucket.List(d.s3Path(path), "/", listResponse.NextMarker, listMax)
-			if err != nil {
-				return nil, err
-			}
-		} else {
+		if !listResponse.IsTruncated {
 			break
+		}
+
+		listResponse, err = d.Bucket.List(d.s3Path(path), "/", listResponse.NextMarker, listMax)
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
It took me a long time to understand when I read these lines of code.
Through my refactoring, this part of the code is easier to understand.


Signed-off-by: uhayate <uhayate.gong@daocloud.io>