### PR TITLE
Allow user provided swift overrides to take precedence

### DIFF
--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -242,8 +242,9 @@ func New(params Parameters) (*Driver, error) {
 				d.BulkDeleteMaxDeletes = info.BulkDelete.MaxDeletesPerRequest
 			}
 		}
-	} else {
-		d.TempURLContainerKey = params.TempURLContainerKey
+	} 
+	d.TempURLContainerKey = params.TempURLContainerKey	
+	if params.TempURLMethods != nil {
 		d.TempURLMethods = params.TempURLMethods
 	}
 

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -243,11 +243,11 @@ func New(params Parameters) (*Driver, error) {
 			}
 		}
 	} 
-	d.TempURLContainerKey = params.TempURLContainerKey	
+	d.TempURLContainerKey = params.TempURLContainerKey
 	if params.TempURLMethods != nil {
 		d.TempURLMethods = params.TempURLMethods
 	}
-
+	
 	if len(d.TempURLMethods) > 0 {
 		secretKey := params.SecretKey
 		if secretKey == "" {


### PR DESCRIPTION
TempURLContainerKey and TempURLMethods overrides take precedence over the swift API /info result.
TempURLContainerKey specifically fixes https://github.com/docker/distribution/issues/2653