### PR TITLE
Serve JSON errors

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -826,6 +826,10 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 			if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthorized.WithDetail(accessRecords)); err != nil {
 				ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
 			}
+		case errcode.Error:
+			if err := errcode.ServeJSON(w, err); err != nil {
+				ctxu.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
+			}
 		default:
 			// This condition is a potential security problem either in
 			// the configuration or whatever is backing the access


### PR DESCRIPTION
This will allow to serve a proper JSON response for `errcode.Error`.

Currently, only two types of errors can be served: 

1. [`auth.Challenge`](https://github.com/docker/distribution/blob/1935c8d50b6b9d3fa8a5fcdb860cd3241a35e8df/registry/handlers/app.go#L822-L828) which is always an unauthorized response.
2. [`default`](https://github.com/docker/distribution/blob/1935c8d50b6b9d3fa8a5fcdb860cd3241a35e8df/registry/handlers/app.go#L829-L835) which is always a bad request without a JSON response causing the client to break:
   
   > error parsing HTTP 400 response body: unexpected end of JSON input: ""

The concrete use case is being able to respond that the targeted repository doesn't exist or that access is forbidden. Likewise, it could inform suspended or unverified users of their status.

This addresses part of #1682.