### PR TITLE
Support HEAD requests without Docker-Content-Digest header

### DIFF
--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -321,7 +321,8 @@ func (t *tags) Get(ctx context.Context, tag string) (distribution.Descriptor, er
 	defer resp.Body.Close()
 
 	switch {
-	case resp.StatusCode >= 200 && resp.StatusCode < 400:
+	case resp.StatusCode >= 200 && resp.StatusCode < 400 && len(resp.Header.Get("Docker-Content-Digest")) > 0:
+		// if the response is a success AND a Docker-Content-Digest can be retrieved from the headers
 		return descriptorFromResponse(resp)
 	default:
 		// if the response is an error - there will be no body to decode.


### PR DESCRIPTION
A statically hosted registry that responds correctly to GET with a manifest will load the right digest (by looking at the manifest body and calculating the digest). If the registry returns a HEAD without
`Docker-Content-Digest`, then the client Tags().Get() call will return an empty digest.

This commit changes the client to fallback to loading the tag via GET if the `Docker-Content-Digest` header is not set.

This allows a static S3 bucket to serve as a registry for the distribution registry client (since S3 cannot set Docker-Content-Digest, but it can serve the manifest correctly). The daemon is able to pull successfully as well.