### PR TITLE
Fixing image manifest schema2 medaitype typo in docs.

### DIFF
--- a/docs/spec/manifest-v2-2.md
+++ b/docs/spec/manifest-v2-2.md
@@ -60,8 +60,8 @@ image manifest based on the Content-Type returned in the HTTP response.
     - **`mediaType`** *string*
 
         The MIME type of the referenced object. This will generally be
-        `application/vnd.docker.image.manifest.v2+json`, but it could also
-        be `application/vnd.docker.image.manifest.v1+json` if the manifest
+        `application/vnd.docker.distribution.manifest.v2+json`, but it could also
+        be `application/vnd.docker.distribution.manifest.v1+json` if the manifest
         list references a legacy schema-1 manifest.
 
     - **`size`** *int*
@@ -123,7 +123,7 @@ image manifest based on the Content-Type returned in the HTTP response.
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
     {
-      "mediaType": "application/vnd.docker.image.manifest.v2+json",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
       "size": 7143,
       "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
       "platform": {
@@ -132,7 +132,7 @@ image manifest based on the Content-Type returned in the HTTP response.
       }
     },
     {
-      "mediaType": "application/vnd.docker.image.manifest.v2+json",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
       "size": 7682,
       "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
       "platform": {


### PR DESCRIPTION
Docs need to correspond to what is actually in the code.
