### PR TITLE
Fix err shadowing in gcs driver

### DIFF
--- a/registry/storage/driver/gcs/gcs.go
+++ b/registry/storage/driver/gcs/gcs.go
@@ -426,7 +426,8 @@ func putContentsClose(wc *storage.Writer, contents []byte) error {
 	var nn int
 	var err error
 	for nn < size {
-		n, err := wc.Write(contents[nn:size])
+		var n int
+		n, err = wc.Write(contents[nn:size])
 		nn += n
 		if err != nil {
 			break


### PR DESCRIPTION
The error from wc.Write exists only in the loop scope, therefore wc.CloseWithError is never called.