### PR TITLE
Add support to build docker-distribution on ARM 32bit

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,32 @@
+FROM armhf/debian:jessie
+
+ENV GOROOT /usr/local/go
+ENV GOPATH $GOROOT/bin
+
+ENV DISTRIBUTION_DIR $GOROOT/src/github.com/docker/distribution
+ENV DOCKER_BUILDTAGS include_oss include_gcs
+
+RUN apt update && apt upgrade -y && \
+    apt install -y make git curl
+
+RUN cd /var/tmp; \
+    curl -O https://storage.googleapis.com/golang/go1.8.1.linux-armv6l.tar.gz; \
+    tar -C /usr/local -xzf go1.8.1.linux-armv6l.tar.gz; \
+    rm go1.8.1.linux-armv6l.tar.gz
+
+ENV PATH $PATH:$GOPATH
+
+RUN mkdir -p $GOROOT/src/github.com/opencontainers; \
+    cd $GOROOT/src/github.com/opencontainers; \
+    git clone https://github.com/opencontainers/go-digest
+
+WORKDIR $DISTRIBUTION_DIR
+COPY . $DISTRIBUTION_DIR
+COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
+
+RUN make PREFIX=$GOROOT clean binaries
+
+VOLUME ["/var/lib/registry"]
+EXPOSE 5000
+ENTRYPOINT ["registry"]
+CMD ["serve", "/etc/docker/registry/config.yml"]


### PR DESCRIPTION
I've add Dockerfile.armhf for support ARM 32bit, especially for Raspberry Pi3.

This Dockerfile use go1.8.1 and baseimage is armhf/debian:jessie.
