### PR TITLE
Add ARGs for cross-compiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM golang:1.8-alpine
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
 ENV DOCKER_BUILDTAGS include_oss include_gcs
 
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 RUN set -ex \
     && apk add --no-cache make git
 


### PR DESCRIPTION
Add build args. Defaults to Linux/x64 so no change to existing image, but can build for other platforms - e.g.
```
docker build --build-arg GOOS=windows -t distribution-builder:windows .
```

(Replaces #2209).