### PR TITLE
Only use custom AWS credentials when necessary

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -28,8 +28,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -397,25 +395,25 @@ func New(params DriverParameters) (*Driver, error) {
 	}
 
 	awsConfig := aws.NewConfig()
-	creds := credentials.NewChainCredentials([]credentials.Provider{
-		&credentials.StaticProvider{
+
+	// Only set the static provider if AccessKey and SecretKey are set in params.
+	// When these values are empty, the default credential provider chain will be used.
+	if params.AccessKey != "" && params.SecretKey != "" {
+		creds := credentials.NewCredentials(&credentials.StaticProvider{
 			Value: credentials.Value{
 				AccessKeyID:     params.AccessKey,
 				SecretAccessKey: params.SecretKey,
 				SessionToken:    params.SessionToken,
 			},
-		},
-		&credentials.EnvProvider{},
-		&credentials.SharedCredentialsProvider{},
-		&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(session.New())},
-	})
+		})
+		awsConfig.WithCredentials(creds)
+	}
 
 	if params.RegionEndpoint != "" {
 		awsConfig.WithS3ForcePathStyle(true)
 		awsConfig.WithEndpoint(params.RegionEndpoint)
 	}
 
-	awsConfig.WithCredentials(creds)
 	awsConfig.WithRegion(params.Region)
 	awsConfig.WithDisableSSL(!params.Secure)
 


### PR DESCRIPTION
This actually fixes #1937.

I believe it was incorrectly closed because updating the library should have fixed it, but I found it was still not working in our ECS environment. Doing some more digging, I found that the credential provider chain was being re-implemented in distribution to accommodate the `accesskey` and `secretkey` configuration. This patch only uses `credentials.StaticProvider` when the configuration values are available -- when they aren't, it will use the default credential chain in aws-sdk-go.