### PR TITLE
[release/2.7 backport] fix markdown issues on configuration page

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -703,11 +703,11 @@ interpretation of the options.
 | `baseurl` | yes      | The `SCHEME://HOST[/PATH]` at which Cloudfront is served. |
 | `privatekey` | yes   | The private key for Cloudfront, provided by AWS.        |
 | `keypairid` | yes    | The key pair ID provided by AWS.                         |
-| `duration` | no      | An integer and unit for the duration of the Cloudfront session. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, or `h`. For example, `3000s` is valid, but `3000 s` is not. If you do not specify a `duration` or you specify an integer without a time unit, the duration defaults to `20m` (20 minutes).|
-|`ipfilteredby`|no     | A string with the following value `none`, `aws` or `awsregion`. |
-|`awsregion`|no        | A comma separated string of AWS regions, only available when `ipfilteredby` is `awsregion`. For example, `us-east-1, us-west-2`|
-|`updatefrenquency`|no | The frequency to update AWS IP regions, default: `12h`|
-|`iprangesurl`|no      | The URL contains the AWS IP ranges information, default: `https://ip-ranges.amazonaws.com/ip-ranges.json`|
+| `duration` | no      | An integer and unit for the duration of the Cloudfront session. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, or `h`. For example, `3000s` is valid, but `3000 s` is not. If you do not specify a `duration` or you specify an integer without a time unit, the duration defaults to `20m` (20 minutes). |
+| `ipfilteredby` | no     | A string with the following value `none`, `aws` or `awsregion`. |
+| `awsregion` | no        | A comma separated string of AWS regions, only available when `ipfilteredby` is `awsregion`. For example, `us-east-1, us-west-2` |
+| `updatefrenquency` | no | The frequency to update AWS IP regions, default: `12h` |
+| `iprangesurl` | no      | The URL contains the AWS IP ranges information, default: `https://ip-ranges.amazonaws.com/ip-ranges.json` |
 
 
 Value of `ipfilteredby` can be:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -704,14 +704,19 @@ interpretation of the options.
 | `privatekey` | yes   | The private key for Cloudfront, provided by AWS.        |
 | `keypairid` | yes    | The key pair ID provided by AWS.                         |
 | `duration` | no      | An integer and unit for the duration of the Cloudfront session. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, or `h`. For example, `3000s` is valid, but `3000 s` is not. If you do not specify a `duration` or you specify an integer without a time unit, the duration defaults to `20m` (20 minutes).|
-|`ipfilteredby`|no     | A string with the following value `none|aws|awsregion`. |
+|`ipfilteredby`|no     | A string with the following value `none`, `aws` or `awsregion`. |
 |`awsregion`|no        | A comma separated string of AWS regions, only available when `ipfilteredby` is `awsregion`. For example, `us-east-1, us-west-2`|
 |`updatefrenquency`|no | The frequency to update AWS IP regions, default: `12h`|
 |`iprangesurl`|no      | The URL contains the AWS IP ranges information, default: `https://ip-ranges.amazonaws.com/ip-ranges.json`|
-Then value of ipfilteredby:
-`none`: default, do not filter by IP
-`aws`: IP from AWS goes to S3 directly
-`awsregion`: IP from certain AWS regions goes to S3 directly, use together with `awsregion`
+
+
+Value of `ipfilteredby` can be:
+
+| Value       | Description                        |
+|-------------|------------------------------------|
+| `none`      | default, do not filter by IP       |
+| `aws`       | IP from AWS goes to S3 directly    |
+| `awsregion` | IP from certain AWS regions goes to S3 directly, use together with `awsregion`. |
 
 ### `redirect`
 


### PR DESCRIPTION
Backports of:

- commit e1e72e9563743afc1649b23a2f651a7c3caaf369 (documentation fixes taken from https://github.com/docker/distribution/pull/2837)
- https://github.com/docker/distribution/pull/3053 Fixing broken table
    - fixes https://github.com/docker/docker.github.io/issues/9935 Docker Registry: CloudFront requirements table broken
    - fixes https://github.com/docker/docker.github.io/issues/9945 "Cloudfront" section is garbled 