### PR TITLE
Add pathspec for repo _layers directory and allow Repository.BlobStore to enumerate over blobs

### DIFF
--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -87,6 +87,7 @@ const (
 // 	Blobs:
 //
 // 	layerLinkPathSpec:            <root>/v2/repositories/<name>/_layers/<algorithm>/<hex digest>/link
+// 	layersPathSpec:               <root>/v2/repositories/<name>/_layers
 //
 //	Uploads:
 //
@@ -206,6 +207,8 @@ func pathFor(spec pathSpec) (string, error) {
 		blobLinkPathComponents := append(repoPrefix, v.name, "_layers")
 
 		return path.Join(path.Join(append(blobLinkPathComponents, components...)...), "link"), nil
+	case layersPathSpec:
+		return append(repoPrefix, v.repo, "_layers")
 	case blobsPathSpec:
 		blobsPathPrefix := append(rootPrefix, "blobs")
 		return path.Join(blobsPathPrefix...), nil
@@ -334,6 +337,13 @@ type manifestTagIndexEntryLinkPathSpec struct {
 }
 
 func (manifestTagIndexEntryLinkPathSpec) pathSpec() {}
+
+// layersPathSpec contains the path for the layers inside a repo
+type layersPathSpec struct {
+	repo string
+}
+
+func (layersPathSpec) pathSpec() {}
 
 // blobLinkPathSpec specifies a path for a blob link, which is a file with a
 // blob id. The blob link will contain a content addressable blob id reference

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -208,7 +208,7 @@ func pathFor(spec pathSpec) (string, error) {
 
 		return path.Join(path.Join(append(blobLinkPathComponents, components...)...), "link"), nil
 	case layersPathSpec:
-		return append(repoPrefix, v.repo, "_layers")
+		return path.Join(append(repoPrefix, v.name, "_layers")...), nil
 	case blobsPathSpec:
 		blobsPathPrefix := append(rootPrefix, "blobs")
 		return path.Join(blobsPathPrefix...), nil
@@ -340,7 +340,7 @@ func (manifestTagIndexEntryLinkPathSpec) pathSpec() {}
 
 // layersPathSpec contains the path for the layers inside a repo
 type layersPathSpec struct {
-	repo string
+	name string
 }
 
 func (layersPathSpec) pathSpec() {}

--- a/registry/storage/paths_test.go
+++ b/registry/storage/paths_test.go
@@ -83,6 +83,10 @@ func TestPathMapper(t *testing.T) {
 			},
 			expected: "/docker/registry/v2/repositories/foo/bar/_uploads/asdf-asdf-asdf-adsf/startedat",
 		},
+		{
+			spec:     layersPathSpec{name: "foo/bar"},
+			expected: "/docker/registry/v2/repositories/foo/bar/_layers",
+		},
 	} {
 		p, err := pathFor(testcase.spec)
 		if err != nil {

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -330,6 +330,7 @@ func (repo *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		// TODO(stevvooe): linkPath limits this blob store to only layers.
 		// This instance cannot be used for manifest checks.
 		linkPathFns:            []linkPathFunc{blobLinkPath},
+		linkDirectoryPathSpec:  layersPathSpec,
 		deleteEnabled:          repo.registry.deleteEnabled,
 		resumableDigestEnabled: repo.resumableDigestEnabled,
 	}

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -330,7 +330,7 @@ func (repo *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		// TODO(stevvooe): linkPath limits this blob store to only layers.
 		// This instance cannot be used for manifest checks.
 		linkPathFns:            []linkPathFunc{blobLinkPath},
-		linkDirectoryPathSpec:  layersPathSpec,
+		linkDirectoryPathSpec:  layersPathSpec{name: repo.name.Name()},
 		deleteEnabled:          repo.registry.deleteEnabled,
 		resumableDigestEnabled: repo.resumableDigestEnabled,
 	}


### PR DESCRIPTION
This code is already used by Hub and helps us GC old content.