### PR TITLE
Add ability to load s3 config from ~/.aws/config

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -403,25 +403,29 @@ func New(params DriverParameters) (*Driver, error) {
 		return nil, fmt.Errorf("on Amazon S3 this storage driver can only be used with v4 authentication")
 	}
 
-	awsConfig := defaults.Config()
-	providers := []credentials.Provider{
-		&credentials.StaticProvider{
-			Value: credentials.Value{
-				AccessKeyID:     params.AccessKey,
-				SecretAccessKey: params.SecretKey,
-				SessionToken:    params.SessionToken,
+	awsConfig := &aws.Config{}
+
+	if params.AccessKey != "" || params.SecretKey != "" || params.SessionToken != "" {
+		providers := []credentials.Provider{
+			&credentials.StaticProvider{
+				Value: credentials.Value{
+					AccessKeyID:     params.AccessKey,
+					SecretAccessKey: params.SecretKey,
+					SessionToken:    params.SessionToken,
+				},
 			},
-		},
+		}
+
+		providers = append(providers, defaults.CredProviders(awsConfig, defaults.Handlers())...)
+		creds := credentials.NewChainCredentials(providers)
+		awsConfig.WithCredentials(creds)
 	}
-	providers = append(providers, defaults.CredProviders(awsConfig, defaults.Handlers())...)
-	creds := credentials.NewChainCredentials(providers)
 
 	if params.RegionEndpoint != "" {
 		awsConfig.WithS3ForcePathStyle(true)
 		awsConfig.WithEndpoint(params.RegionEndpoint)
 	}
 
-	awsConfig.WithCredentials(creds)
 	awsConfig.WithRegion(params.Region)
 	awsConfig.WithDisableSSL(!params.Secure)
 


### PR DESCRIPTION
Signed-off-by: Shaun Sabo <shaunsabo@slack-corp.com>

I noticed that I cannot force the SDK to load my `.aws/config` which I volume mounted into the registry container at `/root/.aws/config`. I want to do this so I can run a registry in a different AWS account from where the S3 bucket is located without using Access Keys. Ideally, I would like to achieve this by using `role_arn` and `credential_source = Ec2InstanceMetadata` in the shared config to assume a role in the account where the bucket is located. 

Currently if we provide `AWS_SDK_LOAD_CONFIG=1` to the registry, it will not actually use the config located at `~/.aws/config`. I believe this is because `defaults.Config()` loads a full `*aws.Config` object who's Credentials override the detection that `session.NewSession()` does. 

By starting with a sparse object with `&aws.Config{}`, I was able to continue to configure the session incrementally without wiping out default behavior for credential discovery. 

This patch will maintain existing behavior, except when `AWS_SDK_LOAD_CONFIG=1` is set in the environment. 