### PR TITLE
Use errors.New() to output the error message and fix some typos

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -152,7 +152,7 @@ type BlobProvider interface {
 
 // BlobServer can serve blobs via http.
 type BlobServer interface {
-	// ServeBlob attempts to serve the blob, identifed by dgst, via http. The
+	// ServeBlob attempts to serve the blob, identified by dgst, via http. The
 	// service may decide to redirect the client elsewhere or serve the data
 	// directly.
 	//

--- a/cmd/digest/main.go
+++ b/cmd/digest/main.go
@@ -32,7 +32,7 @@ func init() {
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "usage: %s [files...]\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, `
+	fmt.Fprint(os.Stderr, `
 Calculate the digest of one or more input files, emitting the result
 to standard out. If no files are provided, the digest of stdin will
 be calculated.

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -132,7 +133,7 @@ type Configuration struct {
 
 		// HTTP2 configuration options
 		HTTP2 struct {
-			// Specifies wether the registry should disallow clients attempting
+			// Specifies whether the registry should disallow clients attempting
 			// to connect via http2. If set to true, only http/1.1 is supported.
 			Disabled bool `yaml:"disabled,omitempty"`
 		} `yaml:"http2,omitempty"`
@@ -235,7 +236,7 @@ type LogHook struct {
 	// Levels set which levels of log message will let hook executed.
 	Levels []string `yaml:"levels,omitempty"`
 
-	// MailOptions allows user to configurate email parameters.
+	// MailOptions allows user to configure email parameters.
 	MailOptions MailOptions `yaml:"options,omitempty"`
 }
 
@@ -627,7 +628,7 @@ func Parse(rd io.Reader) (*Configuration, error) {
 						v0_1.Loglevel = Loglevel("info")
 					}
 					if v0_1.Storage.Type() == "" {
-						return nil, fmt.Errorf("No storage configuration provided")
+						return nil, errors.New("No storage configuration provided")
 					}
 					return (*Configuration)(v0_1), nil
 				}

--- a/errors.go
+++ b/errors.go
@@ -77,7 +77,7 @@ func (err ErrManifestUnknownRevision) Error() string {
 type ErrManifestUnverified struct{}
 
 func (ErrManifestUnverified) Error() string {
-	return fmt.Sprintf("unverified manifest")
+	return "unverified manifest"
 }
 
 // ErrManifestVerification provides a type to collect errors encountered


### PR DESCRIPTION
Use errors.New() directly to output the error message and fix some typos I found.

Signed-off-by: fate-grand-order <chenjg@harmonycloud.cn>