### PR TITLE
Inherit the data from the main logger when setting up the request one

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -600,6 +600,7 @@ func (app *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	ctx = ctxu.WithRequest(ctx, r)
 	ctx, w = ctxu.WithResponseWriter(ctx, w)
+	ctx = ctxu.WithLogger(ctx, ctxu.GetLogger(app.Context))
 	ctx = ctxu.WithLogger(ctx, ctxu.GetRequestLogger(ctx))
 	r = r.WithContext(ctx)
 


### PR DESCRIPTION
As the request context doesn't have an initial logger, it default to an empty one, losing the data set in the main one.
This change will set the request's context logger to be the app one, add the request data on top of that.
That allows setting logging fields app-wide and have them logged on all requests.

Note: this relies on #2323