### PR TITLE
[release/2.6] Improve gcs driver

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,17 @@ storage:
   gcs:
     bucket: bucketname
     keyfile: /path/to/keyfile
+    credentials:
+      type: service_account
+      project_id: project_id_string
+      private_key_id: private_key_id_string
+      private_key: private_key_string
+      client_email: client@example.com
+      client_id: client_id_string
+      auth_uri: http://example.com/auth_uri
+      token_uri: http://example.com/token_uri
+      auth_provider_x509_cert_url: http://example.com/provider_cert_url
+      client_x509_cert_url: http://example.com/client_cert_url
     rootdirectory: /gcs/object/name/prefix
     chunksize: 5242880
   s3:
@@ -373,6 +384,17 @@ storage:
   gcs:
     bucket: bucketname
     keyfile: /path/to/keyfile
+    credentials:
+      type: service_account
+      project_id: project_id_string
+      private_key_id: private_key_id_string
+      private_key: private_key_string
+      client_email: client@example.com
+      client_id: client_id_string
+      auth_uri: http://example.com/auth_uri
+      token_uri: http://example.com/token_uri
+      auth_provider_x509_cert_url: http://example.com/provider_cert_url
+      client_x509_cert_url: http://example.com/client_cert_url
     rootdirectory: /gcs/object/name/prefix
   s3:
     accesskey: awsaccesskey

--- a/registry/storage/driver/base/regulator.go
+++ b/registry/storage/driver/base/regulator.go
@@ -1,7 +1,10 @@
 package base
 
 import (
+	"fmt"
 	"io"
+	"reflect"
+	"strconv"
 	"sync"
 
 	"github.com/docker/distribution/context"
@@ -13,6 +16,46 @@ type regulator struct {
 	*sync.Cond
 
 	available uint64
+}
+
+// GetLimitFromParameter takes an interface type as decoded from the YAML
+// configuration and returns a uint64 representing the maximum number of
+// concurrent calls given a minimum limit and default.
+//
+// If the parameter supplied is of an invalid type this returns an error.
+func GetLimitFromParameter(param interface{}, min, def uint64) (uint64, error) {
+	limit := def
+
+	switch v := param.(type) {
+	case string:
+		var err error
+		if limit, err = strconv.ParseUint(v, 0, 64); err != nil {
+			return limit, fmt.Errorf("parameter must be an integer, '%v' invalid", param)
+		}
+	case uint64:
+		limit = v
+	case int, int32, int64:
+		val := reflect.ValueOf(v).Convert(reflect.TypeOf(param)).Int()
+		// if param is negative casting to uint64 will wrap around and
+		// give you the hugest thread limit ever. Let's be sensible, here
+		if val > 0 {
+			limit = uint64(val)
+		} else {
+			limit = min
+		}
+	case uint, uint32:
+		limit = reflect.ValueOf(v).Convert(reflect.TypeOf(param)).Uint()
+	case nil:
+		// use the default
+	default:
+		return 0, fmt.Errorf("invalid value '%#v'", param)
+	}
+
+	if limit < min {
+		return min, nil
+	}
+
+	return limit, nil
 }
 
 // NewRegulator wraps the given driver and is used to regulate concurrent calls

--- a/registry/storage/driver/base/regulator_test.go
+++ b/registry/storage/driver/base/regulator_test.go
@@ -1,0 +1,36 @@
+package base
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetLimitFromParameter(t *testing.T) {
+	tests := []struct {
+		Input    interface{}
+		Expected uint64
+		Min      uint64
+		Default  uint64
+		Err      error
+	}{
+		{"foo", 0, 5, 5, fmt.Errorf("parameter must be an integer, 'foo' invalid")},
+		{"50", 50, 5, 5, nil},
+		{"5", 25, 25, 50, nil}, // lower than Min returns Min
+		{nil, 50, 25, 50, nil}, // nil returns default
+		{812, 812, 25, 50, nil},
+	}
+
+	for _, item := range tests {
+		t.Run(fmt.Sprint(item.Input), func(t *testing.T) {
+			actual, err := GetLimitFromParameter(item.Input, item.Min, item.Default)
+
+			if err != nil && item.Err != nil && err.Error() != item.Err.Error() {
+				t.Fatalf("GetLimitFromParameter error, expected %#v got %#v", item.Err, err)
+			}
+
+			if actual != item.Expected {
+				t.Fatalf("GetLimitFromParameter result error, expected %d got %d", item.Expected, actual)
+			}
+		})
+	}
+}

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"reflect"
-	"strconv"
 	"time"
 
 	"github.com/docker/distribution/context"
@@ -85,33 +83,9 @@ func fromParametersImpl(parameters map[string]interface{}) (*DriverParameters, e
 			rootDirectory = fmt.Sprint(rootDir)
 		}
 
-		// Get maximum number of threads for blocking filesystem operations,
-		// if specified
-		threads := parameters["maxthreads"]
-		switch v := threads.(type) {
-		case string:
-			if maxThreads, err = strconv.ParseUint(v, 0, 64); err != nil {
-				return nil, fmt.Errorf("maxthreads parameter must be an integer, %v invalid", threads)
-			}
-		case uint64:
-			maxThreads = v
-		case int, int32, int64:
-			val := reflect.ValueOf(v).Convert(reflect.TypeOf(threads)).Int()
-			// If threads is negative casting to uint64 will wrap around and
-			// give you the hugest thread limit ever. Let's be sensible, here
-			if val > 0 {
-				maxThreads = uint64(val)
-			}
-		case uint, uint32:
-			maxThreads = reflect.ValueOf(v).Convert(reflect.TypeOf(threads)).Uint()
-		case nil:
-			// do nothing
-		default:
-			return nil, fmt.Errorf("invalid value for maxthreads: %#v", threads)
-		}
-
-		if maxThreads < minThreads {
-			maxThreads = minThreads
+		maxThreads, err = base.GetLimitFromParameter(parameters["maxthreads"], minThreads, defaultMaxThreads)
+		if err != nil {
+			return nil, fmt.Errorf("maxthreads config error: %s", err.Error())
 		}
 	}
 

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -9,6 +9,8 @@
 //
 // Note that the contents of incomplete uploads are not accessible even though
 // Stat returns their length
+//
+// +build include_gcs
 
 package gcs
 

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -154,12 +154,16 @@ func FromParameters(parameters map[string]interface{}) (storagedriver.StorageDri
 		for k, v := range credentialMap {
 			key, ok := k.(string)
 			if !ok {
-				return nil, fmt.Errorf("One of the credential keys was not a string")
+				return nil, fmt.Errorf("One of the credential keys was not a string: %s", fmt.Sprint(k))
 			}
 			stringMap[key] = v
 		}
 
 		data, err := json.Marshal(stringMap)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to marshal gcs credentials to json")
+		}
+
 		jwtConf, err := google.JWTConfigFromJSON(data, storage.ScopeFullControl)
 		if err != nil {
 			return nil, err

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -180,7 +180,7 @@ func FromParameters(parameters map[string]interface{}) (storagedriver.StorageDri
 			return nil, fmt.Errorf("Failed to marshal gcs credentials to json")
 		}
 
-		jwtConf, err := google.JWTConfigFromJSON(data, storage.ScopeFullControl)
+		jwtConf, err = google.JWTConfigFromJSON(data, storage.ScopeFullControl)
 		if err != nil {
 			return nil, err
 		}

--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -16,6 +16,7 @@ package gcs
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -139,6 +140,27 @@ func FromParameters(parameters map[string]interface{}) (storagedriver.StorageDri
 			return nil, err
 		}
 		jwtConf, err = google.JWTConfigFromJSON(jsonKey, storage.ScopeFullControl)
+		if err != nil {
+			return nil, err
+		}
+		ts = jwtConf.TokenSource(context.Background())
+	} else if credentials, ok := parameters["credentials"]; ok {
+		credentialMap, ok := credentials.(map[interface{}]interface{})
+		if !ok {
+			return nil, fmt.Errorf("The credentials were not specified in the correct format")
+		}
+
+		stringMap := map[string]interface{}{}
+		for k, v := range credentialMap {
+			key, ok := k.(string)
+			if !ok {
+				return nil, fmt.Errorf("One of the credential keys was not a string")
+			}
+			stringMap[key] = v
+		}
+
+		data, err := json.Marshal(stringMap)
+		jwtConf, err := google.JWTConfigFromJSON(data, storage.ScopeFullControl)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR updates the GCS driver:

* adds an alternative input format for configuring credentials - instead of using filepath that points to a credentials file, you can use a dictionary of the respective fields from that credentials file instead
* implements the regulator interface for GCS operations for limiting the number of concurrent GCS calls