### PR TITLE
Handle Blob Create when the underlying registry doesn't provide 'Docker-Upload-UUID'

### DIFF
--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -752,6 +752,11 @@ func (bs *blobs) Create(ctx context.Context, options ...distribution.BlobCreateO
 	case http.StatusAccepted:
 		// TODO(dmcgowan): Check for invalid UUID
 		uuid := resp.Header.Get("Docker-Upload-UUID")
+		if uuid == "" {
+			parts := strings.Split(resp.Header.Get("Location"), "/")
+			uuid = parts[len(parts)-1]
+		}
+
 		location, err := sanitizeLocation(resp.Header.Get("Location"), u)
 		if err != nil {
 			return nil, err

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -756,6 +756,9 @@ func (bs *blobs) Create(ctx context.Context, options ...distribution.BlobCreateO
 			parts := strings.Split(resp.Header.Get("Location"), "/")
 			uuid = parts[len(parts)-1]
 		}
+		if uuid == "" {
+			return nil, errors.New("cannot retrieve docker upload UUID")
+		}
 
 		location, err := sanitizeLocation(resp.Header.Get("Location"), u)
 		if err != nil {


### PR DESCRIPTION
Some registries, such as ECR don't provide a `Docker-Upload-UUID` HTTP header when starting a blob upload. So we can't rely on that, which then fails when we try to generate the `Location` header we return (in [blobupload.go](https://github.com/docker/distribution/blob/0d3efadf0154c2b8a4e7b6621fff9809655cc580/registry/handlers/blobupload.go#L310)).

This fallbacks to try reading the UUID from the Location header returned by the underlying service. If we still don't have any UUID, it then returns an error.

I didn't remove @dmcgowan's TODO because we're technically still not checking for invalid UUID, only for empty strings.