### PR TITLE
fix misspelling "algorithm" for cache/redis/redis.go

### DIFF
--- a/registry/storage/cache/redis/redis.go
+++ b/registry/storage/cache/redis/redis.go
@@ -224,7 +224,7 @@ func (rsrbds *repositoryScopedRedisBlobDescriptorService) SetDescriptor(ctx cont
 
 	if dgst != desc.Digest {
 		if dgst.Algorithm() == desc.Digest.Algorithm() {
-			return fmt.Errorf("redis cache: digest for descriptors differ but algorthim does not: %q != %q", dgst, desc.Digest)
+			return fmt.Errorf("redis cache: digest for descriptors differ but algorithm does not: %q != %q", dgst, desc.Digest)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Helen Chen <chenjg@harmonycloud.cn>