### PR TITLE
Let's Encrypt Host Whitelist Support

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -114,6 +114,10 @@ type Configuration struct {
 
 				// Email is the email to use during Let's Encrypt registration
 				Email string `yaml:"email,omitempty"`
+
+				// Hosts specifies the hosts which are allowed to obtain Let's
+				// Encrypt certificates.
+				Hosts []string `yaml:"hosts,omitempty"`
 			} `yaml:"letsencrypt,omitempty"`
 		} `yaml:"tls,omitempty"`
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -78,8 +78,9 @@ var configStruct = Configuration{
 			Key         string   `yaml:"key,omitempty"`
 			ClientCAs   []string `yaml:"clientcas,omitempty"`
 			LetsEncrypt struct {
-				CacheFile string `yaml:"cachefile,omitempty"`
-				Email     string `yaml:"email,omitempty"`
+				CacheFile string   `yaml:"cachefile,omitempty"`
+				Email     string   `yaml:"email,omitempty"`
+				Hosts     []string `yaml:"hosts,omitempty"`
 			} `yaml:"letsencrypt,omitempty"`
 		} `yaml:"tls,omitempty"`
 		Headers http.Header `yaml:"headers,omitempty"`
@@ -95,8 +96,9 @@ var configStruct = Configuration{
 			Key         string   `yaml:"key,omitempty"`
 			ClientCAs   []string `yaml:"clientcas,omitempty"`
 			LetsEncrypt struct {
-				CacheFile string `yaml:"cachefile,omitempty"`
-				Email     string `yaml:"email,omitempty"`
+				CacheFile string   `yaml:"cachefile,omitempty"`
+				Email     string   `yaml:"email,omitempty"`
+				Hosts     []string `yaml:"hosts,omitempty"`
 			} `yaml:"letsencrypt,omitempty"`
 		}{
 			ClientCAs: []string{"/path/to/ca.pem"},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,6 +215,7 @@ http:
     letsencrypt:
       cachefile: /path/to/cache-file
       email: emailused@letsencrypt.com
+      hosts: [myregistryaddress.org]
   debug:
     addr: localhost:5001
   headers:
@@ -738,6 +739,7 @@ http:
     letsencrypt:
       cachefile: /path/to/cache-file
       email: emailused@letsencrypt.com
+      hosts: [myregistryaddress.org]
   debug:
     addr: localhost:5001
   headers:
@@ -782,12 +784,15 @@ TLS certificates provided by
 > accessible on port `443`. The registry defaults to listening on port `5000`.
 > If you run the registry as a container, consider adding the flag `-p 443:5000`
 > to the `docker run` command or using a similar setting in a cloud
-> configuration.
+> configuration. You should also set the `hosts` option to the list of hostnames
+> that are valid for this registry to avoid trying to get certificates for random
+> hostnames due to malicious clients connecting with bogus SNI hostnames.
 
 | Parameter | Required | Description                                           |
 |-----------|----------|-------------------------------------------------------|
 | `cachefile` | yes    | Absolute path to a file where the Let's Encrypt agent can cache data. |
 | `email`   | yes      | The email address used to register with Let's Encrypt. |
+| `hosts`   | no       | The hostnames allowed for Let's Encrypt certificates. |
 
 ### `debug`
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -147,6 +147,9 @@ func (registry *Registry) ListenAndServe() error {
 					return err
 				}
 			}
+			if len(config.HTTP.TLS.LetsEncrypt.Hosts) > 0 {
+				m.SetHosts(config.HTTP.TLS.LetsEncrypt.Hosts)
+			}
 			tlsConf.GetCertificate = m.GetCertificate
 		} else {
 			tlsConf.Certificates = make([]tls.Certificate, 1)


### PR DESCRIPTION
This adds a new configuration setting `HTTP.TLS.LetsEncrypt.Hosts` which can be set to a list of hosts that the Docker Registry will whitelist for retrieving Let's Encrypt certificates.

It is required to avoid lots of unsuccessful registrations attempts that are triggered by malicious clients connecting with bogus SNI hostnames.

A patch for the vendored [rsc.io/letsencrypt](https://rsc.io/letsencrypt) library is included to fix clearing of the host whitelist if the setting is missing from the configuration.

The patch has been submitted upstream in https://github.com/rsc/letsencrypt/pull/24.