### PR TITLE
fix panic due to index out of range on getOutstandingUploads

### DIFF
--- a/registry/storage/purgeuploads.go
+++ b/registry/storage/purgeuploads.go
@@ -70,7 +70,7 @@ func getOutstandingUploads(ctx context.Context, driver storageDriver.StorageDriv
 	err = driver.Walk(ctx, root, func(fileInfo storageDriver.FileInfo) error {
 		filePath := fileInfo.Path()
 		_, file := path.Split(filePath)
-		if file[0] == '_' {
+		if strings.HasPrefix(file, "_") {
 			// Reserved directory
 			inUploadDir = (file == "_uploads")
 


### PR DESCRIPTION
Fixes #2908 

Hello I am proposing this change to avoid getting `panic error: index out of range` on function [getOutstandingUploads](https://github.com/docker/distribution/blob/master/registry/storage/purgeuploads.go#L60)