### PR TITLE
registry: remove dependency on logrus for client

### DIFF
--- a/registry/storage/blobcachemetrics.go
+++ b/registry/storage/blobcachemetrics.go
@@ -1,9 +1,11 @@
 package storage
 
 import (
+	"context"
 	"expvar"
 	"sync/atomic"
 
+	dcontext "github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/storage/cache"
 )
 
@@ -23,6 +25,10 @@ func (bsc *blobStatCollector) Miss() {
 
 func (bsc *blobStatCollector) Metrics() cache.Metrics {
 	return bsc.metrics
+}
+
+func (bsc *blobStatCollector) Logger(ctx context.Context) cache.Logger {
+	return dcontext.GetLogger(ctx)
 }
 
 // blobStatterCacheMetrics keeps track of cache metrics for blob descriptor


### PR DESCRIPTION
To simplify the vendoring story for the client, we have now removed the
requirement for `logrus` and the forked `context` package (usually
imported as `dcontext`). We inject the logger via the metrics tracker
for the blob cache and via options on the token handler. We preserve
logs on the proxy cache for that case. Clients expecting these log
messages may need to be updated accordingly.

Signed-off-by: Stephen J Day <stephen.day@docker.com>