### PR TITLE
fix memory leak introduced in PR #2648

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -702,7 +702,7 @@ func (app *App) dispatcher(dispatch dispatchFunc) http.Handler {
 			}
 
 			// assign and decorate the authorized repository with an event bridge.
-			context.Repository, context.App.repoRemover = notifications.Listen(
+			context.Repository, context.RepositoryRemover = notifications.Listen(
 				repository,
 				context.App.repoRemover,
 				app.eventBridge(context, r))

--- a/registry/handlers/context.go
+++ b/registry/handlers/context.go
@@ -25,6 +25,9 @@ type Context struct {
 	// should be scoped to a single repository. This field may be nil.
 	Repository distribution.Repository
 
+	// RepositoryRemover provides method to delete a repository
+	RepositoryRemover distribution.RepositoryRemover
+
 	// Errors is a collection of errors encountered during the request to be
 	// returned to the client API. If errors are added to the collection, the
 	// handler *must not* start the response via http.ResponseWriter.


### PR DESCRIPTION
`context.App.repoRemover` is single registry instance stored throughout app run. It was wrapped in another remover when processing each request. This remover happened to be remover got from previous request. This way every remover created was stored in infinite linked list causing memory
leak. Fixing it by storing the wrapped remover inside the request context which will get gced when request context is gced. This was introduced in PR #2648.