### PR TITLE
filesystem: disallow "other" users to read files

### DIFF
--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -199,11 +199,11 @@ func (d *driver) Reader(ctx context.Context, path string, offset int64) (io.Read
 func (d *driver) Writer(ctx context.Context, subPath string, append bool) (storagedriver.FileWriter, error) {
 	fullPath := d.fullPath(subPath)
 	parentDir := path.Dir(fullPath)
-	if err := os.MkdirAll(parentDir, 0777); err != nil {
+	if err := os.MkdirAll(parentDir, 0770); err != nil {
 		return nil, err
 	}
 
-	fp, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE, 0666)
+	fp, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE, 0660)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>


I understand the original intention of 0777 and 0666 was to allow users to configure permission flexibly with `umask`: https://github.com/docker/distribution/issues/1295 https://github.com/docker/distribution/pull/1304

However, this configuration is insecure by default.

So I suggest changing permission bits: 0777 -> 0770, 0666 -> 0660

cc @aaronlehmann 