### PR TITLE
[WIP] health handler: pass through /debug/health/*

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -261,6 +262,12 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 // disable a web application when the health checks fail.
 func Handler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// if this is about health endpoint, we pass it through.
+		if strings.HasPrefix(r.URL.Path, "/debug/health") {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
 		checks := CheckStatus()
 		if len(checks) != 0 {
 			errcode.ServeJSON(w, errcode.ErrorCodeUnavailable.


### PR DESCRIPTION
we can not respond with 503 service unavailable for health status
request, otherwise, we do not have any way to access this api when
the health status is false.

Signed-off-by: zhouhaibing089 <zhouhaibing089@gmail.com>