### PR TITLE
allow for VERSION and REVISION to be passed in during docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV DOCKER_BUILDTAGS include_oss include_gcs
 ARG GOOS=linux
 ARG GOARCH=amd64
 ARG GOARM=6
+ARG VERSION
+ARG REVISION
 
 RUN set -ex \
     && apk add --no-cache make git file

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Used to populate version variable in main package.
-VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
-REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
+REVISION ?= $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 
 
 PKG=github.com/docker/distribution


### PR DESCRIPTION
solve for #2953

Allows `VERSION` and `REVISION` to be set via build args.

E.G `docker build --build-arg VERSION=somerelease --build-arg REVISION=internalRev .` 