### PR TITLE
Support session token

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -98,6 +98,7 @@ type DriverParameters struct {
 	StorageClass                string
 	UserAgent                   string
 	ObjectACL                   string
+	SessionToken                string
 }
 
 func init() {
@@ -331,6 +332,8 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		objectACL = objectACLString
 	}
 
+	sessionToken := ""
+
 	params := DriverParameters{
 		fmt.Sprint(accessKey),
 		fmt.Sprint(secretKey),
@@ -349,6 +352,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		storageClass,
 		fmt.Sprint(userAgent),
 		objectACL,
+		fmt.Sprint(sessionToken),
 	}
 
 	return New(params)
@@ -398,6 +402,7 @@ func New(params DriverParameters) (*Driver, error) {
 			Value: credentials.Value{
 				AccessKeyID:     params.AccessKey,
 				SecretAccessKey: params.SecretKey,
+				SessionToken:    params.SessionToken,
 			},
 		},
 		&credentials.EnvProvider{},

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -36,6 +36,7 @@ func init() {
 	objectACL := os.Getenv("S3_OBJECT_ACL")
 	root, err := ioutil.TempDir("", "driver-")
 	regionEndpoint := os.Getenv("REGION_ENDPOINT")
+	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
 	if err != nil {
 		panic(err)
 	}
@@ -84,6 +85,7 @@ func init() {
 			storageClass,
 			driverName + "-test",
 			objectACL,
+			sessionToken,
 		}
 
 		return New(parameters)

--- a/registry/storage/driver/s3-aws/s3_v2_signer.go
+++ b/registry/storage/driver/s3-aws/s3_v2_signer.go
@@ -137,6 +137,9 @@ func (v2 *signer) Sign() error {
 	host, canonicalPath := parsedURL.Host, parsedURL.Path
 	v2.Request.Header["Host"] = []string{host}
 	v2.Request.Header["date"] = []string{v2.Time.In(time.UTC).Format(time.RFC1123)}
+	if credValue.SessionToken != "" {
+		v2.Request.Header["x-amz-security-token"] = []string{credValue.SessionToken}
+	}
 
 	smap = make(map[string]string)
 	for k, v := range headers {


### PR DESCRIPTION
Amazon supports [making requests using temporary security credentials](http://docs.aws.amazon.com/AmazonS3/latest/dev/MakingRequests.html#requestsUsingTempCred). This requires a session token besides the access key ID and secret access key.