### PR TITLE
On Success Chunk upload should be 202 Accepted in Documentation

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -4084,7 +4084,7 @@ The following parameters should be specified on the request:
 ###### On Success: Chunk Accepted
 
 ```
-204 No Content
+202 Accepted
 Location: /v2/<name>/blobs/uploads/<uuid>
 Range: 0-<offset>
 Content-Length: 0


### PR DESCRIPTION
there is a discrepancy within the documentation. Further down at line 4087 the patch chunk upload response status is 204. It appears 204 is the correct response status. not 202.