### PR TITLE
Registry - corrupted tags handling

### DIFF
--- a/manifests.go
+++ b/manifests.go
@@ -58,6 +58,9 @@ type ManifestService interface {
 	// Put creates or updates the given manifest returning the manifest digest
 	Put(ctx context.Context, manifest Manifest, options ...ManifestServiceOption) (digest.Digest, error)
 
+	// Deletable returns no error if the manifest can be deleted.
+	Deletable(ctx context.Context, dgst digest.Digest) error
+
 	// Delete removes the manifest specified by the given digest. Deleting
 	// a manifest that doesn't exist will return ErrManifestNotFound
 	Delete(ctx context.Context, dgst digest.Digest) error

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -580,6 +580,19 @@ func (ms *manifests) Put(ctx context.Context, m distribution.Manifest, options .
 	return "", HandleErrorResponse(resp)
 }
 
+func (ms *manifests) Deletable(ctx context.Context, dgst digest.Digest) error {
+	exists, err := ms.Exists(ctx, dgst)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return distribution.ErrBlobUnknown
+	}
+
+	return nil
+}
+
 func (ms *manifests) Delete(ctx context.Context, dgst digest.Digest) error {
 	ref, err := reference.WithDigest(ms.name, dgst)
 	if err != nil {

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -91,6 +91,10 @@ func (pms proxyManifestStore) Put(ctx context.Context, manifest distribution.Man
 	return d, distribution.ErrUnsupported
 }
 
+func (pms proxyManifestStore) Deletable(ctx context.Context, dgst digest.Digest) error {
+	return distribution.ErrUnsupported
+}
+
 func (pms proxyManifestStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	return distribution.ErrUnsupported
 }

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -41,6 +41,11 @@ func (te manifestStoreTestEnv) RemoteStats() *map[string]int {
 	return &rs
 }
 
+func (sm statsManifest) Deletable(ctx context.Context, dgst digest.Digest) error {
+	sm.stats["deletable"]++
+	return sm.manifests.Deletable(ctx, dgst)
+}
+
 func (sm statsManifest) Delete(ctx context.Context, dgst digest.Digest) error {
 	sm.stats["delete"]++
 	return sm.manifests.Delete(ctx, dgst)

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -124,6 +124,23 @@ func (ms *manifestStore) Put(ctx context.Context, manifest distribution.Manifest
 	return "", fmt.Errorf("unrecognized manifest type %T", manifest)
 }
 
+func (ms *manifestStore) Deletable(ctx context.Context, dgst digest.Digest) error {
+	if !ms.blobStore.deleteEnabled {
+		return distribution.ErrUnsupported
+	}
+
+	exists, err := ms.Exists(ctx, dgst)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return distribution.ErrBlobUnknown
+	}
+
+	return nil
+}
+
 // Delete removes the revision of the specified manifest.
 func (ms *manifestStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	dcontext.GetLogger(ms.ctx).Debug("(*manifestStore).Delete")


### PR DESCRIPTION
This PR fixes https://github.com/docker/distribution/issues/2430.
As I have received no feedback I decided to create MR with my proposal.

There are two modifications:

1. When tagging, if creating `current/link` fails, we try to remove tag to avoid storage corruption and return error as before.

2. When deleting manifest, we allow to remove corrupted tags with no `current/link` if there is matching blob link. Other tags do not break tag scanning and are reported in logs.
Corrupted tags can be removed via API by digest if it is known. It could also be done with some asynchronous GC-like mechanism in the future.
