### PR TITLE
Update X-Forwarded-Proto to use right most value if comma separated list. 

### DIFF
--- a/registry/api/v2/urls.go
+++ b/registry/api/v2/urls.go
@@ -73,7 +73,9 @@ func NewURLBuilderFromRequest(r *http.Request, relative bool) *URLBuilder {
 		}
 	} else {
 		if forwardedProto := r.Header.Get("X-Forwarded-Proto"); len(forwardedProto) > 0 {
-			scheme = forwardedProto
+			ss := strings.Split(forwardedProto, ",")
+			scheme = ss[len(ss)-1]
+
 		}
 		if forwardedHost := r.Header.Get("X-Forwarded-Host"); len(forwardedHost) > 0 {
 			// According to the Apache mod_proxy docs, X-Forwarded-Host can be a

--- a/registry/api/v2/urls_test.go
+++ b/registry/api/v2/urls_test.go
@@ -219,6 +219,13 @@ func TestBuilderFromRequest(t *testing.T) {
 			base: "https://example.com",
 		},
 		{
+			name: "forwarded protocol with multiple schema hop",
+			request: &http.Request{URL: u, Host: u.Host, Header: http.Header{
+				"X-Forwarded-Proto": []string{"http,https"},
+			}},
+			base: "https://example.com",
+		},
+		{
 			name: "forwarded host with a non-standard header",
 			request: &http.Request{URL: u, Host: u.Host, Header: http.Header{
 				"X-Forwarded-Host": []string{"first.example.com"},


### PR DESCRIPTION
X-Forwarded-Proto can be a comma separated list. It represents the protocol used by each reverse proxy in between the client and the server. This problem happens when switched to ALBs from ELBs because it's another hop. The ALB adds an additional "https" to X-Forwarded-Proto.

After swapping ELBs to ALBs on AWS, we were hitting the following:
```"first path segment in URL cannot contain colon"```

https://tools.ietf.org/html/rfc7239.html

Signed-off-by: Chris Gustavsen <chris.gustavsen@workiva.com>

Reviewers:  
@mirake @manishtomar @dmp42 