### PR TITLE
Add GOARM flag to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV DOCKER_BUILDTAGS include_oss include_gcs
 
 ARG GOOS=linux
 ARG GOARCH=amd64
+ARG GOARM=6
 
 RUN set -ex \
     && apk add --no-cache make git file


### PR DESCRIPTION
When building with arm on alpine, GOARM should be set to 6 by default. This ensure that
setting the GOARCH build arg also allows setting GOARM.
