### PR TITLE
digestset: refine some words on unit test

### DIFF
--- a/digestset/set_test.go
+++ b/digestset/set_test.go
@@ -51,7 +51,7 @@ func TestLookup(t *testing.T) {
 
 	dgst, err = dset.Lookup("9876")
 	if err == nil {
-		t.Fatal("Expected ambiguous error looking up: 9876")
+		t.Fatal("Expected not found error looking up: 9876")
 	}
 	if err != ErrDigestNotFound {
 		t.Fatal(err)
@@ -118,7 +118,7 @@ func TestAddDuplication(t *testing.T) {
 	}
 
 	if len(dset.entries) != 8 {
-		t.Fatal("Duplicate digest insert allowed")
+		t.Fatal("Duplicate digest insert should not increase entries size")
 	}
 
 	if err := dset.Add(digest.Digest("sha384:123451111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")); err != nil {
@@ -126,7 +126,7 @@ func TestAddDuplication(t *testing.T) {
 	}
 
 	if len(dset.entries) != 9 {
-		t.Fatal("Insert with different algorithm not allowed")
+		t.Fatal("Insert with different algorithm should be allowed")
 	}
 }
 


### PR DESCRIPTION
1. when lookup an entry which is missing, it should say NotFound.
2. when add duplicated entry, the entries size should not be increased.
3. when add entry which has different algorithm, it should be allowed.

Signed-off-by: zhouhaibing089 <zhouhaibing089@gmail.com>