### PR TITLE
Replace tab with space in nginx config

### DIFF
--- a/contrib/compose/nginx/docker-registry-v2.conf
+++ b/contrib/compose/nginx/docker-registry-v2.conf
@@ -4,6 +4,6 @@ proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
 proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
 proxy_set_header  X-Forwarded-Proto $scheme;
 proxy_read_timeout                  900;
-proxy_send_timeout            	    300; 
+proxy_send_timeout                  300;
 proxy_request_buffering             off; (see issue #2292 - https://github.com/moby/moby/issues/2292)
 proxy_http_version                  1.1;


### PR DESCRIPTION
Quick follow-up to #9223. This gives better consistency and readability to the
file.

Signed-off-by: Ryan Abrams <rdabrams@gmail.com>