### PR TITLE
Add configurable layers in manifest events

### DIFF
--- a/cmd/registry/config-cache.yml
+++ b/cmd/registry/config-cache.yml
@@ -30,7 +30,7 @@ redis:
   writetimeout: 10ms
 notifications:
     events:
-        manifestlayers: true
+        includereferences: true
     endpoints:
         - name: local-8082
           url: http://localhost:5003/callback

--- a/cmd/registry/config-cache.yml
+++ b/cmd/registry/config-cache.yml
@@ -29,6 +29,8 @@ redis:
   readtimeout: 10ms
   writetimeout: 10ms
 notifications:
+    events:
+        manifestlayers: true
     endpoints:
         - name: local-8082
           url: http://localhost:5003/callback

--- a/cmd/registry/config-dev.yml
+++ b/cmd/registry/config-dev.yml
@@ -48,7 +48,7 @@ redis:
   writetimeout: 10ms
 notifications:
     events:
-        manifestlayers: true
+        includereferences: true
     endpoints:
         - name: local-5003
           url: http://localhost:5003/callback

--- a/cmd/registry/config-dev.yml
+++ b/cmd/registry/config-dev.yml
@@ -47,6 +47,8 @@ redis:
   readtimeout: 10ms
   writetimeout: 10ms
 notifications:
+    events:
+        manifestlayers: true
     endpoints:
         - name: local-5003
           url: http://localhost:5003/callback

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -568,7 +568,7 @@ type Endpoint struct {
 
 // Events configures notification events.
 type Events struct {
-	ManifestLayers bool `yaml:"manifestlayers"` // include layer data in manifest events
+	IncludeReferences bool `yaml:"includereferences"` // include reference data in manifest events
 }
 
 //Ignore configures mediaTypes and actions of the event, that it won't be propagated

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -544,6 +544,8 @@ func (auth Auth) MarshalYAML() (interface{}, error) {
 
 // Notifications configures multiple http endpoints.
 type Notifications struct {
+	// EventConfig is the configuration for the event format that is sent to each Endpoint.
+	EventConfig Events `yaml:"events,omitempty"`
 	// Endpoints is a list of http configurations for endpoints that
 	// respond to webhook notifications. In the future, we may allow other
 	// kinds of endpoints, such as external queues.
@@ -562,6 +564,11 @@ type Endpoint struct {
 	Backoff           time.Duration `yaml:"backoff"`           // backoff duration
 	IgnoredMediaTypes []string      `yaml:"ignoredmediatypes"` // target media types to ignore
 	Ignore            Ignore        `yaml:"ignore"`            // ignore event types
+}
+
+// Events configures notification events.
+type Events struct {
+	ManifestLayers bool `yaml:"manifestlayers"` // include layer data in manifest events
 }
 
 //Ignore configures mediaTypes and actions of the event, that it won't be propagated

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,6 +226,8 @@ http:
   http2:
     disabled: false
 notifications:
+  events:
+    manifestlayers: true
   endpoints:
     - name: alistener
       disabled: false
@@ -853,6 +855,8 @@ settings for the registry.
 
 ```none
 notifications:
+  events:
+    manifestlayers: true
   endpoints:
     - name: alistener
       disabled: false
@@ -896,6 +900,13 @@ accept event notifications.
 | `mediatypes`|no| A list of target media types to ignore. Events with these target media types are not published to the endpoint. |
 | `actions`   |no| A list of actions to ignore. Events with these actions are not published to the endpoint. |
 
+### `events`
+
+The `events` structure configures the information provided in event notifications.
+
+| Parameter | Required | Description                                           |
+|-----------|----------|-------------------------------------------------------|
+| `manifestlayers` | no | If `true`, include layer information in manifest events. |
 
 ## `redis`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,7 +227,7 @@ http:
     disabled: false
 notifications:
   events:
-    manifestlayers: true
+    includereferences: true
   endpoints:
     - name: alistener
       disabled: false
@@ -856,7 +856,7 @@ settings for the registry.
 ```none
 notifications:
   events:
-    manifestlayers: true
+    includereferences: true
   endpoints:
     - name: alistener
       disabled: false
@@ -906,7 +906,7 @@ The `events` structure configures the information provided in event notification
 
 | Parameter | Required | Description                                           |
 |-----------|----------|-------------------------------------------------------|
-| `manifestlayers` | no | If `true`, include layer information in manifest events. |
+| `includereferences` | no | If `true`, include reference information in manifest events. |
 
 ## `redis`
 

--- a/manifest/schema2/manifest.go
+++ b/manifest/schema2/manifest.go
@@ -71,7 +71,7 @@ type Manifest struct {
 	Layers []distribution.Descriptor `json:"layers"`
 }
 
-// References returnes the descriptors of this manifests references.
+// References returns the descriptors of this manifests references.
 func (m Manifest) References() []distribution.Descriptor {
 	references := make([]distribution.Descriptor, 0, 1+len(m.Layers))
 	references = append(references, m.Config)

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -13,7 +13,7 @@ import (
 
 type bridge struct {
 	ub             URLBuilder
-	manfiestLayers bool
+	manifestLayers bool
 	actor          ActorRecord
 	source         SourceRecord
 	request        RequestRecord
@@ -35,7 +35,7 @@ type URLBuilder interface {
 func NewBridge(ub URLBuilder, source SourceRecord, actor ActorRecord, request RequestRecord, sink Sink, manifestLayers bool) Listener {
 	return &bridge{
 		ub:             ub,
-		manfiestLayers: manifestLayers,
+		manifestLayers: manifestLayers,
 		actor:          actor,
 		source:         source,
 		request:        request,
@@ -146,7 +146,7 @@ func (b *bridge) createManifestEvent(action string, repo reference.Named, sm dis
 	event.Target.Length = desc.Size
 	event.Target.Size = desc.Size
 	event.Target.Digest = desc.Digest
-	if b.manfiestLayers {
+	if b.manifestLayers {
 		event.Target.Layers = append(event.Target.Layers, manifest.References()...)
 	}
 

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -12,11 +12,12 @@ import (
 )
 
 type bridge struct {
-	ub      URLBuilder
-	actor   ActorRecord
-	source  SourceRecord
-	request RequestRecord
-	sink    Sink
+	ub             URLBuilder
+	manfiestLayers bool
+	actor          ActorRecord
+	source         SourceRecord
+	request        RequestRecord
+	sink           Sink
 }
 
 var _ Listener = &bridge{}
@@ -31,13 +32,14 @@ type URLBuilder interface {
 // using the actor and source. Any urls populated in the events created by
 // this bridge will be created using the URLBuilder.
 // TODO(stevvooe): Update this to simply take a context.Context object.
-func NewBridge(ub URLBuilder, source SourceRecord, actor ActorRecord, request RequestRecord, sink Sink) Listener {
+func NewBridge(ub URLBuilder, source SourceRecord, actor ActorRecord, request RequestRecord, sink Sink, manifestLayers bool) Listener {
 	return &bridge{
-		ub:      ub,
-		actor:   actor,
-		source:  source,
-		request: request,
-		sink:    sink,
+		ub:             ub,
+		manfiestLayers: manifestLayers,
+		actor:          actor,
+		source:         source,
+		request:        request,
+		sink:           sink,
 	}
 }
 
@@ -135,7 +137,7 @@ func (b *bridge) createManifestEvent(action string, repo reference.Named, sm dis
 	}
 
 	// Ensure we have the canonical manifest descriptor here
-	_, desc, err := distribution.UnmarshalManifest(mt, p)
+	manifest, desc, err := distribution.UnmarshalManifest(mt, p)
 	if err != nil {
 		return nil, err
 	}
@@ -144,6 +146,9 @@ func (b *bridge) createManifestEvent(action string, repo reference.Named, sm dis
 	event.Target.Length = desc.Size
 	event.Target.Size = desc.Size
 	event.Target.Digest = desc.Digest
+	if b.manfiestLayers {
+		event.Target.Layers = append(event.Target.Layers, manifest.References()...)
+	}
 
 	ref, err := reference.WithDigest(repo, event.Target.Digest)
 	if err != nil {

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -12,12 +12,12 @@ import (
 )
 
 type bridge struct {
-	ub             URLBuilder
-	manifestLayers bool
-	actor          ActorRecord
-	source         SourceRecord
-	request        RequestRecord
-	sink           Sink
+	ub                URLBuilder
+	includeReferences bool
+	actor             ActorRecord
+	source            SourceRecord
+	request           RequestRecord
+	sink              Sink
 }
 
 var _ Listener = &bridge{}
@@ -32,14 +32,14 @@ type URLBuilder interface {
 // using the actor and source. Any urls populated in the events created by
 // this bridge will be created using the URLBuilder.
 // TODO(stevvooe): Update this to simply take a context.Context object.
-func NewBridge(ub URLBuilder, source SourceRecord, actor ActorRecord, request RequestRecord, sink Sink, manifestLayers bool) Listener {
+func NewBridge(ub URLBuilder, source SourceRecord, actor ActorRecord, request RequestRecord, sink Sink, includeReferences bool) Listener {
 	return &bridge{
-		ub:             ub,
-		manifestLayers: manifestLayers,
-		actor:          actor,
-		source:         source,
-		request:        request,
-		sink:           sink,
+		ub:                ub,
+		includeReferences: includeReferences,
+		actor:             actor,
+		source:            source,
+		request:           request,
+		sink:              sink,
 	}
 }
 
@@ -146,8 +146,8 @@ func (b *bridge) createManifestEvent(action string, repo reference.Named, sm dis
 	event.Target.Length = desc.Size
 	event.Target.Size = desc.Size
 	event.Target.Digest = desc.Digest
-	if b.manifestLayers {
-		event.Target.Layers = append(event.Target.Layers, manifest.References()...)
+	if b.includeReferences {
+		event.Target.References = append(event.Target.References, manifest.References()...)
 	}
 
 	ref, err := reference.WithDigest(repo, event.Target.Digest)

--- a/notifications/bridge_test.go
+++ b/notifications/bridge_test.go
@@ -180,12 +180,12 @@ func checkCommonManifest(t *testing.T, action string, events ...Event) {
 		t.Fatalf("incorrect url passed: \n%q != \n%q", event.Target.URL, u)
 	}
 
-	if len(event.Target.Layers) != len(layers) {
-		t.Fatalf("unexpected number of layers %v != %v", len(event.Target.Layers), len(layers))
+	if len(event.Target.References) != len(layers) {
+		t.Fatalf("unexpected number of references %v != %v", len(event.Target.References), len(layers))
 	}
-	for i, layer := range event.Target.Layers {
-		if layer.Digest != layers[i].BlobSum {
-			t.Fatalf("unexpected layer: %q != %q", layer.Digest, layers[i].BlobSum)
+	for i, targetReference := range event.Target.References {
+		if targetReference.Digest != layers[i].BlobSum {
+			t.Fatalf("unexpected reference: %q != %q", targetReference.Digest, layers[i].BlobSum)
 		}
 	}
 }

--- a/notifications/event.go
+++ b/notifications/event.go
@@ -72,8 +72,8 @@ type Event struct {
 		// Tag provides the tag
 		Tag string `json:"tag,omitempty"`
 
-		// Layers provides the layers descriptors.
-		Layers []distribution.Descriptor `json:"layers,omitempty"`
+		// References provides the references descriptors.
+		References []distribution.Descriptor `json:"references,omitempty"`
 	} `json:"target,omitempty"`
 
 	// Request covers the request that generated the event.

--- a/notifications/event.go
+++ b/notifications/event.go
@@ -71,6 +71,9 @@ type Event struct {
 
 		// Tag provides the tag
 		Tag string `json:"tag,omitempty"`
+
+		// Layers provides the layers descriptors.
+		Layers []distribution.Descriptor `json:"layers,omitempty"`
 	} `json:"target,omitempty"`
 
 	// Request covers the request that generated the event.

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -869,7 +869,7 @@ func (app *App) eventBridge(ctx *Context, r *http.Request) notifications.Listene
 	}
 	request := notifications.NewRequestRecord(dcontext.GetRequestID(ctx), r)
 
-	return notifications.NewBridge(ctx.urlBuilder, app.events.source, actor, request, app.events.sink)
+	return notifications.NewBridge(ctx.urlBuilder, app.events.source, actor, request, app.events.sink, app.Config.Notifications.EventConfig.ManifestLayers)
 }
 
 // nameRequired returns true if the route requires a name.

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -869,7 +869,7 @@ func (app *App) eventBridge(ctx *Context, r *http.Request) notifications.Listene
 	}
 	request := notifications.NewRequestRecord(dcontext.GetRequestID(ctx), r)
 
-	return notifications.NewBridge(ctx.urlBuilder, app.events.source, actor, request, app.events.sink, app.Config.Notifications.EventConfig.ManifestLayers)
+	return notifications.NewBridge(ctx.urlBuilder, app.events.source, actor, request, app.events.sink, app.Config.Notifications.EventConfig.IncludeReferences)
 }
 
 // nameRequired returns true if the route requires a name.


### PR DESCRIPTION
Adds a configurable option to include layer info in manifest notification events. When we receive manifest notification events we often want to know which layers were accessed and/or compose the image. Rather than re-querying the registry, it is convenient to have that information in the manifest event itself.

With the change the default behavior of not including layer information in manifest events is not changed. An explicit configuration is needed to include the info.