### PR TITLE
Increase Unit Test Code Coverage

### DIFF
--- a/contrib/token-server/token_test.go
+++ b/contrib/token-server/token_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/docker/distribution/registry/auth"
+	"github.com/docker/libtrust"
+	"strings"
+)
+
+func TestCreateJWTSuccessWithEmptyACL(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk, err := libtrust.FromCryptoPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenIssuer := TokenIssuer{
+		Expiration: time.Duration(100),
+		Issuer:     "localhost",
+		SigningKey: pk,
+	}
+
+	grantedAccessList := make([]auth.Access, 0, 0)
+	token, err := tokenIssuer.CreateJWT("test", "test", grantedAccessList)
+
+	tokens := strings.Split(token, ".")
+
+	if len(token) == 0 {
+		t.Fatal("token not generated.")
+	}
+
+	json, err := decodeJWT(tokens[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(json, "test") {
+		t.Fatal("Valid token was not generated.")
+	}
+
+}
+
+func decodeJWT(rawToken string) (string, error) {
+	data, err := joseBase64Decode(rawToken)
+	if err != nil {
+		return "", errors.New("Error in Decoding base64 String")
+	}
+	return data, nil
+}
+
+func joseBase64Decode(s string) (string, error) {
+	switch len(s) % 4 {
+	case 0:
+	case 2:
+		s += "=="
+	case 3:
+		s += "="
+	default:
+		{
+			return "", errors.New("Invalid base64 String")
+		}
+	}
+	data, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return "", err //errors.New("Error in Decoding base64 String")
+	}
+	return string(data), nil
+}

--- a/contrib/token-server/token_test.go
+++ b/contrib/token-server/token_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"strings"
+
 	"github.com/docker/distribution/registry/auth"
 	"github.com/docker/libtrust"
-	"strings"
 )
 
 func TestCreateJWTSuccessWithEmptyACL(t *testing.T) {
@@ -28,8 +29,11 @@ func TestCreateJWTSuccessWithEmptyACL(t *testing.T) {
 		SigningKey: pk,
 	}
 
-	grantedAccessList := make([]auth.Access, 0, 0)
+	grantedAccessList := make([]auth.Access, 0)
 	token, err := tokenIssuer.CreateJWT("test", "test", grantedAccessList)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tokens := strings.Split(token, ".")
 

--- a/notifications/http_test.go
+++ b/notifications/http_test.go
@@ -10,10 +10,10 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/docker/distribution/manifest/schema1"
-	"strings"
 )
 
 // TestHTTPSink mocks out an http endpoint and notifies it under a couple of

--- a/notifications/http_test.go
+++ b/notifications/http_test.go
@@ -10,10 +10,10 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/docker/distribution/manifest/schema1"
+	"strings"
 )
 
 // TestHTTPSink mocks out an http endpoint and notifies it under a couple of
@@ -70,7 +70,7 @@ func TestHTTPSink(t *testing.T) {
 	// first make sure that the default transport gives x509 untrusted cert error
 	events := []Event{}
 	err := sink.Write(events...)
-	if !strings.Contains(err.Error(), "x509") {
+	if !strings.Contains(err.Error(), "x509") && !strings.Contains(err.Error(), "unknown ca") {
 		t.Fatal("TLS server with default transport should give unknown CA error")
 	}
 	if err := sink.Close(); err != nil {

--- a/registry/storage/driver/middleware/cloudfront/middleware_test.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware_test.go
@@ -1,11 +1,11 @@
 package middleware
 
 import (
-	"testing"
-
-	check "gopkg.in/check.v1"
 	"io/ioutil"
 	"os"
+	"testing"
+
+	"gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { check.TestingT(t) }

--- a/registry/storage/driver/middleware/cloudfront/middleware_test.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware_test.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"testing"
+
+	check "gopkg.in/check.v1"
+	"io/ioutil"
+	"os"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type MiddlewareSuite struct{}
+
+var _ = check.Suite(&MiddlewareSuite{})
+
+func (s *MiddlewareSuite) TestNoConfig(c *check.C) {
+	options := make(map[string]interface{})
+	_, err := newCloudFrontStorageMiddleware(nil, options)
+	c.Assert(err, check.ErrorMatches, "no baseurl provided")
+}
+
+func TestCloudFrontStorageMiddlewareGenerateKey(t *testing.T) {
+
+	options := make(map[string]interface{})
+	options["baseurl"] = "example.com"
+
+	var privk = `-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQCy0ZZsItDuYoX3y6hWqyU9YdH/0B+tlOhvjlaJqvkmAIBBatVV
+VAShnEAEircBwV3i08439WYgjXnrZ0FjXBTjTKWwCsbpuWJY1w8hqHW3VDivUo1n
+F9WTeclVJuEMhmiAhek3dhUdATaEDqBNskXMofSgKmQHqhPdXCgDmnzKoQIDAQAB
+AoGBAJM0xI8qrjLAeqa+SktmwtZgM99StvFPt3U2iPj1/fsRyIOR7iM7ckCUf4L9
+qqBQTfjQAmDArR05OlfW/dZM1IfUagiAh+Ss7KTt+re1U0sNwoAk8yJlbYAD+0Qy
+vuMowSDoMnGe/5RJbdqK9n5lUZ7aZk8ybumJeuHb/ykVkU7tAkEA6LoqdQAZ9wwX
+7l0gewwCiAFCYMTuGQcvd5OcjToeCQOgn94YZHQybm1DtGg3+c1raVE5M0xw7Hbs
+P6KCC+Le4wJBAMSzXB7DpBFOpd8AvGNkfo/ESGCDHg3JbNxQh531zeD6Gmm4uEF+
+42J1CVMyPLw5NoBh83GK08FftwN9xXIZw6sCQBnfiJTVXA2hJI/1foTvguCH8086
+1ZWmvNo4aPEyguBRrOvZDzEr0eeA8kP+SirVcZmV1Bwl5XAEkKNKd9bGdC0CQFLi
+wY61Ig2o9nxh8wBu+GXccCM7HQ7yMc0kogEN8xM6UKb8D6iJr4dtieBk6vLlqPGw
+VMUjmteBXb064liSQsECQQDAdw9jH1Y7SJf/aujlrIuzeei3hJ6HdP1OrfM24CK1
+pZeMRablbPQdp8/1NyIwimq1VlG0ohQ4P6qhW7E09ZMC
+-----END RSA PRIVATE KEY-----
+`
+
+	file, err := ioutil.TempFile("", "pkey")
+	if err != nil {
+		t.Fatal("File cannot be created")
+	}
+	file.WriteString(privk)
+	defer os.Remove(file.Name())
+	options["privatekey"] = file.Name()
+	options["keypairid"] = "test"
+	storageDriver, err := newCloudFrontStorageMiddleware(nil, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storageDriver == nil {
+		t.Fatal("Driver couldnt be initialized.")
+	}
+}

--- a/registry/storage/driver/testsuites/testsuites.go
+++ b/registry/storage/driver/testsuites/testsuites.go
@@ -3,7 +3,7 @@ package testsuites
 import (
 	"bytes"
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -278,7 +278,7 @@ func (suite *DriverSuite) TestWriteReadLargeStreams(c *check.C) {
 	filename := randomPath(32)
 	defer suite.deletePath(c, firstPart(filename))
 
-	checksum := sha1.New()
+	checksum := sha256.New()
 	var fileSize int64 = 5 * 1024 * 1024 * 1024
 
 	contents := newRandReader(fileSize)
@@ -298,7 +298,7 @@ func (suite *DriverSuite) TestWriteReadLargeStreams(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer reader.Close()
 
-	writtenChecksum := sha1.New()
+	writtenChecksum := sha256.New()
 	io.Copy(writtenChecksum, reader)
 
 	c.Assert(writtenChecksum.Sum(nil), check.DeepEquals, checksum.Sum(nil))


### PR DESCRIPTION
Unit test coverge was increased to cover the usages of crypto. This helps to ensure that everything is working fine with fips mode enabled.
Also updated sha1 to sha256 in registry/storage/driver/testsuites/testsuites.go because sha1 is not supported in fips mode.

Signed-off-by: Naveed Jamil <naveed.jamil@tenpearls.com>