### PR TITLE
Return early to prevent nil pointer dereference

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -859,8 +859,11 @@ func (app *App) eventBridge(ctx *Context, r *http.Request) notifications.Listene
 // nameRequired returns true if the route requires a name.
 func (app *App) nameRequired(r *http.Request) bool {
 	route := mux.CurrentRoute(r)
+	if route == nil {
+		return true
+	}
 	routeName := route.GetName()
-	return route == nil || (routeName != v2.RouteNameBase && routeName != v2.RouteNameCatalog)
+	return routeName != v2.RouteNameBase && routeName != v2.RouteNameCatalog
 }
 
 // apiBase implements a simple yes-man for doing overall checks against the


### PR DESCRIPTION
I was using an old version of [mux](https://github.com/gorilla/mux) which caused this to blow up.