### PR TITLE
Add annotations to ManifestList

### DIFF
--- a/manifest/manifestlist/manifestlist.go
+++ b/manifest/manifestlist/manifestlist.go
@@ -118,6 +118,10 @@ type ManifestList struct {
 
 	// Config references the image configuration as a blob.
 	Manifests []ManifestDescriptor `json:"manifests"`
+
+	// Annotations contain arbitrary metadata for the ManifestList
+	// For backwards compatibility and compatibility with OCI indices, annotations are optional
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // References returns the distribution descriptors for the referenced image


### PR DESCRIPTION
ManifestList is the closest approximate to [OCI Indices](https://goo.gl/j5Xk9u)
in the distribution implementation. Adding annotations gives the benefit of
arbitrary meta-data associated with multi-arch images and allows ManifestLists
to be compatible with OCI indices.