### PR TITLE
Garbage collection improvement

### DIFF
--- a/registry/root.go
+++ b/registry/root.go
@@ -19,7 +19,7 @@ func init() {
 	RootCmd.AddCommand(GCCmd)
 	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
 	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-untagged", "m", false, "delete manifests that are not currently referenced via tag")
-	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-repositories", "r", false, "delete repositories without manifests")
+	GCCmd.Flags().BoolVarP(&removeRepositories, "delete-repositories", "r", false, "delete repositories without manifests")
 	GCCmd.Flags().Float64VarP(&modificationTimeout, "modification-timeout", "t", 0, "don't remove blobs and manfiests modified less than this seconds ago")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 }

--- a/registry/root.go
+++ b/registry/root.go
@@ -19,6 +19,8 @@ func init() {
 	RootCmd.AddCommand(GCCmd)
 	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
 	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-untagged", "m", false, "delete manifests that are not currently referenced via tag")
+	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-repositories", "r", false, "delete repositories without manifests")
+	GCCmd.Flags().Float64VarP(&modificationTimeout, "modification-timeout", "t", 0, "don't remove blobs and manfiests modified less than this seconds ago")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 }
 
@@ -38,6 +40,8 @@ var RootCmd = &cobra.Command{
 
 var dryRun bool
 var removeUntagged bool
+var removeRepositories bool
+var modificationTimeout float64
 
 // GCCmd is the cobra command that corresponds to the garbage-collect subcommand
 var GCCmd = &cobra.Command{
@@ -78,8 +82,10 @@ var GCCmd = &cobra.Command{
 		}
 
 		err = storage.MarkAndSweep(ctx, driver, registry, storage.GCOpts{
-			DryRun:         dryRun,
-			RemoveUntagged: removeUntagged,
+			DryRun:              dryRun,
+			RemoveUntagged:      removeUntagged,
+			RemoveRepositories:  removeRepositories,
+			ModificationTimeout: modificationTimeout,
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to garbage collect: %v", err)

--- a/registry/root.go
+++ b/registry/root.go
@@ -19,7 +19,7 @@ func init() {
 	RootCmd.AddCommand(GCCmd)
 	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
 	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-untagged", "m", false, "delete manifests that are not currently referenced via tag")
-	GCCmd.Flags().BoolVarP(&remove, "delete-repositories", "r", false, "delete repositories without manifests")
+	GCCmd.Flags().BoolVarP(&removeRepositories, "delete-repositories", "r", false, "delete repositories without manifests")
 	GCCmd.Flags().Float64VarP(&modificationTimeout, "modification-timeout", "t", 0, "don't remove blobs and manfiests modified less than this seconds ago")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 }

--- a/registry/root.go
+++ b/registry/root.go
@@ -20,7 +20,7 @@ func init() {
 	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
 	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-untagged", "m", false, "delete manifests that are not currently referenced via tag")
 	GCCmd.Flags().BoolVarP(&removeRepositories, "delete-repositories", "r", false, "delete repositories without manifests")
-	GCCmd.Flags().Float64VarP(&modificationTimeout, "modification-timeout", "t", 0, "don't remove blobs and manfiests modified less than this seconds ago")
+	GCCmd.Flags().Float64VarP(&modificationTimeout, "modification-timeout", "t", 0, "don't remove objects modified less than this number of seconds ago")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 }
 

--- a/registry/root.go
+++ b/registry/root.go
@@ -19,7 +19,7 @@ func init() {
 	RootCmd.AddCommand(GCCmd)
 	GCCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "do everything except remove the blobs")
 	GCCmd.Flags().BoolVarP(&removeUntagged, "delete-untagged", "m", false, "delete manifests that are not currently referenced via tag")
-	GCCmd.Flags().BoolVarP(&removeRepositories, "delete-repositories", "r", false, "delete repositories without manifests")
+	GCCmd.Flags().BoolVarP(&remove, "delete-repositories", "r", false, "delete repositories without manifests")
 	GCCmd.Flags().Float64VarP(&modificationTimeout, "modification-timeout", "t", 0, "don't remove blobs and manfiests modified less than this seconds ago")
 	RootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 }

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -34,7 +34,13 @@ type ManifestDel struct {
 // MarkAndSweep performs a mark and sweep of registry data
 func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, registry distribution.Namespace, opts GCOpts) error {
 
-	deleteBlobSet, deleteManifestArr, deleteLayerMap, deleteRepositoryArr, err := mark(ctx, storageDriver, registry, opts.RemoveUntagged, opts.ModificationTimeout)
+	deleteBlobSet, deleteManifestArr, deleteLayerMap, deleteRepositoryArr, err := mark(
+		ctx,
+		storageDriver,
+		registry,
+		opts.RemoveUntagged,
+		opts.ModificationTimeout,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to mark blobs and manifests: %v", err)
 	}

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -45,7 +45,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 	}
 
 	emit(
-		"\n%d blobs, %d manifests, %layers, %d repositories eligible for deletion",
+		"\n%d blobs, %d manifests, %d layers, %d repositories eligible for deletion",
 		len(deleteBlobSet),
 		len(deleteManifestArr),
 		deleteLayerCount,

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -34,8 +34,7 @@ type ManifestDel struct {
 // MarkAndSweep performs a mark and sweep of registry data
 func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, registry distribution.Namespace, opts GCOpts) error {
 
-	deleteBlobSet, deleteManifestArr, deleteRepositoryArr, err := markBlobsAndManifests(ctx, storageDriver, registry,
-		opts.RemoveUntagged, opts.ModificationTimeout)
+	deleteBlobSet, deleteManifestArr, deleteRepositoryArr, err := mark(ctx, storageDriver, registry, opts.RemoveUntagged, opts.ModificationTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to mark blobs and manifests: %v", err)
 	}
@@ -111,7 +110,7 @@ func sweepManifests(vacuum Vacuum, deleteManifestArr []ManifestDel, dryRun bool)
 	return nil
 }
 
-func markBlobsAndManifests(
+func mark(
 	ctx context.Context,
 	storageDriver driver.StorageDriver,
 	registry distribution.Namespace,

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -54,7 +54,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 	if opts.RemoveRepositories {
 		err = sweepRepositories(vacuum, deleteRepositoryArr, opts.DryRun)
 		if err != nil {
-			return fmt.Errorf("failed to sweep manifests: %v", err)
+			return fmt.Errorf("failed to sweep repositories: %v", err)
 		}
 	}
 
@@ -67,6 +67,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 }
 
 func sweepRepositories(vacuum Vacuum, deleteRepositoryArr []string, dryRun bool) error {
+	emit("sweep repositories")
 	for _, name := range deleteRepositoryArr {
 		emit("repository eligible for deletion: %s", name)
 		if dryRun {
@@ -81,6 +82,7 @@ func sweepRepositories(vacuum Vacuum, deleteRepositoryArr []string, dryRun bool)
 }
 
 func sweepBlobs(vacuum Vacuum, deleteBlobSet map[digest.Digest]struct{}, dryRun bool) error {
+	emit("sweep blobs")
 	for dgst := range deleteBlobSet {
 		emit("blob eligible for deletion: %s", dgst)
 		if dryRun {
@@ -95,6 +97,7 @@ func sweepBlobs(vacuum Vacuum, deleteBlobSet map[digest.Digest]struct{}, dryRun 
 }
 
 func sweepManifests(vacuum Vacuum, deleteManifestArr []ManifestDel, dryRun bool) error {
+	emit("sweep manifests")
 	for _, obj := range deleteManifestArr {
 		emit("manifest eligible for deletion: %s %s", obj.Name, obj.Digest)
 		if dryRun {

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -28,6 +28,25 @@ type Vacuum struct {
 	ctx    context.Context
 }
 
+// RemoveLayer removes a layer from the filesystem
+func (v Vacuum) RemoveLayer(repoName string, dgst digest.Digest) error {
+	layerLinkPath, err := pathFor(layerLinkPathSpec{name: repoName, digest: dgst})
+	if err != nil {
+		return err
+	}
+
+	layerDir := path.Dir(layerLinkPath)
+
+	dcontext.GetLogger(v.ctx).Infof("Deleting layer: %s", layerDir)
+
+	err = v.driver.Delete(v.ctx, layerLinkPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // RemoveBlob removes a blob from the filesystem
 func (v Vacuum) RemoveBlob(dgst string) error {
 	d, err := digest.Parse(dgst)

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -39,7 +39,7 @@ func (v Vacuum) RemoveLayer(repoName string, dgst digest.Digest) error {
 
 	dcontext.GetLogger(v.ctx).Infof("Deleting layer: %s", layerDir)
 
-	err = v.driver.Delete(v.ctx, layerLinkPath)
+	err = v.driver.Delete(v.ctx, layerDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hi.

This pull request consists of 3 proposals in these pool requests:

https://github.com/docker/distribution/pull/2297
https://github.com/docker/distribution/pull/2288
https://github.com/docker/distribution/pull/3051

It was necessary for our project to integrate these changes.

I added these parameters to this command:
-t ${n} - don't remove objects modified less than this number of seconds ago (it allows to perform garbage collection without stopping)
-r - remove repositories without manifests (it cleans empty repositories)

And now it collects also old links in "_layers" directory.

Also, I added a test for new features.

Let's push this request!