### PR TITLE
Avoid including standard port

### DIFF
--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -46,6 +46,11 @@ func NewURLBuilderFromString(root string, relative bool) (*URLBuilder, error) {
 	return NewURLBuilder(u, relative), nil
 }
 
+var portMap = map[string]string{
+	"http":  "80",
+	"https": "443",
+}
+
 // NewURLBuilderFromRequest uses information from an *http.Request to
 // construct the root url.
 func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
@@ -95,7 +100,9 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 		ports := strings.SplitN(forwardedPort, ",", 2)
 		forwardedPort = strings.TrimSpace(ports[0])
 		if _, err := strconv.ParseInt(forwardedPort, 10, 32); err == nil {
-			port = forwardedPort
+			if forwardedPort != portMap[scheme] {
+				port = forwardedPort
+			}
 		}
 	}
 

--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -83,10 +83,10 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 		host = h
 	}
 
-	portLessHost, port := host, ""
+	portlessHost, port := host, ""
 	if !isIPv6Address(host) {
 		// with go 1.6, this would treat the last part of IPv6 address as a port
-		portLessHost, port, _ = net.SplitHostPort(host)
+		portlessHost, port, _ = net.SplitHostPort(host)
 	}
 	if forwardedPort := r.Header.Get("X-Forwarded-Port"); len(port) == 0 && len(forwardedPort) > 0 {
 		ports := strings.SplitN(forwardedPort, ",", 2)
@@ -96,8 +96,8 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 		}
 	}
 
-	if len(portLessHost) > 0 {
-		host = portLessHost
+	if len(portlessHost) > 0 {
+		host = portlessHost
 	}
 	if len(port) > 0 {
 		// remove enclosing brackets of ipv6 address otherwise they will be duplicated

--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -87,6 +87,9 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 	if !isIPv6Address(host) {
 		// with go 1.6, this would treat the last part of IPv6 address as a port
 		portlessHost, port, _ = net.SplitHostPort(host)
+		if len(portlessHost) > 0 {
+			host = portlessHost
+		}
 	}
 	if forwardedPort := r.Header.Get("X-Forwarded-Port"); len(port) == 0 && len(forwardedPort) > 0 {
 		ports := strings.SplitN(forwardedPort, ",", 2)
@@ -96,9 +99,6 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 		}
 	}
 
-	if len(portlessHost) > 0 {
-		host = portlessHost
-	}
 	if len(port) > 0 {
 		// remove enclosing brackets of ipv6 address otherwise they will be duplicated
 		if len(host) > 1 && host[0] == '[' && host[len(host)-1] == ']' {

--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -84,7 +84,7 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 	}
 
 	portLessHost, port := host, ""
-	if !isIPv6Address(portLessHost) {
+	if !isIPv6Address(host) {
 		// with go 1.6, this would treat the last part of IPv6 address as a port
 		portLessHost, port, _ = net.SplitHostPort(host)
 	}

--- a/registry/api/v2/urls_test.go
+++ b/registry/api/v2/urls_test.go
@@ -265,6 +265,22 @@ func TestBuilderFromRequest(t *testing.T) {
 			base: "http://example.com:443",
 		},
 		{
+			name: "forwarded standard port with non-standard headers",
+			request: &http.Request{URL: u, Host: u.Host, Header: http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-Port":  []string{"443"},
+			}},
+			base: "https://example.com",
+		},
+		{
+			name: "forwarded standard port with non-standard headers and explicit port",
+			request: &http.Request{URL: u, Host: u.Host + ":443", Header: http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-Port":  []string{"443"},
+			}},
+			base: "https://example.com:443",
+		},
+		{
 			name: "several non-standard headers",
 			request: &http.Request{URL: u, Host: u.Host, Header: http.Header{
 				"X-Forwarded-Proto": []string{"https"},


### PR DESCRIPTION
I operate a registry and yesterday upgraded the registry framework (https://github.com/docker/distribution/compare/feddf6cd4e439577ab270d8e3ba63a5d7c5c0d55...v2.6.0).

#2008 (1b43e1e30d6ed171412d88e883660f9b2d51bb0b) introduced a breaking change that would start appending port numbers to generated URLs. This would break clients treating "https://example.com/" and "https://example.com:443/" as different registries (which at the time of the merge was all clients).

When 2.6.0 later got released, [a changelog entry](https://github.com/docker/distribution/blob/v2.6.0/CHANGELOG.md#registry) states:

> Honor `X-Forwarded-Port` and Forwarded headers

I would have expected this to mention that it might break clients. Especially as the only compatible client, 1.13.0, shipped the day of the aforementioned release. (The potential issue had already been resolved in #1868 but didn't get integrated until docker/docker#28235.)

For me, it means that the version I upgraded to yesterday doesn't support users who didn't upgrade in the past two months...

I'm curious what the recommendation is; is there any official testing of backward compatibility? I can certainly wait longer before I upgrade but I'm not convinced there is any guarantee of forward compatibility either.

That said, the potential breakage is easily avoidable by not including standard ports. I'm surprised this wasn't considered in docker/docker#18469 when the incompatibility was brought up.

I hope you'll consider this change so no more users and registries are affected.