### PR TITLE
[release/2.6] Add GOARM flag to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV DOCKER_BUILDTAGS include_oss include_gcs
 
 ARG GOOS=linux
 ARG GOARCH=amd64
+ARG GOARM=6
 
 RUN set -ex \
     && apk add --no-cache make git


### PR DESCRIPTION
When building with arm on alpine, GOARM should be set to 6 by default.

Ensures cross compiled binaries on ARM are compiled with GOARM set, GOARM=6 is expected for alpine
