### PR TITLE
cmd/digest: import crypto algorithms

### DIFF
--- a/cmd/digest/main.go
+++ b/cmd/digest/main.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/docker/distribution/version"
 	"github.com/opencontainers/go-digest"
+
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 )
 
 var (


### PR DESCRIPTION
the digest cli does not work if we do not import this two packages,
tested in go1.9. basically, we have to make several algorithms to
be available by calling crypto.RegisterHash in init functions.