### PR TITLE
Fix the pointer initialization

### DIFF
--- a/configuration/parser.go
+++ b/configuration/parser.go
@@ -220,7 +220,7 @@ func (p *Parser) overwriteStruct(v reflect.Value, fullpath string, path []string
 		}
 	case reflect.Ptr:
 		if field.IsNil() {
-			field.Set(reflect.New(sf.Type))
+			field.Set(reflect.New(field.Type().Elem()))
 		}
 	}
 

--- a/configuration/parser_test.go
+++ b/configuration/parser_test.go
@@ -1,0 +1,70 @@
+package configuration
+
+import (
+	"os"
+	"reflect"
+
+	. "gopkg.in/check.v1"
+)
+
+type localConfiguration struct {
+	Version Version `yaml:"version"`
+	Log     *Log    `yaml:"log"`
+}
+
+type Log struct {
+	Formatter string `yaml:"formatter,omitempty"`
+}
+
+var expectedConfig = localConfiguration{
+	Version: "0.1",
+	Log: &Log{
+		Formatter: "json",
+	},
+}
+
+type ParserSuite struct{}
+
+var _ = Suite(new(ParserSuite))
+
+func (suite *ParserSuite) TestParserOverwriteIninitializedPoiner(c *C) {
+	config := localConfiguration{}
+
+	os.Setenv("REGISTRY_LOG_FORMATTER", "json")
+	defer os.Unsetenv("REGISTRY_LOG_FORMATTER")
+
+	p := NewParser("registry", []VersionedParseInfo{
+		{
+			Version: "0.1",
+			ParseAs: reflect.TypeOf(config),
+			ConversionFunc: func(c interface{}) (interface{}, error) {
+				return c, nil
+			},
+		},
+	})
+
+	err := p.Parse([]byte(`{version: "0.1", log: {formatter: "text"}}`), &config)
+	c.Assert(err, IsNil)
+	c.Assert(config, DeepEquals, expectedConfig)
+}
+
+func (suite *ParserSuite) TestParseOverwriteUnininitializedPoiner(c *C) {
+	config := localConfiguration{}
+
+	os.Setenv("REGISTRY_LOG_FORMATTER", "json")
+	defer os.Unsetenv("REGISTRY_LOG_FORMATTER")
+
+	p := NewParser("registry", []VersionedParseInfo{
+		{
+			Version: "0.1",
+			ParseAs: reflect.TypeOf(config),
+			ConversionFunc: func(c interface{}) (interface{}, error) {
+				return c, nil
+			},
+		},
+	})
+
+	err := p.Parse([]byte(`{version: "0.1"}`), &config)
+	c.Assert(err, IsNil)
+	c.Assert(config, DeepEquals, expectedConfig)
+}


### PR DESCRIPTION
If the `overwriteStruct()` finds an uninitialized pointer, it tries to initialize it, but does it incorrectly. It tries to assign a pointer to pointer, instead of pointer.
