### PR TITLE
Use same env var in Dockerfile and Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.11-alpine AS build
 
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
-ENV DOCKER_BUILDTAGS include_oss include_gcs
+ENV BUILDTAGS include_oss include_gcs
 
 ARG GOOS=linux
 ARG GOARCH=amd64


### PR DESCRIPTION
Ensures that build tags get set in the Dockerfile so that OSS and GCS drivers
are built into the official registry binary.

Closes #2819 

Signed-off-by: Ryan Abrams <rdabrams@gmail.com>