### PR TITLE
Remove expires tag from s3 upload

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -701,15 +701,11 @@ func (d *driver) copy(ctx context.Context, sourcePath string, destPath string) e
 		return nil
 	}
 
-	// Even in the worst case, a multipart copy should take no more
-	// than a few minutes, so 30 minutes is very conservative.
-	expires := time.Now().Add(time.Duration(30) * time.Minute)
 	createResp, err := d.S3.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
 		Bucket:               aws.String(d.Bucket),
 		Key:                  aws.String(d.s3Path(destPath)),
 		ContentType:          d.getContentType(),
 		ACL:                  d.getACL(),
-		Expires:              aws.Time(expires),
 		SSEKMSKeyId:          d.getSSEKMSKeyID(),
 		ServerSideEncryption: d.getEncryptionMode(),
 		StorageClass:         d.getStorageClass(),


### PR DESCRIPTION
As discussed in https://github.com/docker/distribution/issues/2194, when uploading to S3, the Expires tag should not be set as it causes caches to not cache layers after 30 minutes. See documentation https://docs.aws.amazon.com/sdk-for-go/api/service/s3/ and search for Expires.

Signed-off-by: Alvin Feng <alvin4feng@yahoo.com>