### PR TITLE
[release/2.6] Improve s3 driver

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -107,7 +107,9 @@ func init() {
 		"us-west-1",
 		"us-west-2",
 		"eu-west-1",
+		"eu-west-2",
 		"eu-central-1",
+		"ap-south-1",
 		"ap-southeast-1",
 		"ap-southeast-2",
 		"ap-northeast-1",
@@ -115,6 +117,7 @@ func init() {
 		"sa-east-1",
 		"cn-north-1",
 		"us-gov-west-1",
+		"ca-central-1",
 	} {
 		validRegions[region] = struct{}{}
 	}

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -14,6 +14,7 @@ package s3
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -91,6 +92,7 @@ type DriverParameters struct {
 	KeyID                       string
 	Secure                      bool
 	SkipVerify                  bool
+	RootCA                      string
 	V4Auth                      bool
 	ChunkSize                   int64
 	MultipartCopyChunkSize      int64
@@ -265,6 +267,11 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		return nil, fmt.Errorf("The skipVerify parameter should be a boolean")
 	}
 
+	rootCA := parameters["rootca"]
+	if rootCA == nil {
+		rootCA = ""
+	}
+
 	v4Bool := true
 	v4auth := parameters["v4auth"]
 	switch v4auth := v4auth.(type) {
@@ -360,6 +367,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		fmt.Sprint(keyID),
 		secureBool,
 		skipVerifyBool,
+		fmt.Sprint(rootCA),
 		v4Bool,
 		chunkSize,
 		multipartCopyChunkSize,
@@ -433,24 +441,7 @@ func New(params DriverParameters) (*Driver, error) {
 	awsConfig.WithCredentials(creds)
 	awsConfig.WithRegion(params.Region)
 	awsConfig.WithDisableSSL(!params.Secure)
-
-	if params.UserAgent != "" || params.SkipVerify {
-		httpTransport := http.DefaultTransport
-		if params.SkipVerify {
-			httpTransport = &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}
-		}
-		if params.UserAgent != "" {
-			awsConfig.WithHTTPClient(&http.Client{
-				Transport: transport.NewTransport(httpTransport, transport.NewHeaderRequestModifier(http.Header{http.CanonicalHeaderKey("User-Agent"): []string{params.UserAgent}})),
-			})
-		} else {
-			awsConfig.WithHTTPClient(&http.Client{
-				Transport: transport.NewTransport(httpTransport),
-			})
-		}
-	}
+	awsConfig.WithHTTPClient(createHTTPClient(params.UserAgent, params.RootCA, params.SkipVerify))
 
 	s3obj := s3.New(session.New(awsConfig))
 
@@ -1221,4 +1212,36 @@ func (w *writer) flushPart() error {
 	w.readyPart = w.pendingPart
 	w.pendingPart = nil
 	return nil
+}
+
+func createHTTPClient(userAgent, rootCA string, skipVerify bool) *http.Client {
+	if userAgent == "" && rootCA == "" && skipVerify == false {
+		return nil
+	}
+
+	httpTransport := http.DefaultTransport
+
+	if skipVerify || rootCA != "" {
+		tlsConfig := &tls.Config{}
+		if skipVerify {
+			tlsConfig.InsecureSkipVerify = true
+		}
+		if rootCA != "" {
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM([]byte(rootCA))
+			tlsConfig.RootCAs = caCertPool
+		}
+
+		httpTransport = &http.Transport{TLSClientConfig: tlsConfig}
+	}
+
+	if userAgent == "" {
+		return &http.Client{
+			Transport: transport.NewTransport(httpTransport),
+		}
+	}
+
+	return &http.Client{
+		Transport: transport.NewTransport(httpTransport, transport.NewHeaderRequestModifier(http.Header{http.CanonicalHeaderKey("User-Agent"): []string{userAgent}})),
+	}
 }

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -31,6 +31,7 @@ func init() {
 	encrypt := os.Getenv("S3_ENCRYPT")
 	keyID := os.Getenv("S3_KEY_ID")
 	secure := os.Getenv("S3_SECURE")
+	skipVerify := os.Getenv("S3_SKIP_VERIFY")
 	v4Auth := os.Getenv("S3_V4_AUTH")
 	region := os.Getenv("AWS_REGION")
 	objectACL := os.Getenv("S3_OBJECT_ACL")
@@ -58,6 +59,14 @@ func init() {
 			}
 		}
 
+		skipVerifyBool := false
+		if skipVerify != "" {
+			skipVerifyBool, err = strconv.ParseBool(skipVerify)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		v4Bool := true
 		if v4Auth != "" {
 			v4Bool, err = strconv.ParseBool(v4Auth)
@@ -75,6 +84,7 @@ func init() {
 			encryptBool,
 			keyID,
 			secureBool,
+			skipVerifyBool,
 			v4Bool,
 			minChunkSize,
 			defaultMultipartCopyChunkSize,

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -32,6 +32,7 @@ func init() {
 	keyID := os.Getenv("S3_KEY_ID")
 	secure := os.Getenv("S3_SECURE")
 	skipVerify := os.Getenv("S3_SKIP_VERIFY")
+	rootCA := os.Getenv("S3_ROOT_CA")
 	v4Auth := os.Getenv("S3_V4_AUTH")
 	region := os.Getenv("AWS_REGION")
 	objectACL := os.Getenv("S3_OBJECT_ACL")
@@ -85,6 +86,7 @@ func init() {
 			keyID,
 			secureBool,
 			skipVerifyBool,
+			rootCA,
 			v4Bool,
 			minChunkSize,
 			defaultMultipartCopyChunkSize,


### PR DESCRIPTION
This PR updates the S3 driver:

* adds three s3 regions - `eu-west-2`, `ap-south-1`, `ca-central-1`
* adds `skipverify` parameter for skipping TLS verification of third party S3 services
* adds `rootca` parameter for importing certificates of third party S3 services