### PR TITLE
[release/2.7 backport] docs: add redirect for old URL

### DIFF
--- a/docs/spec/api.md
+++ b/docs/spec/api.md
@@ -2,6 +2,8 @@
 title: "HTTP API V2"
 description: "Specification for the Registry API."
 keywords: registry, on-prem, images, tags, repository, distribution, api, advanced
+redirect_from:
+  - /reference/api/registry_api/
 ---
 
 # Docker Registry HTTP API V2

--- a/docs/spec/api.md.tmpl
+++ b/docs/spec/api.md.tmpl
@@ -2,6 +2,8 @@
 title: "HTTP API V2"
 description: "Specification for the Registry API."
 keywords: registry, on-prem, images, tags, repository, distribution, api, advanced
+redirect_from:
+  - /reference/api/registry_api/
 ---
 
 # Docker Registry HTTP API V2


### PR DESCRIPTION
backport https://github.com/docker/distribution/pull/3196

Looks like there's some projects refering to this old URL:
https://grep.app/search?q=https%3A//docs.docker.com/reference/api/registry_api/

fixes https://github.com/docker/docker.github.io/issues/11105