### PR TITLE
ipfilteredby is not required option in cloudfront, but do not validation check

### DIFF
--- a/registry/storage/driver/middleware/cloudfront/middleware.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware.go
@@ -138,7 +138,7 @@ func newCloudFrontStorageMiddleware(storageDriver storagedriver.StorageDriver, o
 
 	// parse ipfilteredby
 	var awsIPs *awsIPs
-	if ipFilteredBy := options["ipfilteredby"].(string); ok {
+	if ipFilteredBy, ok := options["ipfilteredby"].(string); ok {
 		switch strings.ToLower(strings.TrimSpace(ipFilteredBy)) {
 		case "", "none":
 			awsIPs = nil


### PR DESCRIPTION
if do not ipfilteredby defined in cloudfront, occurred error
but to configuration.md is defined what ipfilteredby is not required option

Signed-off-by: alex yoo goods4455@gmail.com