### PR TITLE
API to retrive tag's digests

### DIFF
--- a/registry/storage/tagstore.go
+++ b/registry/storage/tagstore.go
@@ -197,7 +197,7 @@ func (ts *tagStore) Lookup(ctx context.Context, desc distribution.Descriptor) ([
 	return tags, nil
 }
 
-func (ts *tagStore) Indexes(ctx context.Context, tag string) ([]digest.Digest, error) {
+func (ts *tagStore) ManifestDigests(ctx context.Context, tag string) ([]digest.Digest, error) {
 	var tagLinkPath = func(name string, dgst digest.Digest) (string, error) {
 		return pathFor(manifestTagIndexEntryLinkPathSpec{
 			name:     name,

--- a/tags.go
+++ b/tags.go
@@ -28,9 +28,10 @@ type TagService interface {
 	Lookup(ctx context.Context, digest Descriptor) ([]string, error)
 }
 
-// TagIndexes proves method to retreive all the digests that a tag historically pointed to
-type TagIndexes interface {
-	// Indexes returns set of digests that this tag historically pointed to. This also includes
-	// currently linked digest. There is no ordering guaranteed
-	Indexes(ctx context.Context, tag string) ([]digest.Digest, error)
+// TagManifestsProvider provides method to retreive the digests of manifests that a tag historically
+// pointed to
+type TagManifestsProvider interface {
+	// ManifestDigests returns set of digests that this tag historically pointed to. This also
+	// includes currently linked digest. There is no ordering guaranteed
+	ManifestDigests(ctx context.Context, tag string) ([]digest.Digest, error)
 }

--- a/tags.go
+++ b/tags.go
@@ -2,6 +2,8 @@ package distribution
 
 import (
 	"context"
+
+	digest "github.com/opencontainers/go-digest"
 )
 
 // TagService provides access to information about tagged objects.
@@ -24,4 +26,11 @@ type TagService interface {
 
 	// Lookup returns the set of tags referencing the given digest.
 	Lookup(ctx context.Context, digest Descriptor) ([]string, error)
+}
+
+// TagIndexes proves method to retreive all the digests that a tag historically pointed to
+type TagIndexes interface {
+	// Indexes returns set of digests that this tag historically pointed to. This also includes
+	// currently linked digest. There is no ordering guaranteed
+	Indexes(ctx context.Context, tag string) ([]digest.Digest, error)
 }


### PR DESCRIPTION
Add an interface alongside `TagStore` that provides API to retrieve digests of all manifests that a tag historically pointed to. It also includes currently linked tag. This will not currently be used in distribution but is useful to extract data out from the storage.

Signed-off-by: Manish Tomar <manish.tomar@docker.com>