### PR TITLE
Ignore missing paths during enumeration

### DIFF
--- a/registry/storage/driver/walk.go
+++ b/registry/storage/driver/walk.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"sort"
+
+	"github.com/Sirupsen/logrus"
 )
 
 // ErrSkipDir is used as a return value from onFileFunc to indicate that
@@ -32,7 +34,14 @@ func WalkFallback(ctx context.Context, driver StorageDriver, from string, f Walk
 		// performance bottleneck.
 		fileInfo, err := driver.Stat(ctx, child)
 		if err != nil {
-			return err
+			switch err.(type) {
+			case storageDriver.PathNotFoundError:
+				// repository was removed in between listing and enumeration. Ignore it.
+				logrus.WithField("path", child).Infof("ignoring deleted path")
+				continue
+			default:
+				return err
+			}
 		}
 		err = f(fileInfo)
 		if err == nil && fileInfo.IsDir() {


### PR DESCRIPTION
It's possible to run into a race condition in which the enumerator lists
lots of repositories and then starts the long process of enumerating through
them. In that time if someone deletes a repo, the enumerator may error out.

Signed-off-by: Huu Nguyen <whoshuu@gmail.com>