### PR TITLE
make it possible to wrap the client transport in another one

### DIFF
--- a/registry/client/transport/transport.go
+++ b/registry/client/transport/transport.go
@@ -6,6 +6,13 @@ import (
 	"sync"
 )
 
+func identityTransportWrapper(rt http.RoundTripper) http.RoundTripper {
+	return rt
+}
+
+// DefaultTransportWrapper allows a user to wrap every generated transport
+var DefaultTransportWrapper = identityTransportWrapper
+
 // RequestModifier represents an object which will do an inplace
 // modification of an HTTP request.
 type RequestModifier interface {
@@ -31,10 +38,11 @@ func (h headerModifier) ModifyRequest(req *http.Request) error {
 // NewTransport creates a new transport which will apply modifiers to
 // the request on a RoundTrip call.
 func NewTransport(base http.RoundTripper, modifiers ...RequestModifier) http.RoundTripper {
-	return &transport{
-		Modifiers: modifiers,
-		Base:      base,
-	}
+	return DefaultTransportWrapper(
+		&transport{
+			Modifiers: modifiers,
+			Base:      base,
+		})
 }
 
 // transport is an http.RoundTripper that makes HTTP requests after


### PR DESCRIPTION
When using the client, I'd like to modify the behavior somewhat (retries, context-aware, etc). This would allow me to interject a transport to handle that; I'm not set on this impl, though, and I'd do it differently if you'd prefer that. Putting this up as a feeler.