### PR TITLE
Add "upstream" to /v2/ headers for proxy registries.

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -46,6 +46,9 @@ type Namespace interface {
 
 	// BlobStatter returns a BlobStatter to control
 	BlobStatter() BlobStatter
+
+	// TODO(amidlash): Consider returning notary instead of upstream here.
+	Upstream() string
 }
 
 // RepositoryEnumerator describes an operation to enumerate repositories

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -175,6 +175,13 @@ func (pr *proxyingRegistry) BlobStatter() distribution.BlobStatter {
 	return pr.embedded.BlobStatter()
 }
 
+// TODO(amidlash): It might be more natural to have the registry return the notary instance.
+// We wouldn't be able to clean up the check in docker/docker however, without breaking
+// docker-content-trust on other distribution instances.
+func (pr *proxyingRegistry) Upstream() string {
+	return pr.remoteURL.String()
+}
+
 // authChallenger encapsulates a request to the upstream to establish credential challenges
 type authChallenger interface {
 	tryEstablishChallenges(context.Context) error

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -179,6 +179,12 @@ func (reg *registry) BlobStatter() distribution.BlobStatter {
 	return reg.statter
 }
 
+// Only proxy instances have an upstream. Return "" to indicate that there
+// is no upstream.
+func (reg *registry) Upstream() string {
+	return ""
+}
+
 // repository provides name-scoped access to various services.
 type repository struct {
 	*registry


### PR DESCRIPTION
Along with https://github.com/docker/docker/pull/32278 , this
will allow users to pull securely from mirror registries, as long
as the upstream has a notary.

Signed-off-by: Alexander Midlash <amidlash@docker.com>