### PR TITLE
add possibility to clean untagged manifests

### DIFF
--- a/registry/root.go
+++ b/registry/root.go
@@ -18,6 +18,7 @@ func init() {
 	RootCmd.AddCommand(ServeCmd)
 	RootCmd.AddCommand(GCCmd)
 	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
+	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-untagged", "m", false, "delete manifests that are not currently referenced via tag")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 }
 
@@ -36,6 +37,7 @@ var RootCmd = &cobra.Command{
 }
 
 var dryRun bool
+var removeUntagged bool
 
 // GCCmd is the cobra command that corresponds to the garbage-collect subcommand
 var GCCmd = &cobra.Command{
@@ -75,7 +77,10 @@ var GCCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = storage.MarkAndSweep(ctx, driver, registry, dryRun)
+		err = storage.MarkAndSweep(ctx, driver, registry, storage.GCOpts{
+			DryRun:         dryRun,
+			RemoveUntagged: removeUntagged,
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to garbage collect: %v", err)
 			os.Exit(1)

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -14,8 +14,21 @@ func emit(format string, a ...interface{}) {
 	fmt.Printf(format+"\n", a...)
 }
 
+// GCOpts contains options for garbage collector
+type GCOpts struct {
+	DryRun         bool
+	RemoveUntagged bool
+}
+
+// ManifestDel contains manifest structure which will be deleted
+type ManifestDel struct {
+	Name   string
+	Digest digest.Digest
+	Tags   []string
+}
+
 // MarkAndSweep performs a mark and sweep of registry data
-func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, registry distribution.Namespace, dryRun bool) error {
+func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, registry distribution.Namespace, opts GCOpts) error {
 	repositoryEnumerator, ok := registry.(distribution.RepositoryEnumerator)
 	if !ok {
 		return fmt.Errorf("unable to convert Namespace to RepositoryEnumerator")
@@ -23,6 +36,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 
 	// mark
 	markSet := make(map[digest.Digest]struct{})
+	manifestArr := make([]ManifestDel, 0)
 	err := repositoryEnumerator.Enumerate(ctx, func(repoName string) error {
 		emit(repoName)
 
@@ -47,6 +61,25 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 		}
 
 		err = manifestEnumerator.Enumerate(ctx, func(dgst digest.Digest) error {
+			if opts.RemoveUntagged {
+				// fetch all tags where this manifest is the latest one
+				tags, err := repository.Tags(ctx).Lookup(ctx, distribution.Descriptor{Digest: dgst})
+				if err != nil {
+					return fmt.Errorf("failed to retrieve tags for digest %v: %v", dgst, err)
+				}
+				if len(tags) == 0 {
+					emit("manifest eligible for deletion: %s", dgst)
+					// fetch all tags from repository
+					// all of these tags could contain manifest in history
+					// which means that we need check (and delete) those references when deleting manifest
+					allTags, err := repository.Tags(ctx).All(ctx)
+					if err != nil {
+						return fmt.Errorf("failed to retrieve tags %v", err)
+					}
+					manifestArr = append(manifestArr, ManifestDel{Name: repoName, Digest: dgst, Tags: allTags})
+					return nil
+				}
+			}
 			// Mark the manifest's blob
 			emit("%s: marking manifest %s ", repoName, dgst)
 			markSet[dgst] = struct{}{}
@@ -84,6 +117,15 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 	}
 
 	// sweep
+	vacuum := NewVacuum(ctx, storageDriver)
+	if !opts.DryRun {
+		for _, obj := range manifestArr {
+			err = vacuum.RemoveManifest(obj.Name, obj.Digest, obj.Tags)
+			if err != nil {
+				return fmt.Errorf("failed to delete manifest %s: %v", obj.Digest, err)
+			}
+		}
+	}
 	blobService := registry.Blobs()
 	deleteSet := make(map[digest.Digest]struct{})
 	err = blobService.Enumerate(ctx, func(dgst digest.Digest) error {
@@ -96,12 +138,10 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 	if err != nil {
 		return fmt.Errorf("error enumerating blobs: %v", err)
 	}
-	emit("\n%d blobs marked, %d blobs eligible for deletion", len(markSet), len(deleteSet))
-	// Construct vacuum
-	vacuum := NewVacuum(ctx, storageDriver)
+	emit("\n%d blobs marked, %d blobs and %d manifests eligible for deletion", len(markSet), len(deleteSet), len(manifestArr))
 	for dgst := range deleteSet {
 		emit("blob eligible for deletion: %s", dgst)
-		if dryRun {
+		if opts.DryRun {
 			continue
 		}
 		err = vacuum.RemoveBlob(string(dgst))


### PR DESCRIPTION
fixes issue https://github.com/docker/distribution/issues/2301


```
% docker tag alpine:3.4 localhost:5000/alpine:latest
% docker push localhost:5000/alpine:latest
The push refers to a repository [localhost:5000/alpine]
8539d1fe4fab: Pushed
latest: digest: sha256:36fbf18a36d0410de46201a76b7cfb1d69d44a8f407d6a0814517247b896f8e9 size: 528
% docker tag alpine:latest localhost:5000/alpine:latest
% docker push localhost:5000/alpine:latest
The push refers to a repository [localhost:5000/alpine]
3fb66f713c9f: Pushed
latest: digest: sha256:0b94d1d1b5eb130dd0253374552445b39470653fb1a1ec2d81490948876e462c size: 528
```

now the situation is that there is two manifests, and only one has active tag.

New flag added 'm'

```
% docker exec f519ebf4cc51 registry garbage-collect
configuration error: configuration path unspecified

Usage:
  registry garbage-collect <config> [flags]
Flags:
  -m, --delete-manifests=false: delete manifests which does not have tag attached
  -d, --dry-run=false: do everything except remove the blobs
  -h, --help=false: help for garbage-collect
```


old behaviour:

```
% docker exec f519ebf4cc51 registry garbage-collect /etc/docker/registry/config.yml
alpine
alpine: marking manifest sha256:0b94d1d1b5eb130dd0253374552445b39470653fb1a1ec2d81490948876e462c
alpine: marking blob sha256:a41a7446062d197dd4b21b38122dcc7b2399deb0750c4110925a7dd37c80f118
alpine: marking blob sha256:2aecc7e1714b6fad58d13aedb0639011b37b86f743ba7b6a52d82bd03014b78e
alpine: marking manifest sha256:36fbf18a36d0410de46201a76b7cfb1d69d44a8f407d6a0814517247b896f8e9
alpine: marking blob sha256:6008ce38ddc131d5fc1e35b4a06b78fa1388ca94fd8efc1246fcbc44b45b6b74
alpine: marking blob sha256:486a8e636d6250a74d15cdb3582f4dd198271a80118f5a2f59de3d9cd8433611

6 blobs marked, 0 blobs and 0 manifests eligible for deletion
```

disk in this point:

```
 registry % du -h -d 1
4.2M	./v2
4.2M	.
```

new feature:

```
% docker exec f519ebf4cc51 registry garbage-collect -m /etc/docker/registry/config.yml
alpine
alpine: marking manifest sha256:0b94d1d1b5eb130dd0253374552445b39470653fb1a1ec2d81490948876e462c
alpine: marking blob sha256:a41a7446062d197dd4b21b38122dcc7b2399deb0750c4110925a7dd37c80f118
alpine: marking blob sha256:2aecc7e1714b6fad58d13aedb0639011b37b86f743ba7b6a52d82bd03014b78e
manifest has no tags alpine@sha256:36fbf18a36d0410de46201a76b7cfb1d69d44a8f407d6a0814517247b896f8e9

3 blobs marked, 3 blobs and 1 manifests eligible for deletion
manifest eligible for deletion: sha256:36fbf18a36d0410de46201a76b7cfb1d69d44a8f407d6a0814517247b896f8e9
time="2017-06-06T07:56:30.226753065Z" level=info msg="Deleting manifest: /docker/registry/v2/repositories/alpine/_manifests/revisions/sha256/36fbf18a36d0410de46201a76b7cfb1d69d44a8f407d6a0814517247b896f8e9" go.version=go1.8.3 instance.id=a36f92ea-3c7a-420b-8fbb-4392722dc61c
blob eligible for deletion: sha256:36fbf18a36d0410de46201a76b7cfb1d69d44a8f407d6a0814517247b896f8e9
time="2017-06-06T07:56:30.236785668Z" level=info msg="Deleting blob: /docker/registry/v2/blobs/sha256/36/36fbf18a36d0410de46201a76b7cfb1d69d44a8f407d6a0814517247b896f8e9" go.version=go1.8.3 instance.id=a36f92ea-3c7a-420b-8fbb-4392722dc61c
blob eligible for deletion: sha256:486a8e636d6250a74d15cdb3582f4dd198271a80118f5a2f59de3d9cd8433611
time="2017-06-06T07:56:30.248873403Z" level=info msg="Deleting blob: /docker/registry/v2/blobs/sha256/48/486a8e636d6250a74d15cdb3582f4dd198271a80118f5a2f59de3d9cd8433611" go.version=go1.8.3 instance.id=a36f92ea-3c7a-420b-8fbb-4392722dc61c
blob eligible for deletion: sha256:6008ce38ddc131d5fc1e35b4a06b78fa1388ca94fd8efc1246fcbc44b45b6b74
time="2017-06-06T07:56:30.25450166Z" level=info msg="Deleting blob: /docker/registry/v2/blobs/sha256/60/6008ce38ddc131d5fc1e35b4a06b78fa1388ca94fd8efc1246fcbc44b45b6b74" go.version=go1.8.3 instance.id=a36f92ea-3c7a-420b-8fbb-4392722dc61c
```

disk after this:

```
 registry % du -h -d 1
1.9M	./v2
1.9M	.
```