### PR TITLE
Image digest spec does not include the entire alphabet

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -331,9 +331,11 @@ digest. The _hex_ portion is the hex-encoded result of the hash.
 
 We define a _digest_ string to match the following grammar:
 ```
-digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
-hex         := /[A-Fa-f0-9]+/
+digest                     := digest-algorithm ":" digest-hex
+digest-algorithm           := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]*
+digest-algorithm-separator := /[+.-_]/
+digest-algorithm-component := /[A-Za-z][A-Za-z0-9]*/
+digest-hex                 := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
 ```
 
 Some examples of _digests_ include the following:

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -331,9 +331,11 @@ digest. The _hex_ portion is the hex-encoded result of the hash.
 
 We define a _digest_ string to match the following grammar:
 ```
-digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
-hex         := /[A-Fa-f0-9]+/
+digest                     := digest-algorithm ":" digest-hex
+digest-algorithm           := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]*
+digest-algorithm-separator := /[+.-_]/
+digest-algorithm-component := /[A-Za-z][A-Za-z0-9]*/
+digest-hex                 := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
 ```
 
 Some examples of _digests_ include the following:


### PR DESCRIPTION
Note that `algorithm` part only allows `[A-Fa-f]`, instead of `[A-Za-z]`. This looks like a copy-and-paste error from the `hex` part.

Modify it to match the [reference implementation](https://github.com/docker/distribution/blob/master/reference/reference.go).