### PR TITLE
registry: fix binary JSON content-type

### DIFF
--- a/contrib/compose/README.md
+++ b/contrib/compose/README.md
@@ -133,7 +133,7 @@ to the 1.0 registry. Requests from newer clients will route to the 2.0 registry.
 			> Accept: */*
 			> 
 			< HTTP/1.1 200 OK
-			< Content-Type: application/json; charset=utf-8
+			< Content-Type: application/json
 			< Docker-Distribution-Api-Version: registry/2.0
 			< Date: Tue, 14 Apr 2015 22:34:13 GMT
 			< Content-Length: 39

--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -1206,7 +1206,7 @@ The registry does not implement the V2 API.
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1244,7 +1244,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1316,7 +1316,7 @@ The following parameters should be specified on the request:
 ```
 200 OK
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
     "name": <name>,
@@ -1344,7 +1344,7 @@ The following headers will be returned with the response:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1382,7 +1382,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1419,7 +1419,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1456,7 +1456,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1514,7 +1514,7 @@ The following parameters should be specified on the request:
 200 OK
 Content-Length: <length>
 Link: <<url>?n=<last n value>&last=<last entry from response>>; rel="next"
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
     "name": <name>,
@@ -1543,7 +1543,7 @@ The following headers will be returned with the response:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1581,7 +1581,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1618,7 +1618,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1655,7 +1655,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1759,7 +1759,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1792,7 +1792,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1830,7 +1830,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1867,7 +1867,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -1904,7 +1904,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2005,7 +2005,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2041,7 +2041,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2079,7 +2079,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2116,7 +2116,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2153,7 +2153,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2189,7 +2189,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
     "errors:" [{
@@ -2277,7 +2277,7 @@ The following parameters should be specified on the request:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2310,7 +2310,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2348,7 +2348,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2385,7 +2385,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2422,7 +2422,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2458,7 +2458,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2583,7 +2583,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2614,7 +2614,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2647,7 +2647,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2685,7 +2685,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2722,7 +2722,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2759,7 +2759,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2843,7 +2843,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2874,7 +2874,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2917,7 +2917,7 @@ The range specification cannot be satisfied for the requested content. This can 
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2955,7 +2955,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -2992,7 +2992,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3029,7 +3029,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3132,7 +3132,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3163,7 +3163,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 405 Method Not Allowed
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3195,7 +3195,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3233,7 +3233,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3270,7 +3270,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3307,7 +3307,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3445,7 +3445,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3483,7 +3483,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3520,7 +3520,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3557,7 +3557,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3662,7 +3662,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3700,7 +3700,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3737,7 +3737,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3774,7 +3774,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3897,7 +3897,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3935,7 +3935,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -3972,7 +3972,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4009,7 +4009,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4102,7 +4102,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4134,7 +4134,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4166,7 +4166,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4204,7 +4204,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4241,7 +4241,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4278,7 +4278,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4370,7 +4370,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4402,7 +4402,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4434,7 +4434,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4472,7 +4472,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4509,7 +4509,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4546,7 +4546,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4636,7 +4636,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4668,7 +4668,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4710,7 +4710,7 @@ The `Content-Range` specification cannot be accepted, either because it does not
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4748,7 +4748,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4785,7 +4785,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4822,7 +4822,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4916,7 +4916,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4949,7 +4949,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -4981,7 +4981,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5019,7 +5019,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5056,7 +5056,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5093,7 +5093,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5177,7 +5177,7 @@ The following headers will be returned with the response:
 
 ```
 400 Bad Request
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5208,7 +5208,7 @@ The error codes that may be included in the response body are enumerated below:
 
 ```
 404 Not Found
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5240,7 +5240,7 @@ The error codes that may be included in the response body are enumerated below:
 401 Unauthorized
 WWW-Authenticate: <scheme> realm="<realm>", ..."
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5278,7 +5278,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 404 Not Found
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5315,7 +5315,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 403 Forbidden
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5352,7 +5352,7 @@ The error codes that may be included in the response body are enumerated below:
 ```
 429 Too Many Requests
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"errors:" [
@@ -5414,7 +5414,7 @@ Request an unabridged list of repositories available.  The implementation may im
 ```
 200 OK
 Content-Length: <length>
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"repositories": [
@@ -5459,7 +5459,7 @@ The following parameters should be specified on the request:
 200 OK
 Content-Length: <length>
 Link: <<url>?n=<last n value>&last=<last entry from response>>; rel="next"
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 
 {
 	"repositories": [

--- a/docs/spec/auth/token.md
+++ b/docs/spec/auth/token.md
@@ -60,7 +60,7 @@ return this response:
 
 ```
 HTTP/1.1 401 Unauthorized
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 Docker-Distribution-Api-Version: registry/2.0
 Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull,push"
 Date: Thu, 10 Sep 2015 19:32:31 GMT

--- a/health/health.go
+++ b/health/health.go
@@ -291,7 +291,7 @@ func statusResponse(w http.ResponseWriter, r *http.Request, status int, checks m
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Length", fmt.Sprint(len(p)))
 	w.WriteHeader(status)
 	if _, err := w.Write(p); err != nil {

--- a/registry/api/errcode/handler.go
+++ b/registry/api/errcode/handler.go
@@ -9,7 +9,7 @@ import (
 // and sets the content-type header to 'application/json'. It will handle
 // ErrorCoder and Errors, and if necessary will create an envelope.
 func ServeJSON(w http.ResponseWriter, err error) error {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", "application/json")
 	var sc int
 
 	switch errs := err.(type) {

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -126,7 +126,7 @@ var (
 			},
 		},
 		Body: BodyDescriptor{
-			ContentType: "application/json; charset=utf-8",
+			ContentType: "application/json",
 			Format:      errorsBody,
 		},
 		ErrorCodes: []errcode.ErrorCode{
@@ -147,7 +147,7 @@ var (
 			},
 		},
 		Body: BodyDescriptor{
-			ContentType: "application/json; charset=utf-8",
+			ContentType: "application/json",
 			Format:      errorsBody,
 		},
 		ErrorCodes: []errcode.ErrorCode{
@@ -168,7 +168,7 @@ var (
 			},
 		},
 		Body: BodyDescriptor{
-			ContentType: "application/json; charset=utf-8",
+			ContentType: "application/json",
 			Format:      errorsBody,
 		},
 		ErrorCodes: []errcode.ErrorCode{
@@ -189,7 +189,7 @@ var (
 			},
 		},
 		Body: BodyDescriptor{
-			ContentType: "application/json; charset=utf-8",
+			ContentType: "application/json",
 			Format:      errorsBody,
 		},
 		ErrorCodes: []errcode.ErrorCode{
@@ -441,7 +441,7 @@ var routeDescriptors = []RouteDescriptor{
 									},
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format: `{
     "name": <name>,
     "tags": [
@@ -478,7 +478,7 @@ var routeDescriptors = []RouteDescriptor{
 									linkHeader,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format: `{
     "name": <name>,
     "tags": [
@@ -541,7 +541,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeTagInvalid,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -592,7 +592,7 @@ var routeDescriptors = []RouteDescriptor{
 								Description: "The received manifest was invalid in some way, as described by the error codes. The client should resolve the issue and retry the request.",
 								StatusCode:  http.StatusBadRequest,
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
@@ -615,7 +615,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format: `{
     "errors:" [{
             "code": "BLOB_UNKNOWN",
@@ -669,7 +669,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeTagInvalid,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -686,7 +686,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeManifestUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -766,7 +766,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeDigestInvalid,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -774,7 +774,7 @@ var routeDescriptors = []RouteDescriptor{
 								Description: "The blob, identified by `name` and `digest`, is unknown to the registry.",
 								StatusCode:  http.StatusNotFound,
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
@@ -838,7 +838,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeDigestInvalid,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -849,7 +849,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -905,7 +905,7 @@ var routeDescriptors = []RouteDescriptor{
 								Description: "The blob, identified by `name` and `digest`, is unknown to the registry.",
 								StatusCode:  http.StatusNotFound,
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
@@ -917,7 +917,7 @@ var routeDescriptors = []RouteDescriptor{
 								Description: "Blob delete is not allowed because the registry is configured as a pull-through cache or `delete` has been disabled",
 								StatusCode:  http.StatusMethodNotAllowed,
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 								ErrorCodes: []errcode.ErrorCode{
@@ -1179,7 +1179,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUploadInvalid,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1190,7 +1190,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUploadUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1254,7 +1254,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUploadInvalid,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1265,7 +1265,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUploadUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1336,7 +1336,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUploadInvalid,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1347,7 +1347,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUploadUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1431,7 +1431,7 @@ var routeDescriptors = []RouteDescriptor{
 									errcode.ErrorCodeUnsupported,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1442,7 +1442,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUploadUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1488,7 +1488,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUploadInvalid,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1499,7 +1499,7 @@ var routeDescriptors = []RouteDescriptor{
 									ErrorCodeBlobUploadUnknown,
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format:      errorsBody,
 								},
 							},
@@ -1539,7 +1539,7 @@ var routeDescriptors = []RouteDescriptor{
 									},
 								},
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format: `{
 	"repositories": [
 		<name>,
@@ -1558,7 +1558,7 @@ var routeDescriptors = []RouteDescriptor{
 							{
 								StatusCode: http.StatusOK,
 								Body: BodyDescriptor{
-									ContentType: "application/json; charset=utf-8",
+									ContentType: "application/json",
 									Format: `{
 	"repositories": [
 		<name>,

--- a/registry/client/repository_test.go
+++ b/registry/client/repository_test.go
@@ -80,7 +80,7 @@ func addTestFetch(repo string, dgst digest.Digest, content []byte, m *testutil.R
 func addTestCatalog(route string, content []byte, link string, m *testutil.RequestResponseMap) {
 	headers := map[string][]string{
 		"Content-Length": {strconv.Itoa(len(content))},
-		"Content-Type":   {"application/json; charset=utf-8"},
+		"Content-Type":   {"application/json"},
 	}
 	if link != "" {
 		headers["Link"] = append(headers["Link"], link)
@@ -1062,7 +1062,7 @@ func TestObtainsErrorForMissingTag(t *testing.T) {
 			StatusCode: http.StatusNotFound,
 			Body:       errBytes,
 			Headers: http.Header(map[string][]string{
-				"Content-Type": {"application/json; charset=utf-8"},
+				"Content-Type": {"application/json"},
 			}),
 		},
 	})

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -65,7 +65,7 @@ func TestCheckAPI(t *testing.T) {
 
 	checkResponse(t, "issuing api base check", resp, http.StatusOK)
 	checkHeaders(t, resp, http.Header{
-		"Content-Type":   []string{"application/json; charset=utf-8"},
+		"Content-Type":   []string{"application/json"},
 		"Content-Length": []string{"2"},
 	})
 
@@ -259,7 +259,7 @@ func TestURLPrefix(t *testing.T) {
 
 	checkResponse(t, "issuing api base check", resp, http.StatusOK)
 	checkHeaders(t, resp, http.Header{
-		"Content-Type":   []string{"application/json; charset=utf-8"},
+		"Content-Type":   []string{"application/json"},
 		"Content-Length": []string{"2"},
 	})
 }
@@ -1180,7 +1180,7 @@ func testManifestAPISchema1(t *testing.T, env *testEnv, imageName reference.Name
 	// charset.
 	resp = putManifest(t, "re-putting signed manifest", manifestDigestURL, schema1.MediaTypeSignedManifest, sm2)
 	checkResponse(t, "re-putting signed manifest", resp, http.StatusCreated)
-	resp = putManifest(t, "re-putting signed manifest", manifestDigestURL, "application/json; charset=utf-8", sm2)
+	resp = putManifest(t, "re-putting signed manifest", manifestDigestURL, "application/json", sm2)
 	checkResponse(t, "re-putting signed manifest", resp, http.StatusCreated)
 	resp = putManifest(t, "re-putting signed manifest", manifestDigestURL, "application/json", sm2)
 	checkResponse(t, "re-putting signed manifest", resp, http.StatusCreated)
@@ -2329,7 +2329,7 @@ func checkBodyHasErrorCodes(t *testing.T, msg string, resp *http.Response, error
 
 	// TODO(stevvooe): Shoot. The error setup is not working out. The content-
 	// type headers are being set after writing the status code.
-	// if resp.Header.Get("Content-Type") != "application/json; charset=utf-8" {
+	// if resp.Header.Get("Content-Type") != "application/json" {
 	// 	t.Fatalf("unexpected content type: %v != 'application/json'",
 	// 		resp.Header.Get("Content-Type"))
 	// }

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -898,7 +898,7 @@ func (app *App) nameRequired(r *http.Request) bool {
 func apiBase(w http.ResponseWriter, r *http.Request) {
 	const emptyJSON = "{}"
 	// Provide a simple /v2/ 200 OK response with empty json response.
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Length", fmt.Sprint(len(emptyJSON)))
 
 	fmt.Fprint(w, emptyJSON)

--- a/registry/handlers/app_test.go
+++ b/registry/handlers/app_test.go
@@ -188,8 +188,8 @@ func TestNewApp(t *testing.T) {
 		t.Fatalf("unexpected status code during request: %v", err)
 	}
 
-	if req.Header.Get("Content-Type") != "application/json; charset=utf-8" {
-		t.Fatalf("unexpected content-type: %v != %v", req.Header.Get("Content-Type"), "application/json; charset=utf-8")
+	if req.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("unexpected content-type: %v != %v", req.Header.Get("Content-Type"), "application/json")
 	}
 
 	expectedAuthHeader := "Bearer realm=\"realm-test\",service=\"service-test\""

--- a/registry/handlers/catalog.go
+++ b/registry/handlers/catalog.go
@@ -55,7 +55,7 @@ func (ch *catalogHandler) GetCatalog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", "application/json")
 
 	// Add a link header if there are more entries to retrieve
 	if moreEntries {

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -49,7 +49,7 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", "application/json")
 
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(tagsAPIResponse{


### PR DESCRIPTION
This fixes registry endpoints to return the proper `application/json`
content-type for JSON content, also updating spec examples for that.

As per IETF specification and IANA registry [0], the `application/json`
type is a binary media, so the content-type label does not need any
text-charset selector. Additionally, the media type definition
explicitly states that it has no required nor optional parameters,
which makes the current registry headers non-compliant.

[0]: https://www.iana.org/assignments/media-types/application/json

Signed-off-by: Luca Bruno <lucab@debian.org>