### PR TITLE
Remove Aaron Lehmann from maintainers file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -187,7 +187,6 @@ distribution defers to the [Technical Steering Committee](https://github.com/mob
 
 	[Org.Maintainers]
 		people = [
-			"aaronlehmann",
 			"dmcgowan",
 			"dmp42",
 			"stevvooe",
@@ -202,11 +201,6 @@ distribution defers to the [Technical Steering Committee](https://github.com/mob
 # in the people section.
 
 	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
-
-	[people.aaronlehmann]
-	Name = "Aaron Lehmann"
-	Email = "aaron.lehmann@docker.com"
-	GitHub = "aaronlehmann"
 
 	[people.dmcgowan]
 	Name = "Derek McGowan"


### PR DESCRIPTION
I want to think @aaronlehmann for all the contributions he has made this project. He is a big reason this project has been high quality and stable.

Luckily being a maintainer is a choice and not a lifetime sentence :wink: 