### PR TITLE
catalog: List repositories with no unique layers

### DIFF
--- a/registry/storage/catalog.go
+++ b/registry/storage/catalog.go
@@ -143,8 +143,8 @@ func handleRepository(fileInfo driver.FileInfo, root, last string, fn func(repoP
 	repo := filePath[len(root)+1:]
 
 	_, file := path.Split(repo)
-	if file == "_layers" {
-		repo = strings.TrimSuffix(repo, "/_layers")
+	if file == "_manifests" {
+		repo = strings.TrimSuffix(repo, "/_manifests")
 		if lessPath(last, repo) {
 			if err := fn(repo); err != nil {
 				return err


### PR DESCRIPTION
A repository need not contain any unique layers, if its images use only layers mounted from other repositories. But, the catalog endpoint was looking for the _layers directory to indicate that a directory was a repository.

Use the _manifests directory as the marker instead, since any repository with revisions will contain a _manifests directory.

Fixes #3172 

Signed-off-by: Adam Wolfe Gordon <awg@digitalocean.com>