### PR TITLE
Add metrics for s3 filters

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -10,4 +10,7 @@ const (
 var (
 	// StorageNamespace is the prometheus namespace of blob/cache related operations
 	StorageNamespace = metrics.NewNamespace(NamespacePrefix, "storage", nil)
+
+	// MiddlewareNamespace is the prometheus namespace of middleware related operations
+	MiddlewareNamespace = metrics.NewNamespace(NamespacePrefix, "middleware", nil)
 )


### PR DESCRIPTION
It adds the prometheus metrics for the middleware, counting how many reqs hit s3 directly

Signed-off-by: tifayuki <tifayuki@gmail.com>