### PR TITLE
short repository name return must be canonical

### DIFF
--- a/reference/reference.go
+++ b/reference/reference.go
@@ -243,7 +243,8 @@ func ParseNamed(s string) (Named, error) {
 	if err != nil {
 		return nil, err
 	}
-	if named.String() != s {
+	realUri := named.String()
+	if !strings.HasSuffix(realUri, s) {
 		return nil, ErrNameNotCanonical
 	}
 	return named, nil

--- a/reference/reference.go
+++ b/reference/reference.go
@@ -243,8 +243,7 @@ func ParseNamed(s string) (Named, error) {
 	if err != nil {
 		return nil, err
 	}
-	realUri := named.String()
-	if !strings.HasSuffix(realUri, s) {
+	if !strings.HasSuffix(named.String(), s) {
 		return nil, ErrNameNotCanonical
 	}
 	return named, nil


### PR DESCRIPTION
fix: short repository name return must be canonical