### PR TITLE
Fix vendor validation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -50,7 +50,7 @@ test:
     - gvm use stable && go version
 
   # Ensure validation of dependencies
-    - gvm use stable && if test -n "`git diff --stat=1000 master | grep -E \"^[[:space:]]*vendor\"`"; then make dep-validate; fi:
+    - gvm use stable && if test -n "`git diff --stat=1000 origin/master | grep -E \"^[[:space:]]*vendor\"`"; then make dep-validate; fi:
         pwd: $BASE_STABLE
 
   # First thing: build everything. This will catch compile errors, and it's


### PR DESCRIPTION
The dep-validate target appears to never get invoked. In the CircleCI
build environment, "master" points to the commit under test. The
circle.yml fragment needs to compare again "origin/master" instead.