### PR TITLE
[release/2.6] Add go arguments to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM golang:1.7-alpine
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
 ENV DOCKER_BUILDTAGS include_oss include_gcs
 
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 RUN set -ex \
     && apk add --no-cache make git
 


### PR DESCRIPTION
Allows using dockerfile to cross compile binaries in registry 2.6 branch