### PR TITLE
fix make check

### DIFF
--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -2529,35 +2529,6 @@ func TestRegistryAsCacheMutationAPIs(t *testing.T) {
 
 }
 
-// TestCheckContextNotifier makes sure the API endpoints get a ResponseWriter
-// that implements http.ContextNotifier.
-func TestCheckContextNotifier(t *testing.T) {
-	env := newTestEnv(t, false)
-	defer env.Shutdown()
-
-	// Register a new endpoint for testing
-	env.app.router.Handle("/unittest/{name}/", env.app.dispatcher(func(ctx *Context, r *http.Request) http.Handler {
-		return handlers.MethodHandler{
-			"GET": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if _, ok := w.(http.CloseNotifier); !ok {
-					t.Fatal("could not cast ResponseWriter to CloseNotifier")
-				}
-				w.WriteHeader(200)
-			}),
-		}
-	}))
-
-	resp, err := http.Get(env.server.URL + "/unittest/reponame/")
-	if err != nil {
-		t.Fatalf("unexpected error issuing request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		t.Fatalf("wrong status code - expected 200, got %d", resp.StatusCode)
-	}
-}
-
 func TestProxyManifestGetByTag(t *testing.T) {
 	truthConfig := configuration.Configuration{
 		Storage: configuration.Storage{

--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -27,13 +27,7 @@ func closeResources(handler http.Handler, closers ...io.Closer) http.Handler {
 // The copy will be limited to `limit` bytes, if limit is greater than zero.
 func copyFullPayload(ctx context.Context, responseWriter http.ResponseWriter, r *http.Request, destWriter io.Writer, limit int64, action string) error {
 	// Get a channel that tells us if the client disconnects
-	var clientClosed <-chan bool
-	if notifier, ok := responseWriter.(http.CloseNotifier); ok {
-		clientClosed = notifier.CloseNotify()
-	} else {
-		dcontext.GetLogger(ctx).Warnf("the ResponseWriter does not implement CloseNotifier (type: %T)", responseWriter)
-	}
-
+	clientClosed := r.Context().Done()
 	var body = r.Body
 	if limit > 0 {
 		body = http.MaxBytesReader(responseWriter, body, limit)

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -476,11 +476,11 @@ func New(params DriverParameters) (*Driver, error) {
 	// }
 
 	d := &driver{
-		S3:        s3obj,
-		Bucket:    params.Bucket,
-		ChunkSize: params.ChunkSize,
-		Encrypt:   params.Encrypt,
-		KeyID:     params.KeyID,
+		S3:                          s3obj,
+		Bucket:                      params.Bucket,
+		ChunkSize:                   params.ChunkSize,
+		Encrypt:                     params.Encrypt,
+		KeyID:                       params.KeyID,
 		MultipartCopyChunkSize:      params.MultipartCopyChunkSize,
 		MultipartCopyMaxConcurrency: params.MultipartCopyMaxConcurrency,
 		MultipartCopyThresholdSize:  params.MultipartCopyThresholdSize,

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -312,14 +312,14 @@ func (lbs *linkedBlobStore) newBlobUpload(ctx context.Context, uuid, path string
 	}
 
 	bw := &blobWriter{
-		ctx:        ctx,
-		blobStore:  lbs,
-		id:         uuid,
-		startedAt:  startedAt,
-		digester:   digest.Canonical.Digester(),
-		fileWriter: fw,
-		driver:     lbs.driver,
-		path:       path,
+		ctx:                    ctx,
+		blobStore:              lbs,
+		id:                     uuid,
+		startedAt:              startedAt,
+		digester:               digest.Canonical.Digester(),
+		fileWriter:             fw,
+		driver:                 lbs.driver,
+		path:                   path,
 		resumableDigestEnabled: lbs.resumableDigestEnabled,
 	}
 

--- a/registry/storage/linkedblobstore_test.go
+++ b/registry/storage/linkedblobstore_test.go
@@ -162,8 +162,8 @@ type mockBlobDescriptorServiceFactory struct {
 func (f *mockBlobDescriptorServiceFactory) BlobAccessController(svc distribution.BlobDescriptorService) distribution.BlobDescriptorService {
 	return &mockBlobDescriptorService{
 		BlobDescriptorService: svc,
-		t:     f.t,
-		stats: f.stats,
+		t:                     f.t,
+		stats:                 f.stats,
 	}
 }
 


### PR DESCRIPTION
Fixes the gofmt, goimports, and staticcheck errors in `make check`

Removes `http.CloseNotifier`. We can just use `Request.Context()` instead