### PR TITLE
change default Dockerfile to install ssl utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
 RUN CGO_ENABLED=0 make PREFIX=/go clean binaries && file ./bin/registry | grep "statically linked"
 
-FROM alpine
+FROM alpine:3.8
+
+RUN set -ex \
+    && apk add --no-cache ca-certificates apache2-utils
+
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
 COPY --from=build /go/src/github.com/docker/distribution/bin/registry /bin/registry
 VOLUME ["/var/lib/registry"]


### PR DESCRIPTION
The default Dockerfile won't work in docker proxy pull cache mode, error will happen:
```
panic: Get https://xxx/v2/: x509: certificate signed by unknown authority
```

This PR use the config from `distribution-library-image` directly
https://github.com/docker/distribution-library-image/blob/7d18dca46fba84ec5a2a70e0ac81113975c3a159/amd64/Dockerfile#L3-L6

@manishtomar 