### PR TITLE
catalog api check manifests

### DIFF
--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -137,8 +137,8 @@ func handleRepository(fileInfo driver.FileInfo, root, last string, fn func(repoP
 	repo := filePath[len(root)+1:]
 
 	_, file := path.Split(repo)
-	if file == "_layers" {
-		repo = strings.TrimSuffix(repo, "/_layers")
+	if file == "_manifests" {
+		repo = strings.TrimSuffix(repo, "/_manifests")
 		if lessPath(last, repo) {
 			if err := fn(repo); err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: Masataka Mizukoshi <m.mizukoshi.wakuwaku@gmail.com>
I think catalog api should only list images that we can pull.  
So , I changed that the catalog api check the _manifests directories not _layers directories.
See #2273.
