### PR TITLE
Add release notes for 2.7.0 release candidates

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,9 +1,9 @@
-Stephen J Day <stephen.day@docker.com>  Stephen Day <stevvooe@users.noreply.github.com>
-Stephen J Day <stephen.day@docker.com>  Stephen Day <stevvooe@gmail.com>
-Olivier Gambier <olivier@docker.com>    Olivier Gambier <dmp42@users.noreply.github.com>
-Brian Bland <brian.bland@docker.com>    Brian Bland <r4nd0m1n4t0r@gmail.com>
+Stephen J Day <stephen.day@docker.com> Stephen Day <stevvooe@users.noreply.github.com>
+Stephen J Day <stephen.day@docker.com> Stephen Day <stevvooe@gmail.com>
+Olivier Gambier <olivier@docker.com> Olivier Gambier <dmp42@users.noreply.github.com>
+Brian Bland <brian.bland@docker.com> Brian Bland <r4nd0m1n4t0r@gmail.com>
 Brian Bland <brian.bland@docker.com> Brian Bland <brian.t.bland@gmail.com>
-Josh Hawn <josh.hawn@docker.com>        Josh Hawn <jlhawn@berkeley.edu>
+Josh Hawn <josh.hawn@docker.com> Josh Hawn <jlhawn@berkeley.edu>
 Richard Scothern <richard.scothern@docker.com> Richard <richard.scothern@gmail.com>
 Richard Scothern <richard.scothern@docker.com> Richard Scothern <richard.scothern@gmail.com>
 Andrew Meredith <andymeredith@gmail.com> Andrew Meredith <kendru@users.noreply.github.com>
@@ -16,3 +16,17 @@ davidli <wenquan.li@hp.com> davidli <wenquan.li@hpe.com>
 Omer Cohen <git@omer.io> Omer Cohen <git@omerc.net>
 Eric Yang <windfarer@gmail.com> Eric Yang <Windfarer@users.noreply.github.com>
 Nikita Tarasov <nikita@mygento.ru> Nikita <luckyraul@users.noreply.github.com>
+Yu Wang <yuwa@microsoft.com> yuwaMSFT2 <yuwa@microsoft.com>
+Yu Wang <yuwa@microsoft.com> Yu Wang (UC) <yuwa@microsoft.com>
+Olivier Gambier <olivier@docker.com> dmp <dmp@loaner.local>
+Olivier Gambier <olivier@docker.com> Olivier <o+github@gambier.email>
+Olivier Gambier <olivier@docker.com> Olivier <dmp42@users.noreply.github.com>
+Elsan Li 李楠 <elsanli@tencent.com> elsanli(李楠) <elsanli@tencent.com>
+Rui Cao <ruicao@alauda.io> ruicao <ruicao@alauda.io>
+Gwendolynne Barr <gwendolynne.barr@docker.com> gbarr01 <gwendolynne.barr@docker.com>
+Haibing Zhou 周海兵 <zhouhaibing089@gmail.com> zhouhaibing089 <zhouhaibing089@gmail.com>
+Feng Honglin <tifayuki@gmail.com> tifayuki <tifayuki@gmail.com>
+Helen Xie <xieyulin821@harmonycloud.cn> Helen-xie <xieyulin821@harmonycloud.cn>
+Mike Brown <brownwm@us.ibm.com> Mike Brown <mikebrow@users.noreply.github.com>
+Manish Tomar <manish.tomar@docker.com> Manish Tomar <manishtomar@users.noreply.github.com>
+Sakeven Jiang <jc5930@sina.cn> sakeven <jc5930@sina.cn>

--- a/releases/v2.7.0-rc.toml
+++ b/releases/v2.7.0-rc.toml
@@ -1,0 +1,48 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "registry"
+github_repo = "docker/distribution"
+
+# previous release
+previous = "v2.6.0"
+
+pre_release = true
+
+preface = """\
+The 2.7 registry release has been a long time coming and represents both
+a long gap since the previous release and a renewed effort to release
+regularly. The maintainers were committed to get OCI support into the
+next release and thanks to much effort in the community that has
+been accomplished.
+
+## OCI Support
+
+### Push and Pull of OCI Images
+
+The registry now allows pushing and pulling OCI images. OCI images will always
+be preserved exactly without conversion to older types. With this change,
+clients which implement OCI can feel comfortable creating OCI images as part of
+their container image build process.
+
+## Specification Donation
+
+The Distribution specification which has had 4 years of review, implementation,
+and production use is now part of OCI. As part of that move, specification
+changes will no longer be accepted in the open source registry and should
+instead go to [OCI's distribution-spec](https://github.com/opencontainers/distribution-spec/issues).
+
+## Bug fixes
+
+Many many fixes and improvements, see the change log below
+"""
+
+# notable prs to include in the release notes, 1234 is the pr number
+[notes]
+
+[breaking]
+
+[rename_deps]
+	[rename_deps.logrus]
+	old = "github.com/Sirupsen/logrus"
+	new = "github.com/sirupsen/logrus"


### PR DESCRIPTION
This is following containerd's release format, using the same release tool and toml template. This file will be used for all 2.7.0 RCs.

Generated notes https://gist.github.com/dmcgowan/f081d53a8c674dccd1a742b685195ba0

Updated mailmap, please let me know if you want your name displayed differently
@fate-grand-order @mlmhl @sakeven @uhayate @liyongxin