### PR TITLE
retry for certain time during blobwriter.commit

### DIFF
--- a/registry/storage/blobwriter.go
+++ b/registry/storage/blobwriter.go
@@ -66,7 +66,19 @@ func (bw *blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) 
 	bw.Close()
 	desc.Size = bw.Size()
 
-	canonical, err := bw.validateBlob(ctx, desc)
+	attempt := 30
+	attemptRelay := 1000 // relay 500ms before next attempt
+	var canonical distribution.Descriptor
+	var err error
+	for i := 0; i < attempt; i++ {
+		canonical, err = bw.validateBlob(ctx, desc)
+		if err != nil {
+			time.Sleep(time.Duration(attemptRelay))
+			continue
+		} else {
+			break
+		}
+	}
 	if err != nil {
 		return distribution.Descriptor{}, err
 	}


### PR DESCRIPTION
Hi, team, I'm expiencing the same issue described in #1948 , I did my research and found the problem is that s3 needs a bit of time to make the uploaded file avaible after upload(`Amazon S3 data consistency` -> https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel)

> Amazon S3 provides read-after-write consistency for PUTS of new objects in your S3 bucket in all Regions with one caveat. The caveat is that if you make a HEAD or GET request to a key name before the object is created, then create the object shortly after that, a subsequent GET might not return the object due to eventual consistency. 

the time this process take differs in diffrent s3 providers, in my circumstance, the provider seems to take a little bit more time. So the problem would come out.

My silly solution here is to retry in `blobWriter.Commit` , I'd try several times to validate blob, and it did solve my problem.

I'm totally new to both Go and this project, hope someone could guide me or make a better solution for this.

For those tho are also suffering from this issue, you can try this image out:

```
docker pull ghcr.io/leoquote/registry:2.7.2-s3-hack
```