### PR TITLE
go 1.8: update dockerfile and circle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7-alpine
+FROM golang:1.8-alpine
 
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
 ENV DOCKER_BUILDTAGS include_oss include_gcs

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
 
   post:
   # go
-    - gvm install go1.7 --prefer-binary --name=stable
+    - gvm install go1.8 --prefer-binary --name=stable
 
   environment:
   # Convenient shortcuts to "common" locations


### PR DESCRIPTION
Build with go 1.8

There is one known regression with 1.8 but we can update to 1.8.1 before the next release.
See https://github.com/golang/go/issues/19182