### PR TITLE
If the request already has the scope, don't fetchToken again

### DIFF
--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -279,6 +279,9 @@ func (th *tokenHandler) getToken(params map[string]string, additionalScopes ...s
 	}
 	var addedScopes bool
 	for _, scope := range additionalScopes {
+		if hasScope(scopes, scope) {
+			continue
+		}
 		scopes = append(scopes, scope)
 		addedScopes = true
 	}
@@ -300,6 +303,15 @@ func (th *tokenHandler) getToken(params map[string]string, additionalScopes ...s
 	}
 
 	return th.tokenCache, nil
+}
+
+func hasScope(scopes []string, scope string) bool {
+	for _, s := range scopes {
+		if s == scope {
+			return true
+		}
+	}
+	return false
 }
 
 type postTokenResponse struct {


### PR DESCRIPTION
AuthorizeRequest() injects the 'pull' scope if `from` is set unconditionally. If the current token already has that scope, it will be inserted into the scope list twice and `addedScopes` will be set to
true, resulting in a new token being fetched that has no net new scopes.

Instead, check whether `additionalScopes` are actually new.

Signed-off-by: Clayton Coleman <ccoleman@redhat.com>