### PR TITLE
Fix cloudfront middleware

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -706,14 +706,19 @@ interpretation of the options.
 | `privatekey` | yes   | The private key for Cloudfront, provided by AWS.        |
 | `keypairid` | yes    | The key pair ID provided by AWS.                         |
 | `duration` | no      | An integer and unit for the duration of the Cloudfront session. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, or `h`. For example, `3000s` is valid, but `3000 s` is not. If you do not specify a `duration` or you specify an integer without a time unit, the duration defaults to `20m` (20 minutes).|
-|`ipfilteredby`|no     | A string with the following value `none|aws|awsregion`. |
+|`ipfilteredby`|no     | A string with the following value `none`, `aws` or `awsregion`. |
 |`awsregion`|no        | A comma separated string of AWS regions, only available when `ipfilteredby` is `awsregion`. For example, `us-east-1, us-west-2`|
 |`updatefrenquency`|no | The frequency to update AWS IP regions, default: `12h`|
 |`iprangesurl`|no      | The URL contains the AWS IP ranges information, default: `https://ip-ranges.amazonaws.com/ip-ranges.json`|
-Then value of ipfilteredby:
-`none`: default, do not filter by IP
-`aws`: IP from AWS goes to S3 directly
-`awsregion`: IP from certain AWS regions goes to S3 directly, use together with `awsregion`
+
+
+Value of `ipfilteredby` can be:
+
+| Value       | Description                        |
+|-------------|------------------------------------|
+| `none`      | default, do not filter by IP       |
+| `aws`       | IP from AWS goes to S3 directly    |
+| `awsregion` | IP from certain AWS regions goes to S3 directly, use together with `awsregion`. |
 
 ### `redirect`
 

--- a/registry/storage/driver/middleware/cloudfront/middleware.go
+++ b/registry/storage/driver/middleware/cloudfront/middleware.go
@@ -138,27 +138,33 @@ func newCloudFrontStorageMiddleware(storageDriver storagedriver.StorageDriver, o
 
 	// parse ipfilteredby
 	var awsIPs *awsIPs
-	if ipFilteredBy := options["ipfilteredby"].(string); ok {
-		switch strings.ToLower(strings.TrimSpace(ipFilteredBy)) {
-		case "", "none":
-			awsIPs = nil
-		case "aws":
-			newAWSIPs(ipRangesURL, updateFrequency, nil)
-		case "awsregion":
-			var awsRegion []string
-			if regions, ok := options["awsregion"].(string); ok {
-				for _, awsRegions := range strings.Split(regions, ",") {
-					awsRegion = append(awsRegion, strings.ToLower(strings.TrimSpace(awsRegions)))
+	if i, ok := options["ipfilteredby"]; ok {
+		if ipFilteredBy, ok := i.(string); ok {
+			switch strings.ToLower(strings.TrimSpace(ipFilteredBy)) {
+			case "", "none":
+				awsIPs = nil
+			case "aws":
+				awsIPs = newAWSIPs(ipRangesURL, updateFrequency, nil)
+			case "awsregion":
+				var awsRegion []string
+				if i, ok := options["awsregion"]; ok {
+					if regions, ok := i.(string); ok {
+						for _, awsRegions := range strings.Split(regions, ",") {
+							awsRegion = append(awsRegion, strings.ToLower(strings.TrimSpace(awsRegions)))
+						}
+						awsIPs = newAWSIPs(ipRangesURL, updateFrequency, awsRegion)
+					} else {
+						return nil, fmt.Errorf("awsRegion must be a comma separated string of valid aws regions")
+					}
+				} else {
+					return nil, fmt.Errorf("awsRegion is not defined")
 				}
-				awsIPs = newAWSIPs(ipRangesURL, updateFrequency, awsRegion)
-			} else {
-				return nil, fmt.Errorf("awsRegion must be a comma separated string of valid aws regions")
+			default:
+				return nil, fmt.Errorf("ipfilteredby only allows a string the following value: none|aws|awsregion")
 			}
-		default:
-			return nil, fmt.Errorf("ipfilteredby only allows a string the following value: none|aws|awsregion")
+		} else {
+			return nil, fmt.Errorf("ipfilteredby only allows a string with the following value: none|aws|awsregion")
 		}
-	} else {
-		return nil, fmt.Errorf("ipfilteredby only allows a string with the following value: none|aws|awsregion")
 	}
 
 	return &cloudFrontStorageMiddleware{


### PR DESCRIPTION
@manishtomar According to [documentation](https://github.com/docker/distribution/blob/master/docs/configuration.md#cloudfront), `ipfilteredby` is not required. And if you don't set `ipfilteredby` for cloudfront middleware, registry crashes and you get the error `panic: interface conversion: interface {} is nil, not string`.

This PR fixes this issue and some minor formatting issues with cloudfront configuration docs.