### PR TITLE
Fixes #2835 Process Accept header MIME types in case-insensitive way

### DIFF
--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"fmt"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -97,13 +98,9 @@ func (imh *manifestHandler) GetManifest(w http.ResponseWriter, r *http.Request) 
 		// we need to split each header value on "," to get the full list of "Accept" values (per RFC 2616)
 		// https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
 		for _, mediaType := range strings.Split(acceptHeader, ",") {
-			// remove "; q=..." if present
-			if i := strings.Index(mediaType, ";"); i >= 0 {
-				mediaType = mediaType[:i]
+			if mediaType, _, err = mime.ParseMediaType(mediaType); err != nil {
+				continue
 			}
-
-			// it's common (but not required) for Accept values to be space separated ("a/b, c/d, e/f")
-			mediaType = strings.TrimSpace(mediaType)
 
 			if mediaType == schema2.MediaTypeManifest {
 				supports[manifestSchema2] = true


### PR DESCRIPTION
Use mime.ParseMediaType to parse the media types in Accept header in manifest request. Ignore the failed ones.

Signed-off-by: Yu Wang <yuwa@microsoft.com>