### PR TITLE
Allow path ends with '/'. 

### DIFF
--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -109,7 +109,7 @@ type FileWriter interface {
 // number of path components separated by slashes, where each component is
 // restricted to alphanumeric characters or a period, underscore, or
 // hyphen.
-var PathRegexp = regexp.MustCompile(`^(/[A-Za-z0-9._-]+)+$`)
+var PathRegexp = regexp.MustCompile(`^(/[A-Za-z0-9._-]+)+/?$`)
 
 // ErrUnsupportedMethod may be returned in the case where a StorageDriver implementation does not support an optional method.
 type ErrUnsupportedMethod struct {


### PR DESCRIPTION
This fixes "oss: invalid path: /docker/registry/v2/repositories/" error when using oss storage driver.