### PR TITLE
[release/2.6] Add error handling for tag conflicts

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -113,3 +113,13 @@ type ErrManifestNameInvalid struct {
 func (err ErrManifestNameInvalid) Error() string {
 	return fmt.Sprintf("manifest name %q invalid: %v", err.Name, err.Reason)
 }
+
+// ErrTagConflict is returned if a tag cannot be overwritten
+type ErrTagConflict struct {
+	Tag  string
+	Name string
+}
+
+func (err ErrTagConflict) Error() string {
+	return fmt.Sprintf("tag=%s cannot be overwritten because %s is an immutable repository", err.Tag, err.Name)
+}

--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -73,6 +73,16 @@ var (
 		service too many times`,
 		HTTPStatusCode: http.StatusTooManyRequests,
 	})
+
+	// ErrorCodeConflictUnresolvable is returned if the request would overwrite
+	// an existing immutable resource.
+	ErrorCodeConflictUnresolvable = Register("errcode", ErrorDescriptor{
+		Value:   "CONFLICTUNRESOLVABLE",
+		Message: "conflict cannot be resolved",
+		Description: `Returned when a client attempts to overwrite
+		an immutable resource`,
+		HTTPStatusCode: http.StatusConflict,
+	})
 )
 
 var nextCode = 1000

--- a/registry/handlers/images.go
+++ b/registry/handlers/images.go
@@ -322,7 +322,12 @@ func (imh *imageManifestHandler) PutImageManifest(w http.ResponseWriter, r *http
 		tags := imh.Repository.Tags(imh)
 		err = tags.Tag(imh, imh.Tag, desc)
 		if err != nil {
-			imh.Errors = append(imh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+			switch tagError := err.(type) {
+			case distribution.ErrTagConflict:
+				imh.Errors = append(imh.Errors, errcode.ErrorCodeConflictUnresolvable.WithMessage(tagError.Error()))
+			default:
+				imh.Errors = append(imh.Errors, errcode.ErrorCodeUnknown.WithDetail(tagError))
+			}
 			return
 		}
 


### PR DESCRIPTION
This enables a registry operator to return human readable errors to a docker client when a push against an existing tag is made and the operator wants that tag to be immutable.