### PR TITLE
Fix registry stripping newlines from manifests

### DIFF
--- a/registry/storage/manifestlisthandler.go
+++ b/registry/storage/manifestlisthandler.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/docker/distribution"
@@ -23,12 +22,12 @@ var _ ManifestHandler = &manifestListHandler{}
 func (ms *manifestListHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
 	dcontext.GetLogger(ms.ctx).Debug("(*manifestListHandler).Unmarshal")
 
-	var m manifestlist.DeserializedManifestList
-	if err := json.Unmarshal(content, &m); err != nil {
+	m := &manifestlist.DeserializedManifestList{}
+	if err := m.UnmarshalJSON(content); err != nil {
 		return nil, err
 	}
 
-	return &m, nil
+	return m, nil
 }
 
 func (ms *manifestListHandler) Put(ctx context.Context, manifestList distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {

--- a/registry/storage/ocimanifesthandler.go
+++ b/registry/storage/ocimanifesthandler.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -26,12 +25,12 @@ var _ ManifestHandler = &ocischemaManifestHandler{}
 func (ms *ocischemaManifestHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
 	dcontext.GetLogger(ms.ctx).Debug("(*ocischemaManifestHandler).Unmarshal")
 
-	var m ocischema.DeserializedManifest
-	if err := json.Unmarshal(content, &m); err != nil {
+	m := &ocischema.DeserializedManifest{}
+	if err := m.UnmarshalJSON(content); err != nil {
 		return nil, err
 	}
 
-	return &m, nil
+	return m, nil
 }
 
 func (ms *ocischemaManifestHandler) Put(ctx context.Context, manifest distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {

--- a/registry/storage/schema2manifesthandler.go
+++ b/registry/storage/schema2manifesthandler.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -33,12 +32,12 @@ var _ ManifestHandler = &schema2ManifestHandler{}
 func (ms *schema2ManifestHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
 	dcontext.GetLogger(ms.ctx).Debug("(*schema2ManifestHandler).Unmarshal")
 
-	var m schema2.DeserializedManifest
-	if err := json.Unmarshal(content, &m); err != nil {
+	m := &schema2.DeserializedManifest{}
+	if err := m.UnmarshalJSON(content); err != nil {
 		return nil, err
 	}
 
-	return &m, nil
+	return m, nil
 }
 
 func (ms *schema2ManifestHandler) Put(ctx context.Context, manifest distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {


### PR DESCRIPTION
Content must be preserved exactly.

Note that `json.Unmarshal` was stripping the trailing newline before passing it to the manifest's `UnmarshalJSON` function, which expected to receive the original content. Considering those functions are designed to parse the original content, there is no reason not to call it directly. This is also further evidence that the manifest packages are the wrong interface and need to be removed.

Fixes #2703