### PR TITLE
Fix keyword format for downstream docs

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1,7 +1,7 @@
 ---
 title: "HTTP API V2"
 description: "Specification for the Registry API."
-keywords: ["registry, on-prem, images, tags, repository, distribution, api, advanced"]
+keywords: registry, on-prem, images, tags, repository, distribution, api, advanced
 ---
 
 # Docker Registry HTTP API V2

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -1,7 +1,7 @@
 ---
 title: "HTTP API V2"
 description: "Specification for the Registry API."
-keywords: ["registry, on-prem, images, tags, repository, distribution, api, advanced"]
+keywords: registry, on-prem, images, tags, repository, distribution, api, advanced
 ---
 
 # Docker Registry HTTP API V2

--- a/docs/spec/auth/index.md
+++ b/docs/spec/auth/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Docker Registry Token Authentication"
 description: "Docker Registry v2 authentication schema"
-keywords: ["registry, on-prem, images, tags, repository, distribution, authentication, advanced"]
+keywords: registry, on-prem, images, tags, repository, distribution, authentication, advanced
 ---
 
 # Docker Registry v2 authentication

--- a/docs/spec/auth/jwt.md
+++ b/docs/spec/auth/jwt.md
@@ -1,7 +1,7 @@
 ---
 title: "Token Authentication Implementation"
 description: "Describe the reference implementation of the Docker Registry v2 authentication schema"
-keywords: ["registry, on-prem, images, tags, repository, distribution, JWT authentication, advanced"]
+keywords: registry, on-prem, images, tags, repository, distribution, JWT authentication, advanced
 ---
 
 # Docker Registry v2 Bearer token specification

--- a/docs/spec/auth/oauth.md
+++ b/docs/spec/auth/oauth.md
@@ -1,7 +1,7 @@
 ---
 title: "Oauth2 Token Authentication"
 description: "Specifies the Docker Registry v2 authentication"
-keywords: ["registry, on-prem, images, tags, repository, distribution, oauth2, advanced"]
+keywords: registry, on-prem, images, tags, repository, distribution, oauth2, advanced
 ---
 
 # Docker Registry v2 authentication using OAuth2

--- a/docs/spec/auth/scope.md
+++ b/docs/spec/auth/scope.md
@@ -1,7 +1,7 @@
 ---
 title: "Token Scope Documentation"
 description: "Describes the scope and access fields used for registry authorization tokens"
-keywords: ["registry, on-prem, images, tags, repository, distribution, advanced, access, scope"]
+keywords: registry, on-prem, images, tags, repository, distribution, advanced, access, scope
 ---
 
 # Docker Registry Token Scope and Access

--- a/docs/spec/auth/token.md
+++ b/docs/spec/auth/token.md
@@ -1,7 +1,7 @@
 ---
 title: "Token Authentication Specification"
 description: "Specifies the Docker Registry v2 authentication"
-keywords: ["registry, on-prem, images, tags, repository, distribution, Bearer authentication, advanced"]
+keywords: registry, on-prem, images, tags, repository, distribution, Bearer authentication, advanced
 ---
 
 # Docker Registry v2 authentication via central service

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Reference Overview"
 description: "Explains registry JSON objects"
-keywords: ["registry, service, images, repository,  json"]
+keywords: registry, service, images, repository,  json
 ---
 
 # Docker Registry Reference

--- a/docs/spec/manifest-v2-1.md
+++ b/docs/spec/manifest-v2-1.md
@@ -1,7 +1,7 @@
 ---
 title: "Image Manifest V 2, Schema 1 "
 description: "image manifest for the Registry."
-keywords: ["registry, on-prem, images, tags, repository, distribution, api, advanced, manifest"]
+keywords: registry, on-prem, images, tags, repository, distribution, api, advanced, manifest
 ---
 
 # Image Manifest Version 2, Schema 1

--- a/docs/spec/manifest-v2-2.md
+++ b/docs/spec/manifest-v2-2.md
@@ -1,7 +1,7 @@
 ---
 title: "Image Manifest V 2, Schema 2 "
 description: "image manifest for the Registry."
-keywords: ["registry, on-prem, images, tags, repository, distribution, api, advanced, manifest"]
+keywords: registry, on-prem, images, tags, repository, distribution, api, advanced, manifest
 ---
 
 # Image Manifest Version 2, Schema 2

--- a/docs/spec/menu.md
+++ b/docs/spec/menu.md
@@ -1,7 +1,7 @@
 ---
 title: "Reference"
 description: "Explains registry JSON objects"
-keywords: ["registry, service, images, repository,  json"]
+keywords: registry, service, images, repository, json
 type: "menu"
 identifier: "smn_registry_ref"
 ---


### PR DESCRIPTION
Signed-off-by: Misty Stanley-Jones <misty@docker.com>

Relates to #2431 

![squid](https://img0.etsystatic.com/010/0/6715647/il_570xN.423285282_7lgw.jpg)