### PR TITLE
add CONTRIBUTING info for security issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,14 @@ Then please do not open an issue here yet - you should first try one of the foll
  - irc: #docker-distribution on freenode
  - mailing-list: <distribution@dockerproject.org> or https://groups.google.com/a/dockerproject.org/forum/#!forum/distribution
 
+### Reporting security issues
+
+The Docker maintainers take security seriously. If you discover a security
+issue, please bring it to their attention right away!
+
+Please **DO NOT** file a public issue, instead send your report privately to
+[security@docker.com](mailto:security@docker.com).
+
 ## Reporting an issue properly
 
 By following these simple rules you will get better and faster feedback on your issue.


### PR DESCRIPTION
Mimicking [other docker projects](https://github.com/moby/moby/blob/master/CONTRIBUTING.md#reporting-security-issues).

cc @stevvooe @dmcgowan @aaronlehmann 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>