### PR TITLE
Remove context in NewRegistry and NewRepository

### DIFF
--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -62,7 +62,7 @@ func checkHTTPRedirect(req *http.Request, via []*http.Request) error {
 }
 
 // NewRegistry creates a registry namespace which can be used to get a listing of repositories
-func NewRegistry(ctx context.Context, baseURL string, transport http.RoundTripper) (Registry, error) {
+func NewRegistry(baseURL string, transport http.RoundTripper) (Registry, error) {
 	ub, err := v2.NewURLBuilderFromString(baseURL, false)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,6 @@ func NewRegistry(ctx context.Context, baseURL string, transport http.RoundTrippe
 	return &registry{
 		client:  client,
 		ub:      ub,
-		context: ctx,
 	}, nil
 }
 
@@ -133,7 +132,7 @@ func (r *registry) Repositories(ctx context.Context, entries []string, last stri
 }
 
 // NewRepository creates a new Repository for the given repository name and base URL.
-func NewRepository(ctx context.Context, name reference.Named, baseURL string, transport http.RoundTripper) (distribution.Repository, error) {
+func NewRepository(name reference.Named, baseURL string, transport http.RoundTripper) (distribution.Repository, error) {
 	ub, err := v2.NewURLBuilderFromString(baseURL, false)
 	if err != nil {
 		return nil, err
@@ -149,7 +148,6 @@ func NewRepository(ctx context.Context, name reference.Named, baseURL string, tr
 		client:  client,
 		ub:      ub,
 		name:    name,
-		context: ctx,
 	}, nil
 }
 
@@ -192,7 +190,6 @@ func (r *repository) Tags(ctx context.Context) distribution.TagService {
 	return &tags{
 		client:  r.client,
 		ub:      r.ub,
-		context: r.context,
 		name:    r.Named(),
 	}
 }
@@ -201,7 +198,6 @@ func (r *repository) Tags(ctx context.Context) distribution.TagService {
 type tags struct {
 	client  *http.Client
 	ub      *v2.URLBuilder
-	context context.Context
 	name    reference.Named
 }
 

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -75,8 +75,8 @@ func NewRegistry(baseURL string, transport http.RoundTripper) (Registry, error) 
 	}
 
 	return &registry{
-		client:  client,
-		ub:      ub,
+		client: client,
+		ub:     ub,
 	}, nil
 }
 
@@ -145,9 +145,9 @@ func NewRepository(name reference.Named, baseURL string, transport http.RoundTri
 	}
 
 	return &repository{
-		client:  client,
-		ub:      ub,
-		name:    name,
+		client: client,
+		ub:     ub,
+		name:   name,
 	}, nil
 }
 
@@ -188,17 +188,17 @@ func (r *repository) Manifests(ctx context.Context, options ...distribution.Mani
 
 func (r *repository) Tags(ctx context.Context) distribution.TagService {
 	return &tags{
-		client:  r.client,
-		ub:      r.ub,
-		name:    r.Named(),
+		client: r.client,
+		ub:     r.ub,
+		name:   r.Named(),
 	}
 }
 
 // tags implements remote tagging operations.
 type tags struct {
-	client  *http.Client
-	ub      *v2.URLBuilder
-	name    reference.Named
+	client *http.Client
+	ub     *v2.URLBuilder
+	name   reference.Named
 }
 
 // All returns all tags

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -118,7 +118,7 @@ func TestBlobDelete(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestBlobFetch(t *testing.T) {
 
 	ctx := context.Background()
 	repo, _ := reference.WithName("test.example.com/repo1")
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +194,7 @@ func TestBlobExistsNoContentLength(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +220,7 @@ func TestBlobExists(t *testing.T) {
 
 	ctx := context.Background()
 	repo, _ := reference.WithName("test.example.com/repo1")
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,7 +325,7 @@ func TestBlobUploadChunked(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -435,7 +435,7 @@ func TestBlobUploadMonolithic(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -512,7 +512,7 @@ func TestBlobMount(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -723,7 +723,7 @@ func TestV1ManifestFetch(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	r, err := NewRepository(context.Background(), repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -795,7 +795,7 @@ func TestManifestFetchWithEtag(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -836,7 +836,7 @@ func TestManifestDelete(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	r, err := NewRepository(context.Background(), repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -899,7 +899,7 @@ func TestManifestPut(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	r, err := NewRepository(context.Background(), repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -952,7 +952,7 @@ func TestManifestTags(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	r, err := NewRepository(context.Background(), repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1009,7 +1009,7 @@ func TestObtainsErrorForMissingTag(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1040,7 +1040,7 @@ func TestObtainsManifestForTagWithoutHeaders(t *testing.T) {
 	defer c()
 
 	ctx := context.Background()
-	r, err := NewRepository(ctx, repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1098,7 +1098,7 @@ func TestManifestTagsPaginated(t *testing.T) {
 
 	s.Config.Handler = testutil.NewHandler(m)
 
-	r, err := NewRepository(context.Background(), repo, s.URL, nil)
+	r, err := NewRepository(repo, s.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1146,7 +1146,7 @@ func TestManifestUnauthorized(t *testing.T) {
 	e, c := testServer(m)
 	defer c()
 
-	r, err := NewRepository(context.Background(), repo, e, nil)
+	r, err := NewRepository(repo, e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1183,7 +1183,7 @@ func TestCatalog(t *testing.T) {
 
 	entries := make([]string, 5)
 
-	r, err := NewRegistry(context.Background(), e, nil)
+	r, err := NewRegistry(e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1215,7 +1215,7 @@ func TestCatalogInParts(t *testing.T) {
 
 	entries := make([]string, 2)
 
-	r, err := NewRegistry(context.Background(), e, nil)
+	r, err := NewRegistry(e, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/proxy/proxyregistry.go
+++ b/registry/proxy/proxyregistry.go
@@ -146,7 +146,7 @@ func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named
 		return nil, err
 	}
 
-	remoteRepo, err := client.NewRepository(ctx, name, pr.remoteURL.String(), tr)
+	remoteRepo, err := client.NewRepository(name, pr.remoteURL.String(), tr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The context parameter was either not used or misused.

Signed-off-by: Tibor Vass <teabee89@gmail.com>