### PR TITLE
reference: allow more than 1 digest algorithm separator

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -15,7 +15,7 @@
 //	tag                             := /[\w][\w.-]{0,127}/
 //
 //	digest                          := digest-algorithm ":" digest-hex
-//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]
+//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]*
 //	digest-algorithm-separator      := /[+.-_]/
 //	digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
 //	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value


### PR DESCRIPTION
This updates the grammar to allow more than one digest algorithm
separator, matching the regular expression and intended grammar.

Signed-off-by: Stephen J Day <stephen.day@docker.com>