### PR TITLE
Fix TestRegistryAsCacheMutationAPIs

### DIFF
--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -2012,6 +2012,7 @@ type testEnv struct {
 }
 
 func newTestEnvMirror(t *testing.T, deleteEnabled bool) *testEnv {
+	upstreamEnv := newTestEnv(t, deleteEnabled)
 	config := configuration.Configuration{
 		Storage: configuration.Storage{
 			"testdriver": configuration.Parameters{},
@@ -2021,7 +2022,7 @@ func newTestEnvMirror(t *testing.T, deleteEnabled bool) *testEnv {
 			}},
 		},
 		Proxy: configuration.Proxy{
-			RemoteURL: "http://example.com",
+			RemoteURL: upstreamEnv.server.URL,
 		},
 	}
 	config.Compatibility.Schema1.Enabled = true


### PR DESCRIPTION
Use a synthetic upstream registry when creating the testing mirror configuration
to avoid the test fail when trying to reach http://example.com

Signed-off-by: Fernando Mayo Fernandez <fernando@undefinedlabs.com>