### PR TITLE
allow pointing to an AWS config file as a parameter for the s3 driver

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -103,6 +103,7 @@ type DriverParameters struct {
 	UserAgent                   string
 	ObjectACL                   string
 	SessionToken                string
+	CredentialsConfigPath       string
 }
 
 func init() {
@@ -179,6 +180,11 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 	secretKey := parameters["secretkey"]
 	if secretKey == nil {
 		secretKey = ""
+	}
+
+	credentialsConfigPath := parameters["credentialsconfigpath"]
+	if credentialsConfigPath == nil {
+		credentialsConfigPath = ""
 	}
 
 	regionEndpoint := parameters["regionendpoint"]
@@ -361,6 +367,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		fmt.Sprint(userAgent),
 		objectACL,
 		fmt.Sprint(sessionToken),
+		fmt.Sprint(credentialsConfigPath),
 	}
 
 	return New(params)
@@ -405,7 +412,22 @@ func New(params DriverParameters) (*Driver, error) {
 	}
 
 	awsConfig := aws.NewConfig()
-	sess, err := session.NewSession()
+
+	// Makes no sense to provide access/secret keys and the location of a
+	// config file with credentials.
+	if (params.AccessKey != "" || params.SecretKey != "") && params.CredentialsConfigPath != "" {
+		return nil, fmt.Errorf("cannot set both access/secret key and credentials file path")
+	}
+
+	sessionOptions := session.Options{
+		Config: *awsConfig,
+	}
+	if params.CredentialsConfigPath != "" {
+		sessionOptions.SharedConfigFiles = []string{
+			params.CredentialsConfigPath,
+		}
+	}
+	sess, err := session.NewSessionWithOptions(sessionOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new session: %v", err)
 	}

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -38,6 +38,7 @@ func init() {
 	root, err := ioutil.TempDir("", "driver-")
 	regionEndpoint := os.Getenv("REGION_ENDPOINT")
 	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
+	credentialsConfigPath := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
 	if err != nil {
 		panic(err)
 	}
@@ -96,6 +97,7 @@ func init() {
 			driverName + "-test",
 			objectACL,
 			sessionToken,
+			credentialsConfigPath,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
Recognize a new parameter when setting up the AWS client so that a generic AWS config file can be used instead of having to specify AWS access and secret keys.

This should allow someone to use different authentication methods beyond just access key, secret key (and optionally session token). Due to the way the AWS Go SDK works setting AWS_SDK_LOAD_CONFIG to some truthiness (eg. 'true') is needed.

Using the current supported auth methods a valid file would look like:
```
[default]
aws_access_key_id = AKMYAWSACCCESSKEYID
aws_secret_access_key = myawssecretaccesskey
```

But you can also specify alternative auth methods:
```
[default]
role_arn = arn:aws:iam:ACCOUNT_NUM:role/ROLE_NAME
web_identity_token_file = /path/to/token
```