### PR TITLE
fix gometalinter

### DIFF
--- a/registry/auth/htpasswd/access.go
+++ b/registry/auth/htpasswd/access.go
@@ -10,12 +10,13 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"golang.org/x/crypto/bcrypt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
 
 	dcontext "github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/auth"


### PR DESCRIPTION
Signed-off-by: David Wu <david.wu@docker.com>


Fixes static checks after #2362 was merged. This should make CI green again. Old PRs need to be rebased and go through travis in the future