### PR TITLE
Write logs to file

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -43,6 +43,11 @@ type Configuration struct {
 		// Hooks allows users to configure the log hooks, to enabling the
 		// sequent handling behavior, when defined levels of log message emit.
 		Hooks []LogHook `yaml:"hooks,omitempty"`
+
+		// OutputFormat allows users to specify where to output the logs.
+		OutputFormat struct {
+			FileOutput string `yaml:"file,omitempty"`
+		} `yaml:"output,omitempty"`
 	}
 
 	// Loglevel is the level at which registry operations are logged. This is

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -22,10 +22,13 @@ var configStruct = Configuration{
 		AccessLog struct {
 			Disabled bool `yaml:"disabled,omitempty"`
 		} `yaml:"accesslog,omitempty"`
-		Level     Loglevel               `yaml:"level"`
-		Formatter string                 `yaml:"formatter,omitempty"`
-		Fields    map[string]interface{} `yaml:"fields,omitempty"`
-		Hooks     []LogHook              `yaml:"hooks,omitempty"`
+		Level        Loglevel               `yaml:"level"`
+		Formatter    string                 `yaml:"formatter,omitempty"`
+		Fields       map[string]interface{} `yaml:"fields,omitempty"`
+		Hooks        []LogHook              `yaml:"hooks,omitempty"`
+		OutputFormat struct {
+			FileOutput string `yaml:"file,omitempty"`
+		} `yaml:"output,omitempty"`
 	}{
 		Fields: map[string]interface{}{"environment": "test"},
 	},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,8 @@ log:
   fields:
     service: registry
     environment: staging
+  output:
+    file: /var/log/registry.log
   hooks:
     - type: mail
       disabled: true
@@ -306,6 +308,8 @@ log:
   fields:
     service: registry
     environment: staging
+  output:
+    file: /var/log/registry.log
 ```
 
 | Parameter   | Required | Description |

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -226,6 +226,14 @@ func configureReporting(app *handlers.App) http.Handler {
 // configureLogging prepares the context with a logger using the
 // configuration.
 func configureLogging(ctx context.Context, config *configuration.Configuration) (context.Context, error) {
+	if config.Log.OutputFormat.FileOutput != "" {
+		f, err := os.OpenFile(config.Log.OutputFormat.FileOutput, os.O_WRONLY | os.O_CREATE, 0644)
+		if err != nil {
+			return ctx, fmt.Errorf("logfile could not be opened: %q", config.Log.OutputFormat.FileOutput)
+		}
+		log.SetOutput(f)
+	}
+
 	if config.Log.Level == "" && config.Log.Formatter == "" {
 		// If no config for logging is set, fallback to deprecated "Loglevel".
 		log.SetLevel(logLevel(config.Loglevel))

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -227,7 +227,7 @@ func configureReporting(app *handlers.App) http.Handler {
 // configuration.
 func configureLogging(ctx context.Context, config *configuration.Configuration) (context.Context, error) {
 	if config.Log.OutputFormat.FileOutput != "" {
-		f, err := os.OpenFile(config.Log.OutputFormat.FileOutput, os.O_WRONLY | os.O_CREATE, 0644)
+		f, err := os.OpenFile(config.Log.OutputFormat.FileOutput, os.O_WRONLY|os.O_CREATE, 0644)
 		if err != nil {
 			return ctx, fmt.Errorf("logfile could not be opened: %q", config.Log.OutputFormat.FileOutput)
 		}


### PR DESCRIPTION
Was surprised that logs are only written to stdout and there was no option for other destinations. This PR allows for writing logs to file, defined in the config with:

```
log:
  output:
    file: /path/to/log
```