### PR TITLE
Improved Token JSON Decoding Errors

### DIFF
--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -359,11 +360,14 @@ func (th *tokenHandler) fetchTokenWithOAuth(realm *url.URL, refreshToken, servic
 		return "", time.Time{}, err
 	}
 
-	decoder := json.NewDecoder(resp.Body)
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", time.Time{}, err
+	}
 
 	var tr postTokenResponse
-	if err = decoder.Decode(&tr); err != nil {
-		return "", time.Time{}, fmt.Errorf("unable to decode token response: %s", err)
+	if err = json.Unmarshal(b, &tr); err != nil {
+		return "", time.Time{}, fmt.Errorf("unable to decode token response: %s (%s)", b, err)
 	}
 
 	if tr.RefreshToken != "" && tr.RefreshToken != refreshToken {
@@ -439,11 +443,14 @@ func (th *tokenHandler) fetchTokenWithBasicAuth(realm *url.URL, service string, 
 		return "", time.Time{}, err
 	}
 
-	decoder := json.NewDecoder(resp.Body)
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", time.Time{}, err
+	}
 
 	var tr getTokenResponse
-	if err = decoder.Decode(&tr); err != nil {
-		return "", time.Time{}, fmt.Errorf("unable to decode token response: %s", err)
+	if err = json.Unmarshal(b, &tr); err != nil {
+		return "", time.Time{}, fmt.Errorf("unable to decode token response: %s (%s)", b, err)
 	}
 
 	if tr.RefreshToken != "" && th.creds != nil {


### PR DESCRIPTION
* HTTP error responses from non-2xx/non-3xx yield great usable errors which can be floated back up the chain. These have been incredibly helpful.

* This attempts to do the same for responses that are unable to be decoded to JSON.

This comes about from some issues I was having with a registry proxy. It turns out that initial errors from ngrok (non-2xx/non-3xx) errors were presenting a pretty usable body.

JSON errors on the other hand, were a bit harder. Turns out that the standard go error only returns the first character of the invalid JSON string. This attempts to bring errors in line with the registry client errors when invalid status codes are encountered.

If it is a bit much, please let me know. I figured it was suitable given how we treat registry client errors :)