### PR TITLE
registry/handlers: ignore notfound on storage driver healthcheck

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -346,7 +346,10 @@ func (app *App) RegisterHealthChecks(healthRegistries ...*health.Registry) {
 
 		storageDriverCheck := func() error {
 			_, err := app.driver.Stat(app, "/") // "/" should always exist
-			return err                          // any error will be treated as failure
+			if _, ok := err.(storagedriver.PathNotFoundError); ok {
+				err = nil // pass this through, backend is responding, but this path doesn't exist.
+			}
+			return err
 		}
 
 		if app.Config.Health.StorageDriver.Threshold != 0 {


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>

I think this is the right fix. It would be great if someone could give this a try. Let me know if you need instructions.

 cc @dumyan @liclac @deterralba @beniwtv @pollosp @oms

Closes #2292