### PR TITLE
documentation correction

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -332,7 +332,7 @@ digest. The _hex_ portion is the hex-encoded result of the hash.
 We define a _digest_ string to match the following grammar:
 ```
 digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
+algorithm   := /[A-Za-z0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 


### PR DESCRIPTION
digest strings allow the algorithm component to have `A-Za-z` values, not `A-Fa-f`.

No corresponding issue.