### PR TITLE
Update Docker-Content-Digest if manifest list is rewritten

### DIFF
--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -183,6 +183,8 @@ func (imh *manifestHandler) GetManifest(w http.ResponseWriter, r *http.Request) 
 			if err != nil {
 				return
 			}
+		} else {
+			imh.Digest = manifestDigest
 		}
 	}
 


### PR DESCRIPTION
If the client doesn't support manifest lists, the registry will rewrite a manifest list into the old format. The Docker-Content-Digest header should be updated in this case.