### PR TITLE
fix no error returned in fetchTokenWithOAuth

### DIFF
--- a/registry/client/auth/session.go
+++ b/registry/client/auth/session.go
@@ -366,6 +366,10 @@ func (th *tokenHandler) fetchTokenWithOAuth(realm *url.URL, refreshToken, servic
 		return "", time.Time{}, fmt.Errorf("unable to decode token response: %s", err)
 	}
 
+	if tr.AccessToken == "" {
+		return "", time.Time{}, ErrNoToken
+	}
+
 	if tr.RefreshToken != "" && tr.RefreshToken != refreshToken {
 		th.creds.SetRefreshToken(realm, service, tr.RefreshToken)
 	}


### PR DESCRIPTION
fetchTokenWithBasicAuth checks if a token is in the token response
but fetchTokenWithOAuth does not

these changes implements the same behaviour for the latter
returning a `ErrNoToken` if a token is not found in the resposne

Signed-off-by: Sevki Hasirci <sevki@cloudflare.com>