### PR TITLE
digest-algorithm-component regex

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -332,7 +332,7 @@ digest. The _hex_ portion is the hex-encoded result of the hash.
 We define a _digest_ string to match the following grammar:
 ```
 digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
+algorithm   := /[A-Za-z0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -332,7 +332,7 @@ digest. The _hex_ portion is the hex-encoded result of the hash.
 We define a _digest_ string to match the following grammar:
 ```
 digest      := algorithm ":" hex
-algorithm   := /[A-Za-z0-9_+.-]+/
+algorithm   := /[A-Fa-f0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -332,7 +332,7 @@ digest. The _hex_ portion is the hex-encoded result of the hash.
 We define a _digest_ string to match the following grammar:
 ```
 digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
+algorithm   := /[A-Za-z0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 


### PR DESCRIPTION
A algorithm name can include other letters than a-f.

`digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/`
https://github.com/docker/distribution/blob/master/reference/reference.go#L20

Closes https://github.com/docker/docker.github.io/issues/4776

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>