### PR TITLE
[master] Use same env var in Dockerfile and Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13.4-alpine AS build
 
 ENV DISTRIBUTION_DIR /go/src/github.com/docker/distribution
-ENV DOCKER_BUILDTAGS include_oss include_gcs
+ENV BUILDTAGS include_oss include_gcs
 
 ARG GOOS=linux
 ARG GOARCH=amd64


### PR DESCRIPTION
forward-port of https://github.com/docker/distribution/pull/2821 to master

https://github.com/docker/distribution/pull/2821  was created directly against the `release/2.7` branch; forward-porting the fix so that there's no regression in upcoming releases.


Ensures that build tags get set in the Dockerfile so that OSS and GCS drivers
are built into the official registry binary.

Closes #2819
