### PR TITLE
registry/handlers: remove extra type assertions

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -753,14 +753,12 @@ func (app *App) logError(ctx context.Context, errors errcode.Errors) {
 	for _, e1 := range errors {
 		var c context.Context
 
-		switch e1.(type) {
+		switch e := e1.(type) {
 		case errcode.Error:
-			e, _ := e1.(errcode.Error)
 			c = context.WithValue(ctx, errCodeKey{}, e.Code)
 			c = context.WithValue(c, errMessageKey{}, e.Message)
 			c = context.WithValue(c, errDetailKey{}, e.Detail)
 		case errcode.ErrorCode:
-			e, _ := e1.(errcode.ErrorCode)
 			c = context.WithValue(ctx, errCodeKey{}, e)
 			c = context.WithValue(c, errMessageKey{}, e.Message())
 		default:


### PR DESCRIPTION
Assigned type switch var to avoid type assertions inside type switch clauses.

Signed-off-by: Iskander Sharipov quasilyte@gmail.com