### PR TITLE
Allow clients to request specific manifest media types

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -73,6 +73,21 @@ func (o WithTagOption) Apply(m ManifestService) error {
 	return nil
 }
 
+// WithManifestMediaTypes lists the media types the client wishes
+// the server to provide.
+func WithManifestMediaTypes(mediaTypes []string) ManifestServiceOption {
+	return WithManifestMediaTypesOption{mediaTypes}
+}
+
+// WithManifestMediaTypesOption holds a list of accepted media types
+type WithManifestMediaTypesOption struct{ MediaTypes []string }
+
+// Apply conforms to the ManifestServiceOption interface
+func (o WithManifestMediaTypesOption) Apply(m ManifestService) error {
+	// no implementation
+	return nil
+}
+
 // Repository is a named collection of manifests and layers.
 type Repository interface {
 	// Named returns the name of the repository.

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -418,18 +418,22 @@ func (ms *manifests) Get(ctx context.Context, dgst digest.Digest, options ...dis
 		ref         reference.Named
 		err         error
 		contentDgst *digest.Digest
+		mediaTypes  []string
 	)
 
 	for _, option := range options {
-		if opt, ok := option.(distribution.WithTagOption); ok {
+		switch opt := option.(type) {
+		case distribution.WithTagOption:
 			digestOrTag = opt.Tag
 			ref, err = reference.WithTag(ms.name, opt.Tag)
 			if err != nil {
 				return nil, err
 			}
-		} else if opt, ok := option.(contentDigestOption); ok {
+		case contentDigestOption:
 			contentDgst = opt.digest
-		} else {
+		case distribution.WithManifestMediaTypesOption:
+			mediaTypes = opt.MediaTypes
+		default:
 			err := option.Apply(ms)
 			if err != nil {
 				return nil, err
@@ -445,6 +449,10 @@ func (ms *manifests) Get(ctx context.Context, dgst digest.Digest, options ...dis
 		}
 	}
 
+	if len(mediaTypes) == 0 {
+		mediaTypes = distribution.ManifestMediaTypes()
+	}
+
 	u, err := ms.ub.BuildManifestURL(ref)
 	if err != nil {
 		return nil, err
@@ -455,7 +463,7 @@ func (ms *manifests) Get(ctx context.Context, dgst digest.Digest, options ...dis
 		return nil, err
 	}
 
-	for _, t := range distribution.ManifestMediaTypes() {
+	for _, t := range mediaTypes {
 		req.Header.Add("Accept", t)
 	}
 


### PR DESCRIPTION
The current registry/client sends the registered manifest types in
random order. Allow clients to request a single specific manifest type
or a preferred order as per the HTTP spec.

Fixes #2385

Signed-off-by: Clayton Coleman <ccoleman@redhat.com>