### PR TITLE
add repo and tag deletion event

### DIFF
--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -108,6 +108,14 @@ func (b *bridge) BlobDeleted(repo reference.Named, dgst digest.Digest) error {
 	return b.createBlobDeleteEventAndWrite(EventActionDelete, repo, dgst)
 }
 
+func (b *bridge) TagDeleted(repo reference.Named, tag string) error {
+	event := b.createEvent(EventActionDelete)
+	event.Target.Repository = repo.Name()
+	event.Target.Tag = tag
+
+	return b.sink.Write(*event)
+}
+
 func (b *bridge) createManifestEventAndWrite(action string, repo reference.Named, sm distribution.Manifest) error {
 	manifestEvent, err := b.createManifestEvent(action, repo, sm)
 	if err != nil {

--- a/notifications/bridge.go
+++ b/notifications/bridge.go
@@ -116,6 +116,13 @@ func (b *bridge) TagDeleted(repo reference.Named, tag string) error {
 	return b.sink.Write(*event)
 }
 
+func (b *bridge) RepoDeleted(repo reference.Named) error {
+	event := b.createEvent(EventActionDelete)
+	event.Target.Repository = repo.Name()
+
+	return b.sink.Write(*event)
+}
+
 func (b *bridge) createManifestEventAndWrite(action string, repo reference.Named, sm distribution.Manifest) error {
 	manifestEvent, err := b.createManifestEvent(action, repo, sm)
 	if err != nil {

--- a/notifications/bridge_test.go
+++ b/notifications/bridge_test.go
@@ -124,6 +124,18 @@ func TestEventBridgeTagDeleted(t *testing.T) {
 	}
 }
 
+func TestEventBridgeRepoDeleted(t *testing.T) {
+	l := createTestEnv(t, testSinkFn(func(events ...Event) error {
+		checkDeleted(t, EventActionDelete, events...)
+		return nil
+	}))
+
+	repoRef, _ := reference.WithName(repo)
+	if err := l.RepoDeleted(repoRef); err != nil {
+		t.Fatalf("unexpected error notifying repo deletion: %v", err)
+	}
+}
+
 func createTestEnv(t *testing.T, fn testSinkFn) Listener {
 	pk, err := libtrust.GenerateECP256PrivateKey()
 	if err != nil {

--- a/notifications/bridge_test.go
+++ b/notifications/bridge_test.go
@@ -97,12 +97,30 @@ func TestEventBridgeManifestPulledWithTag(t *testing.T) {
 func TestEventBridgeManifestDeleted(t *testing.T) {
 	l := createTestEnv(t, testSinkFn(func(events ...Event) error {
 		checkDeleted(t, EventActionDelete, events...)
+		if events[0].Target.Digest != dgst {
+			t.Fatalf("unexpected digest on event target: %q != %q", events[0].Target.Digest, dgst)
+		}
 		return nil
 	}))
 
 	repoRef, _ := reference.WithName(repo)
 	if err := l.ManifestDeleted(repoRef, dgst); err != nil {
 		t.Fatalf("unexpected error notifying manifest pull: %v", err)
+	}
+}
+
+func TestEventBridgeTagDeleted(t *testing.T) {
+	l := createTestEnv(t, testSinkFn(func(events ...Event) error {
+		checkDeleted(t, EventActionDelete, events...)
+		if events[0].Target.Tag != m.Tag {
+			t.Fatalf("unexpected tag on event target: %q != %q", events[0].Target.Tag, m.Tag)
+		}
+		return nil
+	}))
+
+	repoRef, _ := reference.WithName(repo)
+	if err := l.TagDeleted(repoRef, m.Tag); err != nil {
+		t.Fatalf("unexpected error notifying tag deletion: %v", err)
 	}
 }
 
@@ -142,14 +160,9 @@ func checkDeleted(t *testing.T, action string, events ...Event) {
 		t.Fatalf("request not equal: %#v != %#v", event.Actor, actor)
 	}
 
-	if event.Target.Digest != dgst {
-		t.Fatalf("unexpected digest on event target: %q != %q", event.Target.Digest, dgst)
-	}
-
 	if event.Target.Repository != repo {
 		t.Fatalf("unexpected repository: %q != %q", event.Target.Repository, repo)
 	}
-
 }
 
 func checkCommonManifest(t *testing.T, action string, events ...Event) {

--- a/notifications/listener.go
+++ b/notifications/listener.go
@@ -26,6 +26,7 @@ type BlobListener interface {
 	BlobDeleted(repo reference.Named, desc digest.Digest) error
 }
 
+// RepoListener provides repository methods that respond to repository lifecycle
 type RepoListener interface {
 	TagDeleted(repo reference.Named, tag string) error
 	RepoDeleted(repo reference.Named) error

--- a/notifications/listener_test.go
+++ b/notifications/listener_test.go
@@ -50,12 +50,12 @@ func TestListener(t *testing.T) {
 		"layer:push":      2,
 		"layer:pull":      2,
 		"layer:delete":    2,
+		"tag:delete":      1,
 	}
 
 	if !reflect.DeepEqual(tl.ops, expectedOps) {
 		t.Fatalf("counts do not match:\n%v\n !=\n%v", tl.ops, expectedOps)
 	}
-
 }
 
 type testListener struct {
@@ -64,7 +64,6 @@ type testListener struct {
 
 func (tl *testListener) ManifestPushed(repo reference.Named, m distribution.Manifest, options ...distribution.ManifestServiceOption) error {
 	tl.ops["manifest:push"]++
-
 	return nil
 }
 
@@ -95,6 +94,11 @@ func (tl *testListener) BlobMounted(repo reference.Named, desc distribution.Desc
 
 func (tl *testListener) BlobDeleted(repo reference.Named, d digest.Digest) error {
 	tl.ops["layer:delete"]++
+	return nil
+}
+
+func (tl *testListener) TagDeleted(repo reference.Named, tag string) error {
+	tl.ops["tag:delete"]++
 	return nil
 }
 
@@ -200,6 +204,10 @@ func checkExerciseRepository(t *testing.T, repository distribution.Repository) {
 		if err != nil {
 			t.Fatalf("unexpected error deleting blob: %v", err)
 		}
+	}
 
+	err = repository.Tags(ctx).Untag(ctx, m.Tag)
+	if err != nil {
+		t.Fatalf("unexpected error deleting tag: %v", err)
 	}
 }

--- a/registry.go
+++ b/registry.go
@@ -54,6 +54,11 @@ type RepositoryEnumerator interface {
 	Enumerate(ctx context.Context, ingester func(string) error) error
 }
 
+// RepositoryRemover removes given repository
+type RepositoryRemover interface {
+	Remove(ctx context.Context, name reference.Named) error
+}
+
 // ManifestServiceOption is a function argument for Manifest Service methods
 type ManifestServiceOption interface {
 	Apply(ManifestService) error

--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/storage/driver"
 )
 
@@ -68,6 +69,16 @@ func (reg *registry) Enumerate(ctx context.Context, ingester func(string) error)
 	})
 
 	return err
+}
+
+// Remove removes a repository from storage
+func (r *registry) Remove(ctx context.Context, name reference.Named) error {
+	root, err := pathFor(repositoriesRootPathSpec{})
+	if err != nil {
+		return err
+	}
+	repoDir := path.Join(root, name.Name())
+	return r.driver.Delete(ctx, repoDir)
 }
 
 // lessPath returns true if one path a is less than path b.

--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -72,13 +72,13 @@ func (reg *registry) Enumerate(ctx context.Context, ingester func(string) error)
 }
 
 // Remove removes a repository from storage
-func (r *registry) Remove(ctx context.Context, name reference.Named) error {
+func (reg *registry) Remove(ctx context.Context, name reference.Named) error {
 	root, err := pathFor(repositoriesRootPathSpec{})
 	if err != nil {
 		return err
 	}
 	repoDir := path.Join(root, name.Name())
-	return r.driver.Delete(ctx, repoDir)
+	return reg.driver.Delete(ctx, repoDir)
 }
 
 // lessPath returns true if one path a is less than path b.

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -23,6 +23,7 @@ type registry struct {
 	schema1SigningKey            libtrust.PrivateKey
 	blobDescriptorServiceFactory distribution.BlobDescriptorServiceFactory
 	manifestURLs                 manifestURLs
+	driver                       storagedriver.StorageDriver
 }
 
 // manifestURLs holds regular expressions for controlling manifest URL whitelisting
@@ -133,6 +134,7 @@ func NewRegistry(ctx context.Context, driver storagedriver.StorageDriver, option
 		},
 		statter:                statter,
 		resumableDigestEnabled: true,
+		driver:                 driver,
 	}
 
 	for _, option := range options {


### PR DESCRIPTION
Whenever a repo or tag is deleted an event is sent out via the regular notification channels. When repo is deleted the event will only contain repo name but not tag or digest. When tag is deleted the event it will have repo and tag but not digest. There is new interface `RepositoryRemover` containing method to delete the repo. Its implemented by internal `registry` instance. To capture the event the registry instance is also stored as `RepositoryRemover` in the application context.